### PR TITLE
fix: pass ADMIN_PASS to release gate test jobs

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -144,6 +144,7 @@ jobs:
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
       - uses: actions/checkout@v4
@@ -228,6 +229,7 @@ jobs:
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
       - uses: actions/checkout@v4
@@ -258,6 +260,7 @@ jobs:
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
       - uses: actions/checkout@v4
@@ -288,6 +291,7 @@ jobs:
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
       - uses: actions/checkout@v4
@@ -318,6 +322,7 @@ jobs:
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
       - uses: actions/checkout@v4
@@ -348,6 +353,7 @@ jobs:
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
       - uses: actions/checkout@v4
@@ -378,6 +384,7 @@ jobs:
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
       - uses: actions/checkout@v4
@@ -408,6 +415,7 @@ jobs:
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
       - uses: actions/checkout@v4
@@ -438,6 +446,7 @@ jobs:
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
       - uses: actions/checkout@v4
@@ -468,6 +477,7 @@ jobs:
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
       - uses: actions/checkout@v4
@@ -498,6 +508,7 @@ jobs:
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
       - uses: actions/checkout@v4
@@ -531,6 +542,7 @@ jobs:
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
       - uses: actions/checkout@v4
@@ -568,6 +580,7 @@ jobs:
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
       NAMESPACE: ${{ needs.deploy.outputs.namespace }}
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
@@ -616,6 +629,7 @@ jobs:
     runs-on: ak-e2e-runners
     env:
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds `ADMIN_PASS: TestRunner!2026secure` to the `env:` block of all 14 test jobs in the release-gate workflow
- The v1.1.0 backend rejects login attempts that use insecure default passwords (admin123, admin, password, etc.)
- The Helm test overlay (`helm/values-test.yaml`) already sets `ADMIN_PASSWORD` to `TestRunner!2026secure`, but the workflow was not passing `ADMIN_PASS` to test runner jobs, so `common.sh` could only rely on its compiled-in default

## Changes

All jobs that run test scripts (format-tests, security-tests, compatibility-tests, repo-tests, promotion-tests, rbac-tests, lifecycle-tests, webhook-tests, search-tests, platform-tests, auth-tests, stress-tests, resilience-tests, mesh-tests) now include `ADMIN_PASS` in their job-level `env:` block.

No changes to `scripts/run-suite.sh`, `tests/lib/common.sh`, or any test scripts. Environment variables flow from the job env through to child processes automatically.

## Test plan

- [ ] Trigger a release-gate run with `backend_tag: latest` and verify all 14 suites authenticate successfully
- [ ] Confirm the auth-tests suite passes (it exercises login directly)