### PR TITLE
ci: add test-maven-virtual-snapshot to release-gate jvm matrix (#839)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -130,7 +130,7 @@ jobs:
           - name: python
             scripts: "test-pypi.sh test-pypi-remote.sh test-conda.sh test-huggingface.sh test-mlmodel.sh"
           - name: jvm
-            scripts: "test-maven.sh test-maven-remote.sh test-sbt.sh"
+            scripts: "test-maven.sh test-maven-remote.sh test-maven-virtual-snapshot.sh test-sbt.sh"
           - name: rust-go-swift
             scripts: "test-cargo.sh test-cargo-remote.sh test-go.sh test-swift.sh test-pub.sh"
           - name: system-packages


### PR DESCRIPTION
Follow-up to #33. The format-tests.yml update in #33 wasn't enough because release-gate.yml duplicates the format-tests matrix inline (line 132) rather than invoking format-tests.yml via `uses:`. So when release-gate runs, it uses its own copy of the matrix which still didn't include the new test.

This one-line change adds `test-maven-virtual-snapshot.sh` to the jvm batch in release-gate.yml so the #839 regression test actually fires during release-gate runs.

Once merged I'll re-trigger the Release Gate against `backend_tag=dev` to confirm the test fails on main/dev, proving #839 is reproducible in CI before the fix in artifact-keeper#859 merges.