### PR TITLE
fix(platform): single-shot password change to avoid invalidated-token 401

### DIFF
--- a/tests/platform/test-admin-password-recovery.sh
+++ b/tests/platform/test-admin-password-recovery.sh
@@ -138,8 +138,10 @@ begin_test "Admin can change password"
 if [ -z "$ADMIN_ID" ] || [ "$ADMIN_ID" = "null" ]; then
   skip "could not resolve admin user ID"
 else
-  change_resp=$(api_post "/api/v1/users/${ADMIN_ID}/password" \
-    "{\"current_password\":\"${ORIGINAL_PASS}\",\"new_password\":\"${TEST_PASS}\"}" 2>/dev/null) || true
+  # Send exactly one request. The change_password handler invalidates the
+  # caller's existing JWT after a successful change (backend
+  # auth_service::invalidate_user_tokens), so a second call with the same
+  # ADMIN_TOKEN would get 401 and look like a backend failure.
   change_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X POST \
     -H "$(auth_header)" \
     -H "Content-Type: application/json" \
@@ -147,10 +149,6 @@ else
     "${BASE_URL}/api/v1/users/${ADMIN_ID}/password") || true
 
   if [ "$change_status" -ge 200 ] 2>/dev/null && [ "$change_status" -lt 300 ] 2>/dev/null; then
-    PASSWORD_MUTATED=true
-    pass
-  elif [ -n "$change_resp" ] && echo "$change_resp" | jq -e '.' >/dev/null 2>&1; then
-    # api_post succeeded (set -e did not abort), treat as success
     PASSWORD_MUTATED=true
     pass
   else


### PR DESCRIPTION
## Summary

`test-admin-password-recovery.sh` was sending two consecutive POSTs to `/api/v1/users/{id}/password` with the same Bearer token. The backend's change_password handler calls `auth_service::invalidate_user_tokens(id)` on success (users.rs:853), recording `changed_at = now` in the in-memory invalidation map. Subsequent requests with a JWT whose `iat` is `< changed_at` are rejected by `auth_middleware` (auth_service.rs:149-156) with HTTP 401.

The first call mutated the password successfully; the second call hit the invalidation map and returned 401, surfacing as `FAIL: password change returned HTTP 401` in the release-gate platform job (run 24938542187).

Backend behavior is correct and intentional (changing a password should invalidate existing sessions). This is a test-side fix.

## Change

Drop the redundant `api_post` call and capture status from the single `curl` that was already there. The downstream "Login with new password works" test re-authenticates, so subsequent tests are unaffected. -6/+4 lines.

## Test plan

- [x] bash -n syntax check passes
- [ ] Release-gate platform job goes green on next run

Blocks v1.2.0-rc.1 tag.