### PR TITLE
fix(rbac): use user_ids UUID array for group member-add

### DIFF
--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -184,6 +184,81 @@ create_local_repo() {
 }
 
 # ---------------------------------------------------------------------------
+# User / group helpers
+#
+# The backend's group membership endpoints expect user UUIDs, not usernames:
+#   POST   /api/v1/groups/{id}/members   { "user_ids": ["<uuid>", ...] }
+#   DELETE /api/v1/groups/{id}/members   { "user_ids": ["<uuid>", ...] }
+# Tests typically know the username (because they just created the user),
+# so these helpers resolve the username to a UUID and send the correct shape.
+# ---------------------------------------------------------------------------
+
+# resolve_user_id_by_username USERNAME
+# Looks up a user by exact username via /api/v1/users?search=<name> and prints
+# the matching user's UUID on stdout. Returns 1 if no exact match is found.
+resolve_user_id_by_username() {
+  local username="$1"
+  local resp
+  if ! resp=$(api_get "/api/v1/users?search=${username}&per_page=100" 2>/dev/null); then
+    return 1
+  fi
+  local id
+  id=$(echo "$resp" | jq -r --arg u "$username" '.items[]? | select(.username == $u) | .id' | head -n1)
+  if [ -z "$id" ] || [ "$id" = "null" ]; then
+    return 1
+  fi
+  echo "$id"
+}
+
+# add_group_members GROUP_ID USERNAME [USERNAME ...]
+# Resolves each username to a UUID and POSTs the user_ids array to the
+# group's members endpoint. Returns non-zero if any username cannot be
+# resolved or the API call fails.
+add_group_members() {
+  local group_id="$1"
+  shift
+  local ids=()
+  local username
+  for username in "$@"; do
+    local uid
+    if ! uid=$(resolve_user_id_by_username "$username"); then
+      echo "  resolve_user_id_by_username: no user found for '${username}'"
+      return 1
+    fi
+    ids+=("$uid")
+  done
+  local payload
+  payload=$(printf '%s\n' "${ids[@]}" | jq -R . | jq -s '{user_ids: .}')
+  api_post "/api/v1/groups/${group_id}/members" "$payload"
+}
+
+# remove_group_members GROUP_ID USERNAME [USERNAME ...]
+# Resolves usernames to UUIDs and DELETEs the user_ids array from the
+# group's members endpoint. The backend expects a JSON body on DELETE,
+# which is why we cannot simply use api_delete with a path suffix.
+remove_group_members() {
+  local group_id="$1"
+  shift
+  local ids=()
+  local username
+  for username in "$@"; do
+    local uid
+    if ! uid=$(resolve_user_id_by_username "$username"); then
+      echo "  resolve_user_id_by_username: no user found for '${username}'"
+      return 1
+    fi
+    ids+=("$uid")
+  done
+  local payload
+  payload=$(printf '%s\n' "${ids[@]}" | jq -R . | jq -s '{user_ids: .}')
+  curl -sf $CURL_TIMEOUT -X DELETE \
+    -H "$(auth_header)" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "${BASE_URL}/api/v1/groups/${group_id}/members"
+}
+
+# ---------------------------------------------------------------------------
 # Test framework
 #
 # Usage pattern:

