### PR TITLE
Add E2E regression tests for Maven, OCI, and Cargo remote proxy bugs

### DIFF
--- a/tests/formats/test-cargo-remote.sh
+++ b/tests/formats/test-cargo-remote.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# test-cargo-remote.sh - Cargo remote proxy E2E test
+#
+# Covers:
+#   - Remote proxy (bug #743): create remote Cargo repo pointing at crates.io,
+#     verify config.json has absolute dl URL, pull a known crate
+#
+# Requires: curl, jq
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "cargo-remote"
+auth_admin
+setup_workdir
+
+REPO_KEY="test-cargo-remote-${RUN_ID}"
+UPSTREAM_URL="https://crates.io"
+TEST_CRATE="cfg-if"
+TEST_CRATE_VERSION="1.0.0"
+
+# -------------------------------------------------------------------------
+# Create remote Cargo repository
+# -------------------------------------------------------------------------
+
+begin_test "Create remote Cargo repository"
+if create_remote_repo "$REPO_KEY" "cargo" "$UPSTREAM_URL"; then
+  pass
+else
+  fail "could not create remote Cargo repo"
+fi
+
+# -------------------------------------------------------------------------
+# Check upstream reachability
+# -------------------------------------------------------------------------
+
+begin_test "Verify upstream reachability"
+# crates.io sparse index uses index.crates.io; also check the main domain
+if curl -sf --max-time 10 "https://index.crates.io/config.json" > /dev/null 2>&1 || \
+   curl -sf --max-time 10 "https://crates.io/api/v1/crates/cfg-if" > /dev/null 2>&1; then
+  UPSTREAM_REACHABLE=true
+  pass
+else
+  UPSTREAM_REACHABLE=false
+  skip "crates.io unreachable from test environment"
+fi
+
+# -------------------------------------------------------------------------
+# Verify config.json endpoint (bug #743)
+#
+# The config.json returned by the proxied Cargo repo must have a `dl` field
+# that is a full absolute URL, not a relative path. Cargo clients use this
+# URL template to download crates, and a relative value breaks resolution.
+# -------------------------------------------------------------------------
+
+CARGO_REPO_URL="${BASE_URL}/cargo/${REPO_KEY}"
+
+begin_test "GET config.json from remote Cargo repo (bug #743)"
+if resp=$(curl -sf $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" \
+    "${CARGO_REPO_URL}/config.json" 2>/dev/null); then
+  if assert_contains "$resp" "dl" "config.json must contain a dl field"; then
+    pass
+  fi
+else
+  fail "config.json endpoint not reachable"
+fi
+
+begin_test "Verify config.json dl URL is absolute (bug #743)"
+if [ -n "${resp:-}" ]; then
+  dl_url=$(echo "$resp" | jq -r '.dl // empty') || true
+  if [ -z "$dl_url" ] || [ "$dl_url" = "null" ]; then
+    fail "config.json has no dl field (bug #743)"
+  elif [[ "$dl_url" == http://* ]] || [[ "$dl_url" == https://* ]]; then
+    pass
+  else
+    fail "config.json dl is not an absolute URL: '${dl_url}' (bug #743)"
+  fi
+else
+  skip "no config.json response to check"
+fi
+
+# -------------------------------------------------------------------------
+# Pull a known crate through the remote proxy
+# -------------------------------------------------------------------------
+
+begin_test "Pull crate index entry through remote proxy"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+else
+  # cfg-if is 6 chars, so sparse index path is: /cf/g-/cfg-if
+  # Using the standard crate index naming: first-two/next-two/name
+  name_len=${#TEST_CRATE}
+  if [ "$name_len" -le 2 ]; then
+    index_path="/cargo/${REPO_KEY}/index/${name_len}/${TEST_CRATE}"
+  elif [ "$name_len" -eq 3 ]; then
+    prefix="${TEST_CRATE:0:1}"
+    index_path="/cargo/${REPO_KEY}/index/3/${prefix}/${TEST_CRATE}"
+  else
+    prefix1="${TEST_CRATE:0:2}"
+    prefix2="${TEST_CRATE:2:2}"
+    index_path="/cargo/${REPO_KEY}/index/${prefix1}/${prefix2}/${TEST_CRATE}"
+  fi
+
+  if index_resp=$(curl -sf $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" \
+      "${BASE_URL}${index_path}" 2>/dev/null); then
+    if assert_contains "$index_resp" "$TEST_CRATE" \
+        "index entry should contain crate name"; then
+      pass
+    fi
+  else
+    skip "sparse index lookup returned error for ${index_path}"
+  fi
+fi
+
+begin_test "Download crate through remote proxy using dl URL"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+else
+  # Use the dl URL from config.json if available, otherwise construct it
+  dl_url="${dl_url:-}"
+  download_url=""
+  if [ -n "$dl_url" ] && [ "$dl_url" != "null" ]; then
+    # The dl URL may be a template with {crate} and {version} placeholders,
+    # or it may be a base URL that needs /crate/version/download appended
+    if [[ "$dl_url" == *"{crate}"* ]]; then
+      download_url=$(echo "$dl_url" | sed "s/{crate}/${TEST_CRATE}/g; s/{version}/${TEST_CRATE_VERSION}/g")
+    else
+      # Standard Cargo API layout: dl_url/crate_name/version/download
+      download_url="${dl_url}/${TEST_CRATE}/${TEST_CRATE_VERSION}/download"
+    fi
+  else
+    # Fallback: use the standard Cargo API download path
+    download_url="${BASE_URL}/cargo/${REPO_KEY}/api/v1/crates/${TEST_CRATE}/${TEST_CRATE_VERSION}/download"
+  fi
+
+  DL_CRATE="${WORK_DIR}/downloaded.crate"
+  if curl -sf $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" \
+      -o "$DL_CRATE" -L "$download_url" 2>/dev/null; then
+    if [ -s "$DL_CRATE" ]; then
+      pass
+    else
+      fail "downloaded crate is empty"
+    fi
+  else
+    # Try the standard API path as fallback
+    fallback_url="${BASE_URL}/cargo/${REPO_KEY}/api/v1/crates/${TEST_CRATE}/${TEST_CRATE_VERSION}/download"
+    if curl -sf $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" \
+        -o "$DL_CRATE" -L "$fallback_url" 2>/dev/null; then
+      if [ -s "$DL_CRATE" ]; then
+        pass
+      else
+        fail "downloaded crate is empty (fallback)"
+      fi
+    else
+      fail "crate download returned error"
+    fi
+  fi
+fi
+
+begin_test "Verify downloaded crate is a valid gzip archive"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+elif [ -f "$DL_CRATE" ] && [ -s "$DL_CRATE" ]; then
+  # Crate files are .tar.gz archives; check the gzip magic bytes
+  magic=$(xxd -l 2 -p "$DL_CRATE" 2>/dev/null) || true
+  if [ "$magic" = "1f8b" ]; then
+    pass
+  else
+    # Some registries may serve uncompressed; at least verify it is non-empty
+    skip "downloaded file does not have gzip magic bytes (may be uncompressed)"
+  fi
+else
+  skip "no crate file to verify"
+fi
+
+begin_test "Pull a second crate version to verify caching"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+else
+  # Pull the same crate again; should succeed (possibly from cache)
+  DL_CRATE2="${WORK_DIR}/downloaded2.crate"
+  fallback_url="${BASE_URL}/cargo/${REPO_KEY}/api/v1/crates/${TEST_CRATE}/${TEST_CRATE_VERSION}/download"
+  if curl -sf $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" \
+      -o "$DL_CRATE2" -L "$fallback_url" 2>/dev/null; then
+    if [ -s "$DL_CRATE2" ]; then
+      pass
+    else
+      fail "cached crate download is empty"
+    fi
+  else
+    skip "second download attempt failed"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Cleanup
+# -------------------------------------------------------------------------
+
+api_delete "/api/v1/repositories/${REPO_KEY}" > /dev/null 2>&1 || true
+
+end_suite

--- a/tests/formats/test-maven-remote.sh
+++ b/tests/formats/test-maven-remote.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# test-maven-remote.sh - Maven remote proxy, virtual checksum, and version ordering E2E tests
+#
+# Covers:
+#   - Remote proxy: create remote Maven repo proxying repo1.maven.org, pull known artifact
+#   - Virtual checksum (bug #663): upload to local, resolve .sha256 through virtual
+#   - Version ordering (bug #568): upload multiple versions, verify maven-metadata.xml ordering
+#
+# Requires: curl, jq, shasum (or sha256sum), zip or jar
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "maven-remote"
+auth_admin
+setup_workdir
+
+REMOTE_KEY="test-mvn-remote-${RUN_ID}"
+LOCAL_KEY="test-mvn-local-${RUN_ID}"
+VIRTUAL_KEY="test-mvn-virtual-${RUN_ID}"
+UPSTREAM_URL="https://repo1.maven.org/maven2"
+
+# -------------------------------------------------------------------------
+# Remote proxy tests
+# -------------------------------------------------------------------------
+
+begin_test "Create remote Maven repository"
+if create_remote_repo "$REMOTE_KEY" "maven" "$UPSTREAM_URL"; then
+  pass
+else
+  fail "could not create remote Maven repo"
+fi
+
+begin_test "Verify upstream reachability"
+if curl -sf --max-time 10 "${UPSTREAM_URL}/junit/junit/4.13.2/junit-4.13.2.pom" > /dev/null 2>&1; then
+  UPSTREAM_REACHABLE=true
+  pass
+else
+  UPSTREAM_REACHABLE=false
+  skip "repo1.maven.org unreachable from test environment"
+fi
+
+begin_test "Pull POM through remote proxy"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+else
+  REMOTE_MAVEN_URL="${BASE_URL}/maven/${REMOTE_KEY}"
+  POM_PATH="junit/junit/4.13.2/junit-4.13.2.pom"
+  if resp=$(curl -sf $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" \
+      "${REMOTE_MAVEN_URL}/${POM_PATH}" 2>/dev/null); then
+    if assert_contains "$resp" "<artifactId>junit</artifactId>" \
+        "proxied POM should contain junit artifactId"; then
+      pass
+    fi
+  else
+    fail "GET POM through remote proxy failed"
+  fi
+fi
+
+begin_test "Pull JAR through remote proxy"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+else
+  JAR_PATH="junit/junit/4.13.2/junit-4.13.2.jar"
+  DL_JAR="${WORK_DIR}/junit-remote.jar"
+  if curl -sf $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" \
+      -o "$DL_JAR" "${REMOTE_MAVEN_URL}/${JAR_PATH}" 2>/dev/null; then
+    if [ -s "$DL_JAR" ]; then
+      pass
+    else
+      fail "downloaded JAR is empty"
+    fi
+  else
+    fail "GET JAR through remote proxy failed"
+  fi
+fi
+
+begin_test "Pull maven-metadata.xml through remote proxy"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+else
+  META_PATH="junit/junit/maven-metadata.xml"
+  if resp=$(curl -sf $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" \
+      "${REMOTE_MAVEN_URL}/${META_PATH}" 2>/dev/null); then
+    if assert_contains "$resp" "4.13.2" \
+        "remote maven-metadata.xml should list 4.13.2"; then
+      pass
+    fi
+  else
+    skip "maven-metadata.xml not available through remote proxy"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Virtual checksum test (bug #663)
+#
+# Upload a JAR to a local repo, create a virtual repo with that local as a
+# member, then request the .sha256 checksum file through the virtual repo.
+# -------------------------------------------------------------------------
+
+begin_test "Create local Maven repository"
+if create_local_repo "$LOCAL_KEY" "maven"; then
+  pass
+else
+  fail "could not create local Maven repo"
+fi
+
+begin_test "Create test JAR for checksum test"
+cd "$WORK_DIR"
+mkdir -p cksum-jar/META-INF
+cat > cksum-jar/META-INF/MANIFEST.MF <<EOF
+Manifest-Version: 1.0
+Created-By: artifact-keeper-test
+EOF
+echo "checksum-test-content-${RUN_ID}" > cksum-jar/payload.txt
+cd cksum-jar
+CKSUM_JAR="${WORK_DIR}/cksum-artifact-1.0.jar"
+if command -v jar &>/dev/null; then
+  jar cf "$CKSUM_JAR" META-INF/ payload.txt 2>/dev/null || \
+    zip -r "$CKSUM_JAR" META-INF/ payload.txt > /dev/null 2>&1
+else
+  zip -r "$CKSUM_JAR" META-INF/ payload.txt > /dev/null 2>&1
+fi
+cd "$WORK_DIR"
+
+if [ -f "$CKSUM_JAR" ] && [ -s "$CKSUM_JAR" ]; then
+  pass
+else
+  fail "failed to create test JAR"
+fi
+
+begin_test "Upload JAR to local repo"
+LOCAL_MAVEN_URL="${BASE_URL}/maven/${LOCAL_KEY}"
+CKSUM_GROUP="com/test/cksum"
+CKSUM_ARTIFACT="cksum-artifact"
+CKSUM_VERSION="1.0"
+JAR_UPLOAD_PATH="${CKSUM_GROUP}/${CKSUM_ARTIFACT}/${CKSUM_VERSION}/${CKSUM_ARTIFACT}-${CKSUM_VERSION}.jar"
+EXPECTED_SHA256=$(shasum -a 256 "$CKSUM_JAR" | awk '{print $1}')
+
+if curl -sf $CURL_TIMEOUT -X PUT "${LOCAL_MAVEN_URL}/${JAR_UPLOAD_PATH}" \
+    -u "${ADMIN_USER}:${ADMIN_PASS}" \
+    -H "Content-Type: application/java-archive" \
+    --data-binary "@${CKSUM_JAR}" > /dev/null 2>&1; then
+  pass
+else
+  fail "PUT JAR to local repo failed"
+fi
+
+begin_test "Create virtual Maven repository"
+if create_virtual_repo "$VIRTUAL_KEY" "maven"; then
+  pass
+else
+  fail "could not create virtual Maven repo"
+fi
+
+begin_test "Add local repo as virtual member"
+MEMBERS_PAYLOAD="{\"members\":[{\"member_key\":\"${LOCAL_KEY}\",\"priority\":1}]}"
+if api_put "/api/v1/repositories/${VIRTUAL_KEY}/members" "$MEMBERS_PAYLOAD" > /dev/null 2>&1; then
+  pass
+else
+  if api_post "/api/v1/repositories/${VIRTUAL_KEY}/members" \
+      "{\"member_key\":\"${LOCAL_KEY}\",\"priority\":1}" > /dev/null 2>&1; then
+    pass
+  else
+    fail "could not add local repo as virtual member"
+  fi
+fi
+
+sleep 1
+
+begin_test "GET .sha256 checksum through virtual repo (bug #663)"
+VIRTUAL_MAVEN_URL="${BASE_URL}/maven/${VIRTUAL_KEY}"
+SHA256_PATH="${JAR_UPLOAD_PATH}.sha256"
+if sha256_resp=$(curl -sf $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" \
+    "${VIRTUAL_MAVEN_URL}/${SHA256_PATH}" 2>/dev/null); then
+  # The checksum response should be a hex string matching the uploaded artifact
+  sha256_clean=$(echo "$sha256_resp" | tr -d '[:space:]')
+  if assert_eq "$sha256_clean" "$EXPECTED_SHA256" \
+      "virtual .sha256 does not match uploaded artifact checksum"; then
+    pass
+  fi
+else
+  fail "GET .sha256 through virtual repo returned error (bug #663)"
+fi
+
+begin_test "GET JAR through virtual repo"
+DL_VIRTUAL="${WORK_DIR}/virtual-downloaded.jar"
+if curl -sf $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" \
+    -o "$DL_VIRTUAL" "${VIRTUAL_MAVEN_URL}/${JAR_UPLOAD_PATH}" 2>/dev/null; then
+  DL_SHA256=$(shasum -a 256 "$DL_VIRTUAL" | awk '{print $1}')
+  if assert_eq "$DL_SHA256" "$EXPECTED_SHA256" \
+      "JAR content mismatch through virtual repo"; then
+    pass
+  fi
+else
+  fail "GET JAR through virtual repo failed"
+fi
+
+# -------------------------------------------------------------------------
+# Version ordering test (bug #568)
+#
+# Upload three versions (1.0, 1.1, 2.0) of a GAV to the local repo, then
+# verify maven-metadata.xml reports <release> as 2.0 and versions are listed
+# in order.
+# -------------------------------------------------------------------------
+
+VO_GROUP="com/test/ordering"
+VO_ARTIFACT="order-artifact"
+
+begin_test "Upload version 1.0"
+echo "v1.0-content" > "${WORK_DIR}/v1.0.jar"
+if curl -sf $CURL_TIMEOUT -X PUT \
+    "${LOCAL_MAVEN_URL}/${VO_GROUP}/${VO_ARTIFACT}/1.0/${VO_ARTIFACT}-1.0.jar" \
+    -u "${ADMIN_USER}:${ADMIN_PASS}" \
+    --data-binary "@${WORK_DIR}/v1.0.jar" > /dev/null 2>&1; then
+  pass
+else
+  fail "PUT version 1.0 failed"
+fi
+
+begin_test "Upload version 1.1"
+echo "v1.1-content" > "${WORK_DIR}/v1.1.jar"
+if curl -sf $CURL_TIMEOUT -X PUT \
+    "${LOCAL_MAVEN_URL}/${VO_GROUP}/${VO_ARTIFACT}/1.1/${VO_ARTIFACT}-1.1.jar" \
+    -u "${ADMIN_USER}:${ADMIN_PASS}" \
+    --data-binary "@${WORK_DIR}/v1.1.jar" > /dev/null 2>&1; then
+  pass
+else
+  fail "PUT version 1.1 failed"
+fi
+
+begin_test "Upload version 2.0"
+echo "v2.0-content" > "${WORK_DIR}/v2.0.jar"
+if curl -sf $CURL_TIMEOUT -X PUT \
+    "${LOCAL_MAVEN_URL}/${VO_GROUP}/${VO_ARTIFACT}/2.0/${VO_ARTIFACT}-2.0.jar" \
+    -u "${ADMIN_USER}:${ADMIN_PASS}" \
+    --data-binary "@${WORK_DIR}/v2.0.jar" > /dev/null 2>&1; then
+  pass
+else
+  fail "PUT version 2.0 failed"
+fi
+
+begin_test "Verify maven-metadata.xml version ordering (bug #568)"
+sleep 2
+META_URL="${LOCAL_MAVEN_URL}/${VO_GROUP}/${VO_ARTIFACT}/maven-metadata.xml"
+if metadata=$(curl -sf $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" \
+    "${META_URL}" 2>/dev/null); then
+  # Check <release> is 2.0
+  if echo "$metadata" | grep -q "<release>2.0</release>"; then
+    # Verify all three versions are present
+    has_1_0=$(echo "$metadata" | grep -c "<version>1.0</version>") || true
+    has_1_1=$(echo "$metadata" | grep -c "<version>1.1</version>") || true
+    has_2_0=$(echo "$metadata" | grep -c "<version>2.0</version>") || true
+    if [ "$has_1_0" -ge 1 ] && [ "$has_1_1" -ge 1 ] && [ "$has_2_0" -ge 1 ]; then
+      pass
+    else
+      fail "maven-metadata.xml missing one or more versions"
+    fi
+  else
+    # Check if release tag exists at all
+    if echo "$metadata" | grep -q "<release>"; then
+      release_val=$(echo "$metadata" | grep "<release>" | sed 's/.*<release>\(.*\)<\/release>.*/\1/')
+      fail "expected <release>2.0</release> but got <release>${release_val}</release> (bug #568)"
+    else
+      fail "maven-metadata.xml has no <release> element (bug #568)"
+    fi
+  fi
+else
+  fail "GET maven-metadata.xml returned error"
+fi
+
+begin_test "Verify version order in metadata"
+if [ -n "${metadata:-}" ]; then
+  # Extract versions in order from the XML
+  versions=$(echo "$metadata" | grep "<version>" | sed 's/.*<version>\(.*\)<\/version>.*/\1/' | tr '\n' ',')
+  # Versions should appear in ascending order: 1.0, 1.1, 2.0
+  # Check that 1.0 appears before 2.0
+  pos_1_0=$(echo "$metadata" | grep -n "<version>1.0</version>" | head -1 | cut -d: -f1) || true
+  pos_2_0=$(echo "$metadata" | grep -n "<version>2.0</version>" | head -1 | cut -d: -f1) || true
+  if [ -n "$pos_1_0" ] && [ -n "$pos_2_0" ] && [ "$pos_1_0" -lt "$pos_2_0" ]; then
+    pass
+  else
+    fail "versions not in ascending order: ${versions}"
+  fi
+else
+  skip "no metadata to check"
+fi
+
+# -------------------------------------------------------------------------
+# Cleanup
+# -------------------------------------------------------------------------
+
+api_delete "/api/v1/repositories/${VIRTUAL_KEY}" > /dev/null 2>&1 || true
+api_delete "/api/v1/repositories/${LOCAL_KEY}" > /dev/null 2>&1 || true
+api_delete "/api/v1/repositories/${REMOTE_KEY}" > /dev/null 2>&1 || true
+
+end_suite

--- a/tests/formats/test-oci-remote.sh
+++ b/tests/formats/test-oci-remote.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+# test-oci-remote.sh - OCI remote proxy, push/delete/re-push, token auth, and anonymous access E2E tests
+#
+# Covers:
+#   - Docker Hub proxy (bug #586): remote OCI repo proxying registry-1.docker.io
+#   - Push/delete/re-push (bug #600): push image, delete, verify 404, re-push, verify 200
+#   - API token auth (bug #599): use API token as password in /v2/token endpoint
+#   - Anonymous public access (bug #744): pull from public repo without auth
+#
+# Requires: curl, jq, shasum
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "oci-remote"
+auth_admin
+setup_workdir
+
+REMOTE_KEY="test-oci-remote-${RUN_ID}"
+LOCAL_KEY="test-oci-local-${RUN_ID}"
+PUBLIC_KEY="test-oci-public-${RUN_ID}"
+UPSTREAM_URL="https://registry-1.docker.io"
+UNIQUE_TAG="1.0.$(date +%s)"
+
+# =========================================================================
+# Docker Hub proxy tests (bug #586)
+# =========================================================================
+
+begin_test "Create remote OCI repository pointing at Docker Hub"
+if create_remote_repo "$REMOTE_KEY" "docker" "$UPSTREAM_URL"; then
+  pass
+else
+  fail "could not create remote OCI repo"
+fi
+
+begin_test "Verify Docker Hub reachability"
+# Docker Hub requires a token even for public images. Check the auth endpoint.
+if curl -sf --max-time 10 "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/alpine:pull" > /dev/null 2>&1; then
+  UPSTREAM_REACHABLE=true
+  pass
+else
+  UPSTREAM_REACHABLE=false
+  skip "Docker Hub unreachable from test environment"
+fi
+
+# Obtain a registry token for our backend
+TOKEN=""
+token_resp=$(curl -sf -u "${ADMIN_USER}:${ADMIN_PASS}" "${BASE_URL}/v2/token" 2>/dev/null) || true
+if [ -n "$token_resp" ]; then
+  TOKEN=$(echo "$token_resp" | jq -r '.token // empty')
+fi
+
+begin_test "Pull alpine manifest through remote proxy (library/ prefix)"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+elif [ -z "$TOKEN" ]; then
+  skip "could not obtain registry token"
+else
+  status=$(curl -s -o "$WORK_DIR/alpine-manifest.json" -w '%{http_code}' \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json" \
+    "${BASE_URL}/v2/${REMOTE_KEY}/library/alpine/manifests/3.20") || true
+  if [ "$status" = "200" ]; then
+    pass
+  else
+    fail "pull alpine manifest (library/alpine) returned ${status}, expected 200"
+  fi
+fi
+
+begin_test "Pull alpine manifest without library/ prefix"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+elif [ -z "$TOKEN" ]; then
+  skip "could not obtain registry token"
+else
+  status=$(curl -s -o "$WORK_DIR/alpine-manifest-short.json" -w '%{http_code}' \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json" \
+    "${BASE_URL}/v2/${REMOTE_KEY}/alpine/manifests/3.20") || true
+  if [ "$status" = "200" ]; then
+    pass
+  else
+    # Some registries require the library/ prefix for official images
+    skip "pull without library/ prefix returned ${status} (may require library/ prefix)"
+  fi
+fi
+
+begin_test "Pull alpine blob through remote proxy"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+elif [ -z "$TOKEN" ]; then
+  skip "could not obtain registry token"
+else
+  # Extract a blob digest from the manifest (config or layer)
+  blob_digest=""
+  if [ -f "$WORK_DIR/alpine-manifest.json" ]; then
+    # If it is a manifest list/index, try getting the config digest from the first listed manifest
+    media_type=$(jq -r '.mediaType // .schemaVersion' "$WORK_DIR/alpine-manifest.json" 2>/dev/null) || true
+    if echo "$media_type" | grep -qi "list\|index"; then
+      # It is a manifest list; get the first manifest's digest and fetch it
+      first_digest=$(jq -r '.manifests[0].digest // empty' "$WORK_DIR/alpine-manifest.json" 2>/dev/null) || true
+      if [ -n "$first_digest" ]; then
+        curl -sf $CURL_TIMEOUT \
+          -H "Authorization: Bearer $TOKEN" \
+          -H "Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json" \
+          -o "$WORK_DIR/alpine-single-manifest.json" \
+          "${BASE_URL}/v2/${REMOTE_KEY}/library/alpine/manifests/${first_digest}" 2>/dev/null || true
+        blob_digest=$(jq -r '.config.digest // empty' "$WORK_DIR/alpine-single-manifest.json" 2>/dev/null) || true
+      fi
+    else
+      blob_digest=$(jq -r '.config.digest // empty' "$WORK_DIR/alpine-manifest.json" 2>/dev/null) || true
+    fi
+  fi
+
+  if [ -n "$blob_digest" ] && [ "$blob_digest" != "null" ]; then
+    blob_status=$(curl -s -o /dev/null -w '%{http_code}' \
+      -H "Authorization: Bearer $TOKEN" \
+      "${BASE_URL}/v2/${REMOTE_KEY}/library/alpine/blobs/${blob_digest}") || true
+    if [ "$blob_status" = "200" ]; then
+      pass
+    else
+      fail "blob GET returned ${blob_status}, expected 200"
+    fi
+  else
+    skip "could not extract blob digest from manifest"
+  fi
+fi
+
+# =========================================================================
+# Push/delete/re-push test (bug #600)
+# =========================================================================
+
+begin_test "Create local OCI repository for push/delete test"
+if create_local_repo "$LOCAL_KEY" "docker"; then
+  pass
+else
+  fail "could not create local OCI repo"
+fi
+
+# Re-obtain token (scoped to the new repo)
+TOKEN=""
+token_resp=$(curl -sf -u "${ADMIN_USER}:${ADMIN_PASS}" "${BASE_URL}/v2/token" 2>/dev/null) || true
+if [ -n "$token_resp" ]; then
+  TOKEN=$(echo "$token_resp" | jq -r '.token // empty')
+fi
+
+# Helper: push a minimal OCI image (config blob + manifest)
+push_test_image() {
+  local repo_key="$1"
+  local image_name="$2"
+  local tag="$3"
+  local token="$4"
+  local content_id="${5:-default}"
+
+  # Create config blob
+  local config_content="{\"architecture\":\"amd64\",\"os\":\"linux\",\"rootfs\":{\"type\":\"layers\",\"diff_ids\":[]},\"config\":{},\"id\":\"${content_id}\"}"
+  local config_digest="sha256:$(printf '%s' "$config_content" | shasum -a 256 | awk '{print $1}')"
+  local config_size=${#config_content}
+
+  # Initiate blob upload
+  local upload_headers="$WORK_DIR/push-upload-headers-${content_id}.txt"
+  curl -s -D "$upload_headers" -o /dev/null \
+    -X POST \
+    -H "Authorization: Bearer $token" \
+    "${BASE_URL}/v2/${repo_key}/${image_name}/blobs/uploads/" 2>/dev/null || true
+
+  local location
+  location=$(grep -i '^location:' "$upload_headers" | tr -d '\r' | awk '{print $2}') || true
+
+  if [ -z "$location" ]; then
+    echo "upload-initiation-failed"
+    return 1
+  fi
+
+  # Complete blob upload
+  local put_url
+  if [[ "$location" == http* ]]; then
+    if [[ "$location" == *"?"* ]]; then
+      put_url="${location}&digest=${config_digest}"
+    else
+      put_url="${location}?digest=${config_digest}"
+    fi
+  else
+    if [[ "$location" == *"?"* ]]; then
+      put_url="${BASE_URL}${location}&digest=${config_digest}"
+    else
+      put_url="${BASE_URL}${location}?digest=${config_digest}"
+    fi
+  fi
+
+  curl -s -o /dev/null \
+    -X PUT \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/octet-stream" \
+    -d "$config_content" \
+    "$put_url" 2>/dev/null || true
+
+  # Push manifest
+  local manifest="{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\"config\":{\"mediaType\":\"application/vnd.oci.image.config.v1+json\",\"digest\":\"${config_digest}\",\"size\":${config_size}},\"layers\":[]}"
+  local manifest_status
+  manifest_status=$(curl -s -o /dev/null -w '%{http_code}' \
+    -X PUT \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/vnd.oci.image.manifest.v1+json" \
+    -d "$manifest" \
+    "${BASE_URL}/v2/${repo_key}/${image_name}/manifests/${tag}") || true
+
+  echo "$manifest_status"
+}
+
+begin_test "Push image with tag test:1.0 (bug #600)"
+if [ -z "$TOKEN" ]; then
+  fail "no registry token"
+else
+  push_status=$(push_test_image "$LOCAL_KEY" "pushdelete" "$UNIQUE_TAG" "$TOKEN" "initial")
+  if [ "$push_status" = "201" ] || [ "$push_status" = "200" ]; then
+    pass
+  else
+    fail "initial push returned ${push_status}, expected 201"
+  fi
+fi
+
+begin_test "Verify image exists after push"
+if [ -z "$TOKEN" ]; then
+  skip "no registry token"
+else
+  status=$(curl -s -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+    "${BASE_URL}/v2/${LOCAL_KEY}/pushdelete/manifests/${UNIQUE_TAG}") || true
+  if [ "$status" = "200" ]; then
+    pass
+  else
+    fail "manifest GET returned ${status} after push, expected 200"
+  fi
+fi
+
+begin_test "Delete image (bug #600)"
+if [ -z "$TOKEN" ]; then
+  skip "no registry token"
+else
+  del_status=$(curl -s -o /dev/null -w '%{http_code}' \
+    -X DELETE \
+    -H "Authorization: Bearer $TOKEN" \
+    "${BASE_URL}/v2/${LOCAL_KEY}/pushdelete/manifests/${UNIQUE_TAG}") || true
+  if [ "$del_status" = "202" ] || [ "$del_status" = "200" ]; then
+    pass
+  else
+    # Some registries use the digest for delete; try fetching digest first
+    manifest_digest=$(curl -s -D - -o /dev/null \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+      "${BASE_URL}/v2/${LOCAL_KEY}/pushdelete/manifests/${UNIQUE_TAG}" 2>/dev/null \
+      | grep -i "docker-content-digest" | tr -d '\r' | awk '{print $2}') || true
+    if [ -n "$manifest_digest" ]; then
+      del_status2=$(curl -s -o /dev/null -w '%{http_code}' \
+        -X DELETE \
+        -H "Authorization: Bearer $TOKEN" \
+        "${BASE_URL}/v2/${LOCAL_KEY}/pushdelete/manifests/${manifest_digest}") || true
+      if [ "$del_status2" = "202" ] || [ "$del_status2" = "200" ]; then
+        pass
+      else
+        fail "delete by digest returned ${del_status2}, expected 202"
+      fi
+    else
+      fail "delete by tag returned ${del_status}, expected 202"
+    fi
+  fi
+fi
+
+begin_test "Verify image returns 404 after delete (bug #600)"
+if [ -z "$TOKEN" ]; then
+  skip "no registry token"
+else
+  sleep 1
+  status=$(curl -s -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+    "${BASE_URL}/v2/${LOCAL_KEY}/pushdelete/manifests/${UNIQUE_TAG}") || true
+  if [ "$status" = "404" ]; then
+    pass
+  else
+    fail "expected 404 after delete, got ${status}"
+  fi
+fi
+
+begin_test "Re-push same tag after delete (bug #600)"
+if [ -z "$TOKEN" ]; then
+  skip "no registry token"
+else
+  repush_status=$(push_test_image "$LOCAL_KEY" "pushdelete" "$UNIQUE_TAG" "$TOKEN" "repushed")
+  if [ "$repush_status" = "201" ] || [ "$repush_status" = "200" ]; then
+    pass
+  else
+    fail "re-push returned ${repush_status}, expected 201 (bug #600)"
+  fi
+fi
+
+begin_test "Verify image exists after re-push (bug #600)"
+if [ -z "$TOKEN" ]; then
+  skip "no registry token"
+else
+  status=$(curl -s -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+    "${BASE_URL}/v2/${LOCAL_KEY}/pushdelete/manifests/${UNIQUE_TAG}") || true
+  if [ "$status" = "200" ]; then
+    pass
+  else
+    fail "manifest GET returned ${status} after re-push, expected 200 (bug #600)"
+  fi
+fi
+
+# =========================================================================
+# API token auth test (bug #599)
+# =========================================================================
+
+begin_test "Create API token for Docker auth (bug #599)"
+API_TOKEN=""
+TOKEN_ID=""
+TOKEN_NAME="e2e-oci-token-${RUN_ID}"
+if resp=$(api_post "/api/v1/auth/tokens" \
+    "{\"name\":\"${TOKEN_NAME}\",\"scopes\":[\"read\",\"write\"]}" 2>/dev/null); then
+  API_TOKEN=$(echo "$resp" | jq -r '.token // .api_key // .key // empty') || true
+  TOKEN_ID=$(echo "$resp" | jq -r '.id // .token_id // empty') || true
+  if [ -n "$API_TOKEN" ] && [ "$API_TOKEN" != "null" ]; then
+    pass
+  else
+    fail "token created but value not returned"
+  fi
+else
+  skip "API tokens endpoint not available"
+fi
+
+begin_test "Use API token as password in /v2/token endpoint (bug #599)"
+if [ -z "${API_TOKEN:-}" ] || [ "$API_TOKEN" = "null" ]; then
+  skip "no API token"
+else
+  # Use the API token as the password with the admin username in basic auth
+  token_resp2=$(curl -sf $CURL_TIMEOUT \
+    -u "${ADMIN_USER}:${API_TOKEN}" \
+    "${BASE_URL}/v2/token" 2>/dev/null) || true
+  if [ -n "$token_resp2" ]; then
+    api_registry_token=$(echo "$token_resp2" | jq -r '.token // empty') || true
+    if [ -n "$api_registry_token" ] && [ "$api_registry_token" != "null" ]; then
+      pass
+    else
+      fail "API token auth returned response but no registry token"
+    fi
+  else
+    fail "/v2/token with API token as password failed (bug #599)"
+  fi
+fi
+
+begin_test "Verify image operations with API-token-based registry token (bug #599)"
+if [ -z "${api_registry_token:-}" ] || [ "$api_registry_token" = "null" ]; then
+  skip "no registry token from API token auth"
+else
+  # Try reading the manifest we pushed earlier
+  status=$(curl -s -o /dev/null -w '%{http_code}' \
+    -H "Authorization: Bearer ${api_registry_token}" \
+    -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+    "${BASE_URL}/v2/${LOCAL_KEY}/pushdelete/manifests/${UNIQUE_TAG}") || true
+  if [ "$status" = "200" ]; then
+    pass
+  else
+    fail "image GET with API-token-derived registry token returned ${status}, expected 200 (bug #599)"
+  fi
+fi
+
+# Cleanup: revoke the API token
+if [ -n "${TOKEN_ID:-}" ] && [ "$TOKEN_ID" != "null" ]; then
+  api_delete "/api/v1/auth/tokens/${TOKEN_ID}" > /dev/null 2>&1 || true
+fi
+
+# =========================================================================
+# Anonymous public access test (bug #744)
+# =========================================================================
+
+begin_test "Create public OCI repository (bug #744)"
+# Explicitly set is_public: true in the repo creation payload
+PAYLOAD="{\"key\":\"${PUBLIC_KEY}\",\"name\":\"${PUBLIC_KEY}\",\"format\":\"docker\",\"repo_type\":\"local\",\"is_public\":true}"
+if api_post "/api/v1/repositories" "$PAYLOAD" > /dev/null 2>&1; then
+  pass
+else
+  fail "could not create public OCI repo"
+fi
+
+# Re-obtain token for push
+TOKEN=""
+token_resp=$(curl -sf -u "${ADMIN_USER}:${ADMIN_PASS}" "${BASE_URL}/v2/token" 2>/dev/null) || true
+if [ -n "$token_resp" ]; then
+  TOKEN=$(echo "$token_resp" | jq -r '.token // empty')
+fi
+
+begin_test "Push image to public repo as admin (bug #744)"
+if [ -z "$TOKEN" ]; then
+  fail "no registry token for push"
+else
+  push_status=$(push_test_image "$PUBLIC_KEY" "public-image" "latest" "$TOKEN" "public-content")
+  if [ "$push_status" = "201" ] || [ "$push_status" = "200" ]; then
+    pass
+  else
+    fail "push to public repo returned ${push_status}, expected 201"
+  fi
+fi
+
+begin_test "Pull manifest from public repo with NO auth (bug #744)"
+# This is the key assertion: no Authorization header at all
+status=$(curl -s -o "$WORK_DIR/public-manifest.json" -w '%{http_code}' \
+  -H "Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json" \
+  "${BASE_URL}/v2/${PUBLIC_KEY}/public-image/manifests/latest") || true
+if [ "$status" = "200" ]; then
+  pass
+else
+  fail "anonymous pull from public repo returned ${status}, expected 200 (bug #744)"
+fi
+
+begin_test "Verify anonymous pull returned valid manifest (bug #744)"
+if [ -f "$WORK_DIR/public-manifest.json" ]; then
+  schema_ver=$(jq -r '.schemaVersion' "$WORK_DIR/public-manifest.json" 2>/dev/null) || true
+  if [ "$schema_ver" = "2" ]; then
+    pass
+  else
+    fail "anonymous manifest schemaVersion is '${schema_ver}', expected '2'"
+  fi
+else
+  skip "no manifest file to verify"
+fi
+
+# -------------------------------------------------------------------------
+# Cleanup
+# -------------------------------------------------------------------------
+
+api_delete "/api/v1/repositories/${PUBLIC_KEY}" > /dev/null 2>&1 || true
+api_delete "/api/v1/repositories/${LOCAL_KEY}" > /dev/null 2>&1 || true
+api_delete "/api/v1/repositories/${REMOTE_KEY}" > /dev/null 2>&1 || true
+
+end_suite


### PR DESCRIPTION
## Summary

- **test-maven-remote.sh**: Remote proxy (pull from repo1.maven.org), virtual repo `.sha256` checksum resolution (bug #663), and `maven-metadata.xml` version ordering (bug #568)
- **test-oci-remote.sh**: Docker Hub proxy pull with and without `library/` prefix (bug #586), push/delete/re-push lifecycle (bug #600), API token as Docker auth password (bug #599), anonymous pull from public repo (bug #744)
- **test-cargo-remote.sh**: Remote proxy pointing at crates.io, `config.json` dl URL absoluteness check (bug #743), crate download through proxy

All scripts follow existing conventions: source `common.sh`, use `$RUN_ID` in repo keys, produce JUnit XML output, and clean up repos on completion.

## Test plan

- [ ] Run `bash tests/formats/test-maven-remote.sh` against a local backend with internet access
- [ ] Run `bash tests/formats/test-oci-remote.sh` against a local backend with internet access
- [ ] Run `bash tests/formats/test-cargo-remote.sh` against a local backend with internet access
- [ ] Verify tests skip gracefully when upstream registries are unreachable
- [ ] Confirm JUnit XML output in `$JUNIT_OUTPUT_DIR`