### PR TITLE
feat: add full-stack test infrastructure (P0)

### DIFF
--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -1,0 +1,120 @@
+# values-test-full.yaml - Full-stack test deployment overlay
+#
+# Extends values-test.yaml with security scanning services (Trivy, scan
+# workspace). Used by create-test-namespace.sh --full-stack for test suites
+# that exercise vulnerability scanning, SBOM generation, and proxy caching.
+#
+# Does NOT enable DependencyTrack (requires complex bootstrapping, handled
+# separately).
+
+# Use a stable name so service URLs are predictable regardless of release name
+fullnameOverride: artifact-keeper
+
+backend:
+  image:
+    repository: ghcr.io/artifact-keeper/artifact-keeper-backend
+    tag: dev
+    pullPolicy: Always
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 500m
+      memory: 256Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  env:
+    ENVIRONMENT: test
+    RUST_LOG: info
+    ADMIN_PASSWORD: TestRunner!2026secure
+    ACCOUNT_LOCKOUT_THRESHOLD: "0"
+    TRIVY_URL: "http://artifact-keeper-trivy:8090"
+    SCAN_WORKSPACE_PATH: "/data/scan-workspace"
+  persistence:
+    size: 2Gi
+  scanWorkspace:
+    enabled: true
+    size: 2Gi
+
+web:
+  image:
+    repository: ghcr.io/artifact-keeper/artifact-keeper-web
+    tag: dev
+    pullPolicy: Always
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+
+postgres:
+  enabled: true
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  persistence:
+    size: 2Gi
+  password: "test-db-password"
+
+meilisearch:
+  enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  persistence:
+    size: 1Gi
+  masterKey: "artifact-keeper-test-key"
+
+trivy:
+  enabled: true
+  image:
+    repository: aquasec/trivy
+    tag: "0.62.1"
+  persistence:
+    size: 2Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+
+secrets:
+  jwtSecret: "test-jwt-secret-not-for-production"
+
+# Disabled services: not needed for scanning test runs
+dependencyTrack:
+  enabled: false
+
+edge:
+  enabled: false
+
+ingress:
+  enabled: false
+
+networkPolicy:
+  enabled: false
+
+serviceMonitor:
+  enabled: false
+
+cosign:
+  enabled: false
+
+autoscaling:
+  enabled: false
+
+pdb:
+  enabled: false

--- a/scripts/create-test-namespace.sh
+++ b/scripts/create-test-namespace.sh
@@ -2,7 +2,7 @@
 # create-test-namespace.sh - Create an isolated Kubernetes namespace for testing
 #
 # Usage:
-#   ./create-test-namespace.sh --run-id <id> [--backend-tag <tag>] [--web-tag <tag>] [--iac-repo <path>] [--values <file>]
+#   ./create-test-namespace.sh --run-id <id> [--backend-tag <tag>] [--web-tag <tag>] [--iac-repo <path>] [--values <file>] [--full-stack]
 #
 # Creates namespace test-<run-id>, deploys the Helm chart with test overlays,
 # and waits for the backend to become healthy.
@@ -24,6 +24,7 @@ BACKEND_TAG="dev"
 WEB_TAG="dev"
 IAC_REPO=""
 EXTRA_VALUES=""
+FULL_STACK=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -32,9 +33,10 @@ while [[ $# -gt 0 ]]; do
     --web-tag)     WEB_TAG="$2"; shift 2 ;;
     --iac-repo)    IAC_REPO="$2"; shift 2 ;;
     --values)      EXTRA_VALUES="$2"; shift 2 ;;
+    --full-stack)  FULL_STACK=true; shift ;;
     *)
       echo "Unknown argument: $1"
-      echo "Usage: create-test-namespace.sh --run-id <id> [--backend-tag <tag>] [--web-tag <tag>] [--iac-repo <path>] [--values <file>]"
+      echo "Usage: create-test-namespace.sh --run-id <id> [--backend-tag <tag>] [--web-tag <tag>] [--iac-repo <path>] [--values <file>] [--full-stack]"
       exit 1
       ;;
   esac