--- a/tests/rbac/test-group-detail-members.sh
+++ b/tests/rbac/test-group-detail-members.sh
@@ -30,9 +30,7 @@ if resp=$(api_post "/api/v1/groups" \
   if [ -n "$GROUP_ID" ]; then
     pass
   else
-    # Some API shapes use the name as identifier
-    GROUP_ID="$GROUP_NAME"
-    pass
+    fail "create group response did not include an id"
   fi
 else
   fail "could not create group"
@@ -61,16 +59,9 @@ fi
 # -------------------------------------------------------------------------
 
 begin_test "Add 3 users to the group"
-members_endpoint="/api/v1/groups/${GROUP_ID}/members"
-added=false
-if api_post "$members_endpoint" \
-    "{\"usernames\":[\"${USER_A}\",\"${USER_B}\",\"${USER_C}\"]}" > /dev/null 2>&1; then
-  added=true
-elif api_post "$members_endpoint" \
-    "{\"members\":[\"${USER_A}\",\"${USER_B}\",\"${USER_C}\"]}" > /dev/null 2>&1; then
-  added=true
-fi
-if $added; then
+# The backend expects { "user_ids": [<uuid>, ...] } at POST /api/v1/groups/{id}/members
+# (see backend MembersRequest). add_group_members resolves usernames to UUIDs first.
+if add_group_members "$GROUP_ID" "$USER_A" "$USER_B" "$USER_C" > /dev/null 2>&1; then
   pass
 else
   fail "could not add members to group"

--- a/tests/rbac/test-group-management.sh
+++ b/tests/rbac/test-group-management.sh
@@ -26,7 +26,11 @@ begin_test "Create group"
 if resp=$(api_post "/api/v1/groups" \
     "{\"name\":\"${GROUP_NAME}\",\"description\":\"E2E test group\"}" 2>/dev/null); then
   GROUP_ID=$(echo "$resp" | jq -r '.id // empty') || true
-  pass
+  if [ -n "$GROUP_ID" ]; then
+    pass
+  else
+    fail "create group response did not include an id"
+  fi
 else
   fail "could not create group"
 fi
@@ -49,13 +53,12 @@ fi
 # -------------------------------------------------------------------------
 
 begin_test "Add members to group"
-endpoint="/api/v1/groups/${GROUP_ID:-$GROUP_NAME}/members"
-if api_post "$endpoint" "{\"usernames\":[\"${USER_A}\",\"${USER_B}\"]}" > /dev/null 2>&1; then
-  pass
-elif api_post "$endpoint" "{\"members\":[\"${USER_A}\",\"${USER_B}\"]}" > /dev/null 2>&1; then
+# Backend MembersRequest is { user_ids: Vec<Uuid> }; add_group_members resolves
+# usernames to UUIDs and posts the correct payload.
+if add_group_members "$GROUP_ID" "$USER_A" "$USER_B" > /dev/null 2>&1; then
   pass
 else
-  skip "add members endpoint not available or different shape"
+  fail "could not add members to group"
 fi
 
 # -------------------------------------------------------------------------
@@ -63,12 +66,13 @@ fi
 # -------------------------------------------------------------------------
 
 begin_test "List group members"
-if resp=$(api_get "$endpoint" 2>/dev/null); then
+# Group detail returns members inline, not via a separate /members GET.
+if resp=$(api_get "/api/v1/groups/${GROUP_ID}" 2>/dev/null); then
   if assert_contains "$resp" "$USER_A"; then
     pass
   fi
 else
-  skip "member listing not available"
+  fail "could not fetch group detail"
 fi
 
 # -------------------------------------------------------------------------
@@ -76,12 +80,11 @@ fi
 # -------------------------------------------------------------------------
 
 begin_test "Remove member from group"
-if api_delete "${endpoint}/${USER_B}" > /dev/null 2>&1; then
-  pass
-elif api_post "${endpoint}/remove" "{\"usernames\":[\"${USER_B}\"]}" > /dev/null 2>&1; then
+# Backend remove_members takes the same { user_ids: [...] } body via DELETE.
+if remove_group_members "$GROUP_ID" "$USER_B" > /dev/null 2>&1; then
   pass
 else
-  skip "remove member not available"
+  fail "could not remove member from group"
 fi
 
 # -------------------------------------------------------------------------
@@ -89,7 +92,7 @@ fi
 # -------------------------------------------------------------------------
 
 begin_test "Delete group"
-if api_delete "/api/v1/groups/${GROUP_ID:-$GROUP_NAME}" > /dev/null 2>&1; then
+if api_delete "/api/v1/groups/${GROUP_ID}" > /dev/null 2>&1; then
   pass
 else
   fail "could not delete group"


### PR DESCRIPTION
## Summary

The rbac group-membership tests were failing in release-gate run 24934467423 because the test payloads used the wrong schema.

The backend (`artifact-keeper/backend/src/api/handlers/groups.rs`) declares the request body for both `POST` and `DELETE /api/v1/groups/{id}/members` as:

```rust
pub struct MembersRequest {
    pub user_ids: Vec<Uuid>,
}
```

Two rbac tests were sending the wrong shape:

- `tests/rbac/test-group-detail-members.sh` tried `{"usernames":[...]}` then `{"members":[...]}` (both with usernames as values). Both fail validation. The "Add 3 users to the group" step always returned 4xx, and every subsequent assertion also failed because the group was empty.
- `tests/rbac/test-group-management.sh` had the same bad payload plus a remove path that hit endpoints (`DELETE .../members/<username>`, `POST .../members/remove`) that do not exist on the backend.

## Fix

- Added three helpers to `tests/lib/common.sh`:
  - `resolve_user_id_by_username` looks up a user via `GET /api/v1/users?search=<name>` and returns the exact-match UUID.
  - `add_group_members` resolves usernames and POSTs `{"user_ids":[...]}` to the group's members endpoint.
  - `remove_group_members` does the same for `DELETE` (which takes a JSON body, so it cannot use the path-based `api_delete` helper).
- Rewrote both rbac tests to use the helpers.
- Dropped the `${GROUP_ID:-$GROUP_NAME}` fallback in both tests; the backend takes `Path<Uuid>`, so the name fallback could never succeed and was masking the real failure mode.

## Evidence

- Release-gate run https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/24934467423 had `rbac-tests` failing on the "Add 3 users to the group" step in `test-group-detail-members.sh`.
- Backend schema confirmed at `artifact-keeper/backend/src/api/handlers/groups.rs` lines 527-530.
- Backend route confirmed: `Router::new().route("/:id/members", post(add_members).delete(remove_members))` with `Path(id): Path<Uuid>` on both handlers.

## Test Checklist

- [x] `bash -n` clean on every script under `tests/rbac/` and `tests/lib/common.sh`
- [x] `shellcheck -x` clean on the two changed test files and `common.sh` (only pre-existing info-level warnings remain on `$CURL_TIMEOUT` word splitting, which matches the project pattern)
- [x] Manually traced one full path end-to-end: create users -> resolve UUIDs -> POST `{"user_ids":[...]}` -> backend `INSERT INTO user_group_members` -> `GET /api/v1/groups/{id}` returns `members[].username` matching the created users.

## API Changes

None. Test-only fix. The API contract for group membership has not changed; the tests were the ones out of date.

## Out of scope

This PR addresses only the rbac group member-add failure called out in release-gate run 24934467423. Any other failures in that run (if present) are not touched here. Open a separate issue/PR for those.