### PR TITLE
fix(common): don't leak IFS=',' into api_post calls in create_virtual_repo

### DIFF
--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -472,10 +472,14 @@ create_virtual_repo() {
 
   api_post "/api/v1/repositories" "$payload" > /dev/null
 
-  # Add each member repository (if any specified)
+  # Add each member repository (if any specified). Use a subshell tr to split
+  # on commas so we don't leak `IFS=','` into downstream `api_post` calls — the
+  # earlier in-place `local IFS=','` form caused `$CURL_TIMEOUT` to splat as a
+  # single arg rather than multiple flags, producing
+  # `curl: option --max-time 60 --connect-timeout 10: is unknown`.
   if [ -n "$member_keys" ]; then
-    local IFS=','
-    for member in $member_keys; do
+    local member
+    for member in $(printf '%s\n' "$member_keys" | tr ',' '\n'); do
       local member_payload
       member_payload=$(jq -n --arg key "$member" '{member_key: $key}')
       api_post "/api/v1/repositories/${key}/members" "$member_payload" > /dev/null


### PR DESCRIPTION
## Summary

**Bug I introduced in #35.** When I added `local IFS=','` to split the comma-separated MEMBER_KEYS argument, I scoped it to the wrong block. IFS=',' stayed in effect for the entire function scope, including the `api_post` call inside the loop body. Inside `api_post`:

```bash
curl -sf $CURL_TIMEOUT -X POST ...
```

`$CURL_TIMEOUT` is `"--max-time 60 --connect-timeout 10"`. Word-splitting under IFS=',' keeps the whole 4-token string as a single argument, and curl errors:

```
curl: option --max-time 60 --connect-timeout 10: is unknown
```

Surfaced loudly in release-gate run 24934467423 today (jvm batch, test-maven-virtual-snapshot.sh).

## Fix

Split member_keys via `printf | tr ',' '\\n'` instead of mutating IFS. IFS stays at default whitespace for any function called from the loop body.

## Verification

`bash -n` clean. The same pattern is used elsewhere in well-known shell scripts (e.g. dockerd entrypoints) without IFS leakage issues.

This is one of 5 PRs being staged today to clean the release-gate signal for v1.2.0-rc.1. Not all-encompassing — separate PRs handle rbac, auth/platform, generic-protocol, and stress.

## Test Checklist
- [x] Manually verified `bash -n` syntax check passes
- [x] No regressions: function signature and behavior unchanged for callers
- [x] Will be validated by next release-gate run after merge

## API Changes
- [x] N/A - test infrastructure only