### PR TITLE
fix: correct Helm chart path in create-test-namespace.sh

### DIFF
--- a/scripts/create-test-namespace.sh
+++ b/scripts/create-test-namespace.sh
@@ -76,13 +76,13 @@ fi
 # ---------------------------------------------------------------------------
 
 if [ -n "$IAC_REPO" ]; then
-  CHART_DIR="${IAC_REPO}/helm"
+  CHART_DIR="${IAC_REPO}/charts/artifact-keeper"
 else
   echo "Cloning artifact-keeper-iac for Helm chart..."
   TMPDIR="$(mktemp -d)"
   trap "rm -rf '$TMPDIR'" EXIT
   git clone --depth 1 https://github.com/artifact-keeper/artifact-keeper-iac.git "$TMPDIR/iac"
-  CHART_DIR="${TMPDIR}/iac/helm"
+  CHART_DIR="${TMPDIR}/iac/charts/artifact-keeper"
 fi
 
 if [ ! -f "${CHART_DIR}/Chart.yaml" ]; then


### PR DESCRIPTION
## Summary
- Fix chart path from `helm/` to `charts/artifact-keeper/` to match actual iac repo structure
- This was blocking all release-gate deployments

## Test plan
- [ ] Trigger release-gate workflow after merge and verify deploy step succeeds