### PR TITLE
fix(common): use member_key field when adding virtual repo members

### DIFF
--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -477,8 +477,8 @@ create_virtual_repo() {
     local IFS=','
     for member in $member_keys; do
       local member_payload
-      member_payload=$(jq -n --arg key "$member" '{repository_key: $key}')
-      api_post "/api/v1/repositories/${key}/members" "$member_payload" > /dev/null || true
+      member_payload=$(jq -n --arg key "$member" '{member_key: $key}')
+      api_post "/api/v1/repositories/${key}/members" "$member_payload" > /dev/null
     done
   fi
 }


### PR DESCRIPTION
## Summary

Fixes a 2-year-old (or however long it has been) silent bug in `tests/lib/common.sh` that meant virtual repos created via `create_virtual_repo KEY FORMAT MEMBER_KEYS` actually had **zero members**. The backend API expects `member_key` in the request body but the helper sent `repository_key`. The server rejected the body with 400, the trailing `|| true` swallowed the error, and the resulting virtual repo had no members at all.

## How we found it

The new `test-maven-virtual-snapshot.sh` (added in #33 to regression-test artifact-keeper#839) was the first test in the suite to use the optional `MEMBER_KEYS` argument. After artifact-keeper#859 merged and the dev image rebuilt, the regression test STILL reported 5 failures, identical to the pre-fix run. We assumed the fix didn't work.

After SSHing to a Rocky test namespace running the post-#859 backend, port-forwarding the service, and curling each step manually:
1. The hosted repo correctly served everything (uploads worked, format-endpoint reads worked).
2. `GET /api/v1/repositories/{virtual}/members` returned `{"members":[]}`.
3. With `member_key` instead of `repository_key`, the same flow returned 200 on all four #839 assertions.

So #859 is correct, the test fixture was broken, and the test would have caught the bug if the helper actually worked.

## Changes

- `tests/lib/common.sh` — switch `repository_key` to `member_key` (matches `AddVirtualMemberRequest` in `backend/src/api/handlers/repositories.rs`).
- Drop `|| true` so future bad request bodies fail loudly.

## Verification

Reran the same fixture against the live test namespace post-fix:

| Assertion | Status |
|---|---|
| Virtual repo serves version-level SNAPSHOT metadata | HTTP 200 |
| Virtual repo serves SNAPSHOT alias jar | HTTP 200 |
| Virtual repo serves timestamped jar | HTTP 200 |
| Virtual repo serves group-level metadata | HTTP 200 |

## Test Checklist

- [x] No new test scripts (one-line helper fix)
- [x] Manually tested against a live deployment of the post-#859 backend
- [x] No regressions: no other test passes the optional MEMBER_KEYS argument so blast radius is the new test plus any future caller

## API Changes

- [x] N/A - test infra only