@@ -96,9 +98,17 @@ fi
 
 echo "Installing Helm release: ${RELEASE_NAME}"
 
+# Select base values file: --full-stack enables Trivy + scan workspace
+if [ "$FULL_STACK" = true ]; then
+  VALUES_FILE="${REPO_ROOT}/helm/values-test-full.yaml"
+  echo "  Mode: full-stack (Trivy + scan workspace enabled)"
+else
+  VALUES_FILE="${REPO_ROOT}/helm/values-test.yaml"
+fi
+
 HELM_CMD=(helm upgrade --install "$RELEASE_NAME" "$CHART_DIR"
   --namespace "$NAMESPACE"
-  --values "${REPO_ROOT}/helm/values-test.yaml"
+  --values "$VALUES_FILE"
   --set backend.image.tag="$BACKEND_TAG"
   --set web.image.tag="$WEB_TAG"
   --wait

--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -183,19 +183,6 @@ create_local_repo() {
   create_repo "$1" "$2" "local"
 }
 
-create_remote_repo() {
-  local key="$1"
-  local format="$2"
-  local upstream_url="$3"
-  create_repo "$key" "$format" "remote" "$upstream_url"
-}
-
-create_virtual_repo() {
-  local key="$1"
-  local format="$2"
-  create_repo "$key" "$format" "virtual"
-}
-
 # ---------------------------------------------------------------------------
 # Test framework
 #
@@ -439,4 +426,258 @@ _xml_escape() {
   s="${s//\"/&quot;}"
   s="${s//\'/&apos;}"
   echo "$s"
+}
+
+# ---------------------------------------------------------------------------
+# Remote / Virtual repository helpers
+# ---------------------------------------------------------------------------
+
+# create_remote_repo KEY FORMAT UPSTREAM_URL [DESCRIPTION]
+# Creates a remote (proxy) repository that caches artifacts from an upstream.
+create_remote_repo() {
+  local key="$1"
+  local format="$2"
+  local upstream_url="$3"
+  local description="${4:-Remote proxy for ${format}}"
+
+  local payload
+  payload=$(jq -n \
+    --arg key "$key" \
+    --arg name "$key" \
+    --arg format "$format" \
+    --arg upstream_url "$upstream_url" \
+    --arg description "$description" \
+    '{key: $key, name: $name, format: $format, repo_type: "remote", upstream_url: $upstream_url, description: $description, is_public: true}')
+
+  api_post "/api/v1/repositories" "$payload" > /dev/null
+}
+
+# create_virtual_repo KEY FORMAT [MEMBER_KEYS] [DESCRIPTION]
+# Creates a virtual repository that aggregates multiple backing repos.
+# MEMBER_KEYS is a comma-separated list of repository keys (e.g. "local-npm,remote-npm").
+# If omitted, the virtual repo is created with no members (add them later via the API).
+create_virtual_repo() {
+  local key="$1"
+  local format="$2"
+  local member_keys="${3:-}"
+  local description="${4:-Virtual repo for ${format}}"
+
+  local payload
+  payload=$(jq -n \
+    --arg key "$key" \
+    --arg name "$key" \
+    --arg format "$format" \
+    --arg description "$description" \
+    '{key: $key, name: $name, format: $format, repo_type: "virtual", description: $description, is_public: true}')
+
+  api_post "/api/v1/repositories" "$payload" > /dev/null
+
+  # Add each member repository (if any specified)
+  if [ -n "$member_keys" ]; then
+    local IFS=','
+    for member in $member_keys; do
+      local member_payload
+      member_payload=$(jq -n --arg key "$member" '{repository_key: $key}')
+      api_post "/api/v1/repositories/${key}/members" "$member_payload" > /dev/null || true
+    done
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Scan helpers
+# ---------------------------------------------------------------------------
+
+# wait_for_scan REPO_KEY ARTIFACT_PATH [TIMEOUT_SECS]
+# Polls the scan endpoint until the status is no longer "pending" or "scanning".
+# Returns the final scan status on stdout.
+wait_for_scan() {
+  local repo_key="$1"
+  local artifact_path="$2"
+  local timeout="${3:-60}"
+
+  local elapsed=0
+  local status=""
+  while [ "$elapsed" -lt "$timeout" ]; do
+    local resp
+    resp=$(api_get "/api/v1/repositories/${repo_key}/artifacts/${artifact_path}/security/scan" 2>/dev/null) || true
+    if [ -n "$resp" ]; then
+      status=$(echo "$resp" | jq -r '.scan_status // .status // "unknown"')
+      if [ "$status" != "pending" ] && [ "$status" != "scanning" ]; then
+        echo "$status"
+        return 0
+      fi
+    fi
+    sleep 3
+    elapsed=$(( elapsed + 3 ))
+  done
+
+  echo "${status:-timeout}"
+  return 1
+}
+
+# assert_scan_completed REPO_KEY ARTIFACT_PATH
+# Waits for the scan to finish and asserts the status is "completed" or "clean".
+assert_scan_completed() {
+  local repo_key="$1"
+  local artifact_path="$2"
+
+  local status
+  if ! status=$(wait_for_scan "$repo_key" "$artifact_path" 60); then
+    fail "scan did not complete within 60s for ${repo_key}/${artifact_path} (status: ${status})"
+    return 1
+  fi
+
+  if [ "$status" != "completed" ] && [ "$status" != "clean" ]; then
+    fail "expected scan status 'completed' or 'clean', got '${status}' for ${repo_key}/${artifact_path}"
+    return 1
+  fi
+  return 0
+}
+
+# assert_scan_has_findings REPO_KEY ARTIFACT_PATH
+# Waits for the scan and verifies the findings array is non-empty.
+assert_scan_has_findings() {
+  local repo_key="$1"
+  local artifact_path="$2"
+
+  wait_for_scan "$repo_key" "$artifact_path" 60 > /dev/null || true
+
+  local resp
+  resp=$(api_get "/api/v1/repositories/${repo_key}/artifacts/${artifact_path}/security/scan") || {
+    fail "failed to fetch scan results for ${repo_key}/${artifact_path}"
+    return 1
+  }
+
+  local count
+  count=$(echo "$resp" | jq '.findings | length // 0')
+  if [ "$count" -eq 0 ]; then
+    fail "expected scan findings for ${repo_key}/${artifact_path}, got none"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# SBOM helpers
+# ---------------------------------------------------------------------------
+
+# get_sbom REPO_KEY ARTIFACT_NAME ARTIFACT_VERSION
+# Fetches the SBOM for a specific artifact version. Outputs the JSON response.
+get_sbom() {
+  local repo_key="$1"
+  local artifact_name="$2"
+  local artifact_version="$3"
+
+  api_get "/api/v1/repositories/${repo_key}/artifacts/${artifact_name}/${artifact_version}/sbom"
+}
+
+# assert_sbom_has_components REPO_KEY ARTIFACT_NAME ARTIFACT_VERSION [MIN_COUNT]
+# Fetches the SBOM and asserts the components array has at least MIN_COUNT entries.
+assert_sbom_has_components() {
+  local repo_key="$1"
+  local artifact_name="$2"
+  local artifact_version="$3"
+  local min_count="${4:-1}"
+
+  local resp
+  resp=$(get_sbom "$repo_key" "$artifact_name" "$artifact_version") || {
+    fail "failed to fetch SBOM for ${repo_key}/${artifact_name}@${artifact_version}"
+    return 1
+  }
+
+  local count
+  count=$(echo "$resp" | jq '.components | length // 0')
+  if [ "$count" -lt "$min_count" ]; then
+    fail "expected >= ${min_count} SBOM components for ${repo_key}/${artifact_name}@${artifact_version}, got ${count}"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Cache helpers
+# ---------------------------------------------------------------------------
+
+# assert_artifact_cached REPO_KEY ARTIFACT_PATH
+# Verifies that an artifact exists in the repository's artifact list.
+assert_artifact_cached() {
+  local repo_key="$1"
+  local artifact_path="$2"
+
+  local resp
+  resp=$(api_get "/api/v1/repositories/${repo_key}/artifacts") || {
+    fail "failed to list artifacts for ${repo_key}"
+    return 1
+  }
+
+  local found
+  found=$(echo "$resp" | jq --arg path "$artifact_path" '
+    if type == "array" then map(select(.path == $path or .name == $path)) | length
+    elif .items then [.items[] | select(.path == $path or .name == $path)] | length
+    else 0
+    end
+  ')
+  if [ "$found" -eq 0 ]; then
+    fail "artifact '${artifact_path}' not found in cached artifacts for ${repo_key}"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Proxy helpers
+# ---------------------------------------------------------------------------
+
+# proxy_and_verify REPO_KEY FORMAT PACKAGE_NAME PACKAGE_VERSION
+# Pulls an artifact through the remote proxy using the format-native endpoint,
+# then verifies it was cached locally.
+proxy_and_verify() {
+  local repo_key="$1"
+  local format="$2"
+  local package_name="$3"
+  local package_version="$4"
+
+  local pull_path=""
+  case "$format" in
+    npm)
+      pull_path="/${repo_key}/${package_name}/-/${package_name}-${package_version}.tgz"
+      ;;
+    pypi)
+      pull_path="/api/v1/pypi/${repo_key}/packages/${package_name}/${package_version}/${package_name}-${package_version}.tar.gz"
+      ;;
+    maven)
+      # Expects package_name as "group/artifact" (e.g. "org/example/mylib")
+      pull_path="/${repo_key}/${package_name}/${package_version}/${package_name##*/}-${package_version}.jar"
+      ;;
+    cargo)
+      pull_path="/api/v1/crates/${repo_key}/${package_name}/${package_version}/download"
+      ;;
+    nuget)
+      pull_path="/api/v1/nuget/${repo_key}/package/${package_name}/${package_version}/${package_name}.${package_version}.nupkg"
+      ;;
+    go)
+      pull_path="/${repo_key}/${package_name}/@v/${package_version}.zip"
+      ;;
+    docker|oci)
+      # For OCI/Docker, pull the manifest to trigger caching
+      pull_path="/v2/${repo_key}/${package_name}/manifests/${package_version}"
+      ;;
+    *)
+      pull_path="/api/v1/repositories/${repo_key}/artifacts/${package_name}/${package_version}"
+      ;;
+  esac
+
+  local http_status
+  http_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(format_auth_header)" \
+    "${BASE_URL}${pull_path}") || true
+
+  if [ "$http_status" -lt 200 ] 2>/dev/null || [ "$http_status" -ge 300 ] 2>/dev/null; then
+    fail "proxy pull failed for ${format}/${package_name}@${package_version}: HTTP ${http_status}"
+    return 1
+  fi
+
+  # Verify the artifact was cached
+  assert_artifact_cached "$repo_key" "${package_name}" || return 1
+  return 0
 }


### PR DESCRIPTION
## Summary

Add the test infrastructure foundation for scan/proxy/SBOM test suites:

- `helm/values-test-full.yaml`: Full-stack Helm values overlay that enables Trivy and scan workspace alongside the existing base services. Backend env vars configure `TRIVY_URL` to the in-namespace trivy service and `SCAN_WORKSPACE_PATH`. DependencyTrack is left disabled (complex bootstrap, separate PR).
- `tests/lib/common.sh`: New shared helpers for remote/virtual repo creation (with description and member support), scan polling (`wait_for_scan`, `assert_scan_completed`, `assert_scan_has_findings`), SBOM verification (`get_sbom`, `assert_sbom_has_components`), cache validation (`assert_artifact_cached`), and format-aware proxy pull-and-verify (`proxy_and_verify`). The old `create_remote_repo`/`create_virtual_repo` stubs are replaced with the enhanced versions, keeping backward compatibility with all existing callers.
- `scripts/create-test-namespace.sh`: New `--full-stack` flag that selects `values-test-full.yaml` instead of `values-test.yaml`. Default behavior is unchanged.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes