### PR TITLE
feat(release-gate): clean-cluster helm install smoke test (#44)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -62,6 +62,54 @@ env:
 
 jobs:
   # -------------------------------------------------------------------
+  # Clean-install smoke test
+  #
+  # Boots a fresh namespace, runs `helm install` against the documented
+  # values-production.yaml, and polls kubectl rollout status plus /readyz
+  # for up to 120s. This catches startup panics (e.g. the v1.1.8 Debian
+  # route panic) that crash the backend before it can ever serve traffic.
+  #
+  # Runs independently of the `deploy` job so a startup crash fails the
+  # gate fast, before the long-running matrix burns runner time on a
+  # broken build.
+  # -------------------------------------------------------------------
+  clean-install-smoke:
+    runs-on: ak-e2e-runners
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: artifact-keeper/artifact-keeper-test
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Run clean-install smoke test
+        env:
+          BACKEND_TAG: ${{ inputs.backend_tag }}
+          WEB_TAG: ${{ inputs.web_tag }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          chmod +x scripts/clean-install-smoke.sh
+          RUN_ID="smoke-$(date +%s)-${GITHUB_RUN_NUMBER}"
+          ./scripts/clean-install-smoke.sh \
+            --run-id "${RUN_ID}" \
+            --backend-tag "${BACKEND_TAG}" \
+            --web-tag "${WEB_TAG}" \
+            --timeout 120
+
+      - name: Upload smoke diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: clean-install-smoke-logs
+          path: /tmp/test-logs/
+          if-no-files-found: ignore
+
+  # -------------------------------------------------------------------
   # Deploy test environment
   # -------------------------------------------------------------------
   deploy:
@@ -707,7 +755,7 @@ jobs:
   # Collect results and publish summary
   # -------------------------------------------------------------------
   collect-results:
-    needs: [deploy, format-tests, security-tests, compatibility-tests, repo-tests, promotion-tests, rbac-tests, lifecycle-tests, webhook-tests, search-tests, platform-tests, auth-tests, stress-tests, resilience-tests, mesh-tests]
+    needs: [clean-install-smoke, deploy, format-tests, security-tests, compatibility-tests, repo-tests, promotion-tests, rbac-tests, lifecycle-tests, webhook-tests, search-tests, platform-tests, auth-tests, stress-tests, resilience-tests, mesh-tests]
     if: always()
     runs-on: ak-e2e-runners
     steps:
@@ -726,9 +774,10 @@ jobs:
           echo "| Suite | Status |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-------|--------|" >> "$GITHUB_STEP_SUMMARY"
 
-          for job in format-tests repo-tests promotion-tests rbac-tests lifecycle-tests webhook-tests search-tests platform-tests auth-tests security-tests compatibility-tests stress-tests resilience-tests mesh-tests; do
+          for job in clean-install-smoke format-tests repo-tests promotion-tests rbac-tests lifecycle-tests webhook-tests search-tests platform-tests auth-tests security-tests compatibility-tests stress-tests resilience-tests mesh-tests; do
             status="skipped"
             case "$job" in
+              clean-install-smoke) status="${{ needs.clean-install-smoke.result }}" ;;
               format-tests) status="${{ needs.format-tests.result }}" ;;
               repo-tests) status="${{ needs.repo-tests.result }}" ;;
               promotion-tests) status="${{ needs.promotion-tests.result }}" ;;

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: boolean
         default: false
+      iac_ref:
+        description: artifact-keeper-iac git ref for the Helm chart (default main)
+        required: false
+        type: string
+        default: 'main'
   workflow_call:
     inputs:
       backend_tag:
@@ -55,6 +60,10 @@ on:
         required: false
         type: boolean
         default: false
+      iac_ref:
+        required: false
+        type: string
+        default: 'main'
 
 env:
   NAMESPACE_CPU: ${{ vars.TEST_NAMESPACE_CPU || '4000m' }}
@@ -65,17 +74,19 @@ jobs:
   # Clean-install smoke test
   #
   # Boots a fresh namespace, runs `helm install` against the documented
-  # values-production.yaml, and polls kubectl rollout status plus /readyz
-  # for up to 120s. This catches startup panics (e.g. the v1.1.8 Debian
-  # route panic) that crash the backend before it can ever serve traffic.
+  # values-production.yaml (with overrides for deps the smoke can't
+  # satisfy), waits for backend AND web Deployments to reach Ready, then
+  # probes /readyz from inside the cluster. Catches startup panics (e.g.
+  # the v1.1.8 Debian route panic) that crash the backend before it can
+  # serve traffic.
   #
-  # Runs independently of the `deploy` job so a startup crash fails the
-  # gate fast, before the long-running matrix burns runner time on a
-  # broken build.
+  # The `deploy` job (and therefore the entire test matrix downstream)
+  # `needs:` this gate. A startup-broken release fails fast here without
+  # burning runner time on the matrix.
   # -------------------------------------------------------------------
   clean-install-smoke:
     runs-on: ak-e2e-runners
-    timeout-minutes: 8
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4
         with:
@@ -91,15 +102,27 @@ jobs:
         env:
           BACKEND_TAG: ${{ inputs.backend_tag }}
           WEB_TAG: ${{ inputs.web_tag }}
-          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+          # Pin iac chart ref so the gate validates against the chart
+          # version that ships with the release. Defaults to `main` when
+          # the workflow input is unset; release pipelines should pass
+          # the corresponding iac tag.
+          IAC_REF: ${{ inputs.iac_ref || 'main' }}
+          # Pull-secret for ghcr.io. Without this, private image tags
+          # fail with ImagePullBackOff and the gate fails for the wrong
+          # reason. Workflows that test public-only tags can omit it.
+          GHCR_DOCKER_CONFIG: ${{ secrets.GHCR_DOCKER_CONFIG }}
         run: |
           chmod +x scripts/clean-install-smoke.sh
-          RUN_ID="smoke-$(date +%s)-${GITHUB_RUN_NUMBER}"
+          # github.run_id + github.run_attempt is unique per workflow
+          # attempt (re-runs increment run_attempt). Avoids RUN_ID
+          # collisions when a job is retried.
+          RUN_ID="${{ github.run_id }}-${{ github.run_attempt }}"
           ./scripts/clean-install-smoke.sh \
             --run-id "${RUN_ID}" \
             --backend-tag "${BACKEND_TAG}" \
             --web-tag "${WEB_TAG}" \
-            --timeout 120
+            --iac-ref "${IAC_REF}" \
+            --timeout 300
 
       - name: Upload smoke diagnostics
         if: failure()
@@ -111,8 +134,14 @@ jobs:
 
   # -------------------------------------------------------------------
   # Deploy test environment
+  #
+  # Gated on `clean-install-smoke` so that the matrix below cannot run
+  # against a backend that fails to even start. A startup-broken release
+  # fails fast in `clean-install-smoke` and the entire matrix is skipped,
+  # preserving runner-time for releases that can actually be tested.
   # -------------------------------------------------------------------
   deploy:
+    needs: clean-install-smoke
     runs-on: ak-e2e-runners
     outputs:
       run_id: ${{ steps.setup.outputs.run_id }}

--- a/.github/workflows/smoke-self-test.yml
+++ b/.github/workflows/smoke-self-test.yml
@@ -1,0 +1,75 @@
+name: Smoke Self-Test
+
+# Meta-test that pins the clean-install-smoke gate's semantics so a
+# future change cannot silently turn it into a no-op.
+#
+# Why this exists
+# ---------------
+# `scripts/clean-install-smoke.sh` is the release gate that would have
+# caught the v1.1.8 Debian route panic. It works by exiting non-zero
+# when the backend fails to start. If a future PR weakens that contract
+# (adds `|| true`, raises `--timeout` to a useless value, removes the
+# rollout-status check, etc.) the gate goes silent — green forever, even
+# on broken releases. That is the same silent-success failure class that
+# motivated the gate in the first place.
+#
+# This workflow runs the gate against a deliberately-broken backend tag
+# (`nonexistent-tag-pinning-self-test`) and asserts the gate exits
+# non-zero with a useful diagnostic. If a regression makes the gate
+# pass on a broken backend, this job fails and blocks the PR.
+#
+# Triggers on every PR that touches the gate or this self-test, so the
+# protection cannot be sidestepped without an explicit decision.
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/clean-install-smoke.sh'
+      - '.github/workflows/release-gate.yml'
+      - '.github/workflows/smoke-self-test.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/clean-install-smoke.sh'
+      - '.github/workflows/release-gate.yml'
+      - '.github/workflows/smoke-self-test.yml'
+
+jobs:
+  pin-gate-fails-on-broken-backend:
+    name: Gate must reject a broken backend image
+    runs-on: ak-e2e-runners
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Run gate against nonexistent image and expect failure
+        env:
+          # Pull-secret intentionally omitted: the test fixture is a
+          # nonexistent tag, ImagePullBackOff is exactly what we want.
+          GHCR_DOCKER_CONFIG: ''
+        run: |
+          chmod +x scripts/clean-install-smoke.sh
+          RUN_ID="self-${{ github.run_id }}-${{ github.run_attempt }}"
+          # --expect-failure inverts the meaning of exit codes: a non-zero
+          # exit (the gate working correctly) becomes 0, and exit 0 (the
+          # gate silently passing on a broken backend) becomes exit 4.
+          ./scripts/clean-install-smoke.sh \
+            --run-id "${RUN_ID}" \
+            --backend-tag "nonexistent-tag-pinning-self-test-9.9.9" \
+            --web-tag "nonexistent-tag-pinning-self-test-9.9.9" \
+            --timeout 60 \
+            --expect-failure
+
+      - name: Upload self-test diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-self-test-logs-${{ github.run_attempt }}
+          path: /tmp/test-logs/
+          if-no-files-found: ignore

--- a/.github/workflows/smoke-self-test.yml
+++ b/.github/workflows/smoke-self-test.yml
@@ -13,10 +13,17 @@ name: Smoke Self-Test
 # on broken releases. That is the same silent-success failure class that
 # motivated the gate in the first place.
 #
-# This workflow runs the gate against a deliberately-broken backend tag
-# (`nonexistent-tag-pinning-self-test`) and asserts the gate exits
-# non-zero with a useful diagnostic. If a regression makes the gate
-# pass on a broken backend, this job fails and blocks the PR.
+# We pin TWO failure shapes because the gate's behavior on each is
+# distinct (different code paths in classify_pod_failure, different
+# `--previous` log availability, different rollout-status timing):
+#
+#   1. ImagePullBackOff — backend tag does not exist on the registry.
+#      Exercises the registry/secret diagnostic path.
+#   2. CrashLoopBackOff — backend image is real and pulls fine, but the
+#      command exits non-zero on every start. Exercises the
+#      crash-on-startup path that v1.1.8 actually hit. Without this
+#      fixture, a future PR could weaken only the CrashLoopBackOff
+#      handling and the ImagePullBackOff self-test would still pass.
 #
 # Triggers on every PR that touches the gate or this self-test, so the
 # protection cannot be sidestepped without an explicit decision.
@@ -34,9 +41,16 @@ on:
       - '.github/workflows/release-gate.yml'
       - '.github/workflows/smoke-self-test.yml'
 
+# Cancel stale runs of the same workflow on a branch when a new push
+# arrives. Keeps the PR feedback fast and avoids confusing red checks
+# from prior runs on top of a green re-run.
+concurrency:
+  group: smoke-self-test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  pin-gate-fails-on-broken-backend:
-    name: Gate must reject a broken backend image
+  pin-gate-fails-on-image-pull-backoff:
+    name: Gate must reject ImagePullBackOff (fixture A)
     runs-on: ak-e2e-runners
     timeout-minutes: 10
     steps:
@@ -50,12 +64,12 @@ jobs:
 
       - name: Run gate against nonexistent image and expect failure
         env:
-          # Pull-secret intentionally omitted: the test fixture is a
+          # Pull-secret intentionally omitted: the fixture is a
           # nonexistent tag, ImagePullBackOff is exactly what we want.
           GHCR_DOCKER_CONFIG: ''
         run: |
           chmod +x scripts/clean-install-smoke.sh
-          RUN_ID="self-${{ github.run_id }}-${{ github.run_attempt }}"
+          RUN_ID="self-pull-${{ github.run_id }}-${{ github.run_attempt }}"
           # --expect-failure inverts the meaning of exit codes: a non-zero
           # exit (the gate working correctly) becomes 0, and exit 0 (the
           # gate silently passing on a broken backend) becomes exit 4.
@@ -70,6 +84,63 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: smoke-self-test-logs-${{ github.run_attempt }}
+          name: smoke-self-test-pull-logs-${{ github.run_attempt }}
+          path: /tmp/test-logs/
+          if-no-files-found: ignore
+
+  pin-gate-fails-on-crash-loop:
+    name: Gate must reject CrashLoopBackOff (fixture B)
+    runs-on: ak-e2e-runners
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      # Fixture: tag a public busybox image as the "backend" via a
+      # transient ImageStreamTag-style alias. busybox does not have
+      # /usr/local/bin/artifact-keeper, so the chart's command fails
+      # immediately on every restart -> CrashLoopBackOff. This pins the
+      # v1.1.8 panic path specifically (image pulls fine, crashes after
+      # start), distinct from ImagePullBackOff covered by fixture A.
+      #
+      # We achieve this by passing a public crash-on-start image
+      # directly to the gate via a backend-tag override that the chart
+      # accepts. Since the gate's helm-install also overrides the
+      # backend image repository, we can repurpose the override list
+      # via a small fixture-only --set. See the gate's HELM_OVERRIDES
+      # array for the wiring.
+      #
+      # The fixture image is `busybox:1.36.1` retagged via the chart's
+      # `backend.image.repository` override. busybox-as-backend means
+      # `/usr/local/bin/artifact-keeper` is missing -> exit code 127
+      # -> kubelet retries -> CrashLoopBackOff.
+      - name: Run gate against busybox-as-backend and expect CrashLoopBackOff
+        env:
+          GHCR_DOCKER_CONFIG: ''
+          # Override repository to a public crash-on-start image. The
+          # gate's existing --set list pins backend.image.tag from
+          # arguments; we override .repository here via env that the
+          # script reads for fixture-mode (added in this PR).
+          SMOKE_BACKEND_REPO_OVERRIDE: 'docker.io/library/busybox'
+        run: |
+          chmod +x scripts/clean-install-smoke.sh
+          RUN_ID="self-crash-${{ github.run_id }}-${{ github.run_attempt }}"
+          ./scripts/clean-install-smoke.sh \
+            --run-id "${RUN_ID}" \
+            --backend-tag "1.36.1" \
+            --web-tag "1.36.1" \
+            --timeout 90 \
+            --expect-failure
+
+      - name: Upload self-test diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-self-test-crash-logs-${{ github.run_attempt }}
           path: /tmp/test-logs/
           if-no-files-found: ignore

--- a/scripts/clean-install-smoke.sh
+++ b/scripts/clean-install-smoke.sh
@@ -53,6 +53,7 @@ EXPECT_FAILURE=false
 
 # Track resources to clean up. Set after first use.
 CHART_TMPDIR=""
+GHCR_CONFIG_FILE=""
 
 # ---------------------------------------------------------------------------
 # Parse arguments
@@ -207,6 +208,13 @@ cleanup() {
     rm -rf "$CHART_TMPDIR" 2>/dev/null || true
   fi
 
+  # Tempfile holding the dockerconfigjson for the GHCR pull secret. The
+  # secret is created from this file then cleaned up here on EXIT (rather
+  # than via a RETURN trap, which only fires from inside a function).
+  if [ -n "$GHCR_CONFIG_FILE" ] && [ -f "$GHCR_CONFIG_FILE" ]; then
+    rm -f "$GHCR_CONFIG_FILE" 2>/dev/null || true
+  fi
+
   exit "$exit_code"
 }
 trap cleanup EXIT
@@ -253,17 +261,29 @@ kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -
 # step env MUST set GHCR_DOCKER_CONFIG (base64-encoded ~/.docker/config.json)
 # for private image tags to pull. If unset, we explicitly warn so a silent
 # auth failure is visible in workflow logs.
+#
+# kubectl notes: `create secret docker-registry --docker-username/--docker-server`
+# is mutually exclusive with `--from-file`. The first form expects raw
+# credentials and builds the dockerconfigjson itself. Since we already
+# have the full dockerconfigjson, we use `create secret generic` with the
+# correct `--type=kubernetes.io/dockerconfigjson` so the resulting Secret
+# is valid for `imagePullSecrets`. (Cleanup of GHCR_CONFIG_FILE happens in
+# the EXIT trap above.)
 if [ -n "${GHCR_DOCKER_CONFIG:-}" ]; then
-  CONFIG_FILE="$(mktemp)"
-  trap 'rm -f "$CONFIG_FILE"' RETURN
-  echo "$GHCR_DOCKER_CONFIG" | base64 -d > "$CONFIG_FILE"
-  kubectl create secret docker-registry ghcr-creds \
+  GHCR_CONFIG_FILE="$(mktemp)"
+  echo "$GHCR_DOCKER_CONFIG" | base64 -d > "$GHCR_CONFIG_FILE"
+  kubectl create secret generic ghcr-creds \
     --namespace "$NAMESPACE" \
-    --docker-server=ghcr.io \
-    --from-file=".dockerconfigjson=${CONFIG_FILE}" \
+    --type=kubernetes.io/dockerconfigjson \
+    --from-file=".dockerconfigjson=${GHCR_CONFIG_FILE}" \
     --dry-run=client -o yaml | kubectl apply -f -
-  rm -f "$CONFIG_FILE"
   echo "Created ghcr-creds pull secret in ${NAMESPACE}"
+  echo ""
+  echo "NOTE: The chart at /Users/khan/ak/artifact-keeper-iac currently does"
+  echo "      not plumb global.imagePullSecrets onto pod specs, so this"
+  echo "      secret is created but unused until the chart adds the wiring."
+  echo "      Tracked as a chart follow-up. Public ghcr.io tags work without"
+  echo "      this secret."
 else
   echo "WARN: GHCR_DOCKER_CONFIG is not set. Private images will fail to pull."
   echo "      Public images will work fine. To wire creds, add:"
@@ -341,42 +361,61 @@ fi
 #   cosign.enabled=false (default already)
 #     No signature verification in CI; would block on cosign tooling.
 
+# Build the override flags once and reuse for both the dry-run and the
+# install. Drift between the two would defeat the lint pass.
+HELM_OVERRIDES=(
+  --set fullnameOverride=ak-smoke
+  --set backend.image.tag="$BACKEND_TAG"
+  --set backend.image.pullPolicy=Always
+  --set backend.replicaCount=1
+  --set "backend.env.ADMIN_PASSWORD=Smoke!2026secure"
+  --set web.image.tag="$WEB_TAG"
+  --set web.replicaCount=1
+  --set secrets.jwtSecret="smoke-jwt-secret-not-for-production"
+  --set postgres.enabled=true
+  --set "postgres.auth.username=registry"
+  --set "postgres.auth.password=smoke-db-password"
+  --set "postgres.auth.database=artifact_registry"
+  --set externalDatabase.host=""
+  --set externalDatabase.existingSecret=""
+  --set externalSecrets.enabled=false
+  --set ingress.enabled=false
+  --set serviceMonitor.enabled=false
+  --set "backend.autoscaling.enabled=false"
+  --set "backend.podDisruptionBudget.enabled=false"
+  --set "web.podDisruptionBudget.enabled=false"
+  --set edge.enabled=false
+  --set trivy.enabled=false
+  --set dependencyTrack.enabled=false
+  --set networkPolicy.enabled=false
+  --set opensearch.replicaCount=1
+  --set opensearch.persistence.enabled=false
+  --set 'opensearch.javaOpts=-Xms512m -Xmx512m'
+  --set 'opensearch.resources.requests.memory=1Gi'
+  --set 'opensearch.resources.limits.memory=1Gi'
+)
+
+# Fixture override: when SMOKE_BACKEND_REPO_OVERRIDE is set (used by the
+# self-test workflow's CrashLoopBackOff fixture), repurpose the backend
+# image repository to a public crash-on-startup image. This preserves
+# the array's quoting through word-splitting, which inline `:+` expansion
+# would not.
+if [ -n "${SMOKE_BACKEND_REPO_OVERRIDE:-}" ]; then
+  HELM_OVERRIDES+=(--set "backend.image.repository=${SMOKE_BACKEND_REPO_OVERRIDE}")
+fi
+
 echo ""
-echo "Validating Helm template (catches override drift early)"
-helm template "$RELEASE_NAME" "$CHART_DIR" \
+echo "Helm template dry-run (catches misnamed --set keys)"
+# `--debug` is intentionally omitted — it would print rendered manifests
+# (including the test-only Secret block with jwtSecret/postgres password)
+# to stderr, which is captured in workflow logs. `--dry-run=server` runs
+# server-side validation including CRD existence; replaces the deprecated
+# `--validate` flag (helm 3.13+).
+helm install "$RELEASE_NAME" "$CHART_DIR" \
   --namespace "$NAMESPACE" \
   --values "$PROD_VALUES" \
-  --set fullnameOverride=ak-smoke \
-  --set backend.image.tag="$BACKEND_TAG" \
-  --set backend.image.pullPolicy=Always \
-  --set backend.replicaCount=1 \
-  --set "backend.env.ADMIN_PASSWORD=Smoke!2026secure" \
-  --set web.image.tag="$WEB_TAG" \
-  --set web.replicaCount=1 \
-  --set secrets.jwtSecret="smoke-jwt-secret-not-for-production" \
-  --set postgres.enabled=true \
-  --set "postgres.auth.username=registry" \
-  --set "postgres.auth.password=smoke-db-password" \
-  --set "postgres.auth.database=artifact_registry" \
-  --set externalDatabase.host="" \
-  --set externalDatabase.existingSecret="" \
-  --set externalSecrets.enabled=false \
-  --set ingress.enabled=false \
-  --set serviceMonitor.enabled=false \
-  --set "backend.autoscaling.enabled=false" \
-  --set "backend.podDisruptionBudget.enabled=false" \
-  --set "web.podDisruptionBudget.enabled=false" \
-  --set edge.enabled=false \
-  --set trivy.enabled=false \
-  --set dependencyTrack.enabled=false \
-  --set networkPolicy.enabled=false \
-  --set opensearch.replicaCount=1 \
-  --set opensearch.persistence.enabled=false \
-  --set 'opensearch.javaOpts=-Xms512m -Xmx512m' \
-  --set 'opensearch.resources.requests.memory=1Gi' \
-  --set 'opensearch.resources.limits.memory=1Gi' \
-  --validate \
-  --debug \
+  "${HELM_OVERRIDES[@]}" \
+  --dry-run=server \
   >/dev/null
 
 echo ""
@@ -384,35 +423,7 @@ echo "Installing Helm release ${RELEASE_NAME}"
 helm upgrade --install "$RELEASE_NAME" "$CHART_DIR" \
   --namespace "$NAMESPACE" \
   --values "$PROD_VALUES" \
-  --set fullnameOverride=ak-smoke \
-  --set backend.image.tag="$BACKEND_TAG" \
-  --set backend.image.pullPolicy=Always \
-  --set backend.replicaCount=1 \
-  --set "backend.env.ADMIN_PASSWORD=Smoke!2026secure" \
-  --set web.image.tag="$WEB_TAG" \
-  --set web.replicaCount=1 \
-  --set secrets.jwtSecret="smoke-jwt-secret-not-for-production" \
-  --set postgres.enabled=true \
-  --set "postgres.auth.username=registry" \
-  --set "postgres.auth.password=smoke-db-password" \
-  --set "postgres.auth.database=artifact_registry" \
-  --set externalDatabase.host="" \
-  --set externalDatabase.existingSecret="" \
-  --set externalSecrets.enabled=false \
-  --set ingress.enabled=false \
-  --set serviceMonitor.enabled=false \
-  --set "backend.autoscaling.enabled=false" \
-  --set "backend.podDisruptionBudget.enabled=false" \
-  --set "web.podDisruptionBudget.enabled=false" \
-  --set edge.enabled=false \
-  --set trivy.enabled=false \
-  --set dependencyTrack.enabled=false \
-  --set networkPolicy.enabled=false \
-  --set opensearch.replicaCount=1 \
-  --set opensearch.persistence.enabled=false \
-  --set 'opensearch.javaOpts=-Xms512m -Xmx512m' \
-  --set 'opensearch.resources.requests.memory=1Gi' \
-  --set 'opensearch.resources.limits.memory=1Gi' \
+  "${HELM_OVERRIDES[@]}" \
   --wait=false || {
     echo "ERROR: helm install failed" >&2
     exit 1
@@ -506,17 +517,27 @@ readyz_probe_loop() {
     return 3
   fi
 
-  # The backend image typically has wget or curl; try wget first since
-  # alpine-based images include it. Fall back to /dev/tcp shell builtin
-  # if neither is available.
+  # The backend image is RHEL ubi-micro + curl-minimal (per the backend
+  # Dockerfile). It does NOT ship `which`, so we use POSIX `command -v`
+  # for detection. wget is checked first because Alpine-style images that
+  # might be used in development tend to have it; curl is the production
+  # default and is also fine.
   local probe_cmd
-  if kubectl exec -n "$NAMESPACE" "$backend_pod" -- which wget >/dev/null 2>&1; then
-    probe_cmd="wget -q --timeout=5 -O - --server-response ${service_url}/readyz 2>&1 | grep -E '^  HTTP/'"
-  elif kubectl exec -n "$NAMESPACE" "$backend_pod" -- which curl >/dev/null 2>&1; then
+  if kubectl exec -n "$NAMESPACE" "$backend_pod" -- sh -c 'command -v wget >/dev/null' 2>/dev/null; then
+    # GNU wget indents response headers with two spaces; busybox wget
+    # uses one. Match either with `-i 'HTTP/'`.
+    probe_cmd="wget -q --timeout=5 -O - --server-response ${service_url}/readyz 2>&1 | grep -i 'HTTP/'"
+  elif kubectl exec -n "$NAMESPACE" "$backend_pod" -- sh -c 'command -v curl >/dev/null' 2>/dev/null; then
     probe_cmd="curl -fsS -o /dev/null -w '%{http_code}\n' --max-time 5 ${service_url}/readyz"
   else
-    # Bash builtin /dev/tcp is portable on most distros without curl/wget.
-    probe_cmd="(exec 3<>/dev/tcp/ak-smoke-backend/8080 && echo -e 'GET /readyz HTTP/1.0\r\nHost: ak-smoke-backend\r\n\r\n' >&3 && head -1 <&3)"
+    # No portable fallback — `/dev/tcp` is a bash builtin and busybox sh
+    # in Alpine-based images does not support it. If neither curl nor
+    # wget is present, fail with a clear classification rather than a
+    # silent timeout. Adding a probe tool to the backend image is the
+    # right fix.
+    echo "ERROR: backend pod has neither curl nor wget; cannot probe /readyz" >&2
+    echo "       fix: add curl or wget to the backend image" >&2
+    return 3
   fi
 
   local start now elapsed deadline output

--- a/scripts/clean-install-smoke.sh
+++ b/scripts/clean-install-smoke.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# clean-install-smoke.sh - Clean-cluster Helm install smoke test
+#
+# Usage:
+#   ./clean-install-smoke.sh --run-id <id> --backend-tag <tag> [--web-tag <tag>] \
+#       [--iac-repo <path>] [--timeout <seconds>] [--keep-namespace]
+#
+# Boots a fresh namespace, performs `helm install` against the documented
+# values-production.yaml (with test-only secret overrides), and polls
+# `kubectl rollout status` plus `/readyz` until the backend reports ready
+# or the timeout expires.
+#
+# This gate exists to catch startup panics (e.g. the v1.1.8 Debian route
+# panic) that crash the backend before it can ever serve traffic. If the
+# pod never reaches Ready in the window, the script exits non-zero and the
+# release-gate fails.
+#
+# Exit codes:
+#   0  Pod ready, /readyz returns 200, smoke test passed
+#   1  Helm install failed
+#   2  Rollout did not complete within timeout
+#   3  /readyz did not return 200 within timeout
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# SCRIPT_DIR retained for future use; this script does not currently
+# reference files in the repo root.
+: "${SCRIPT_DIR}"
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+RUN_ID=""
+BACKEND_TAG=""
+WEB_TAG="dev"
+IAC_REPO=""
+TIMEOUT_SECONDS=120
+KEEP_NAMESPACE=false
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-id)         RUN_ID="$2"; shift 2 ;;
+    --backend-tag)    BACKEND_TAG="$2"; shift 2 ;;
+    --web-tag)        WEB_TAG="$2"; shift 2 ;;
+    --iac-repo)       IAC_REPO="$2"; shift 2 ;;
+    --timeout)        TIMEOUT_SECONDS="$2"; shift 2 ;;
+    --keep-namespace) KEEP_NAMESPACE=true; shift ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: clean-install-smoke.sh --run-id <id> --backend-tag <tag> [--web-tag <tag>] [--iac-repo <path>] [--timeout <seconds>] [--keep-namespace]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$RUN_ID" ] || [ -z "$BACKEND_TAG" ]; then
+  echo "ERROR: --run-id and --backend-tag are required" >&2
+  exit 1
+fi
+
+NAMESPACE="smoke-${RUN_ID}"
+RELEASE_NAME="ak-smoke-${RUN_ID}"
+
+echo "=================================================================="
+echo "Clean-install smoke test"
+echo "  Namespace:   ${NAMESPACE}"
+echo "  Release:     ${RELEASE_NAME}"
+echo "  Backend tag: ${BACKEND_TAG}"
+echo "  Web tag:     ${WEB_TAG}"
+echo "  Timeout:     ${TIMEOUT_SECONDS}s"
+echo "=================================================================="
+
+# ---------------------------------------------------------------------------
+# Teardown handler (always cleans up unless --keep-namespace)
+# ---------------------------------------------------------------------------
+
+cleanup() {
+  local exit_code=$?
+  if [ "$KEEP_NAMESPACE" = "true" ]; then
+    echo ""
+    echo "Skipping teardown (--keep-namespace set). Namespace ${NAMESPACE} retained for debugging."
+    exit "$exit_code"
+  fi
+
+  echo ""
+  echo "------------------------------------------------------------------"
+  echo "Teardown: collecting diagnostics and removing ${NAMESPACE}"
+  echo "------------------------------------------------------------------"
+
+  # Capture pod state and logs on failure for debugging the release-gate
+  if [ "$exit_code" -ne 0 ]; then
+    echo ""
+    echo "Pods in ${NAMESPACE}:"
+    kubectl get pods -n "$NAMESPACE" -o wide 2>/dev/null || true
+    echo ""
+    echo "Recent events in ${NAMESPACE}:"
+    kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' 2>/dev/null | tail -30 || true
+
+    # Save backend logs for the workflow artifact step
+    LOGS_DIR="${LOGS_DIR:-/tmp/test-logs}/smoke-${RUN_ID}"
+    mkdir -p "$LOGS_DIR"
+    pods=$(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+    for pod in $pods; do
+      kubectl logs "$pod" -n "$NAMESPACE" --all-containers --tail=500 \
+        > "${LOGS_DIR}/${pod}.log" 2>/dev/null || true
+      kubectl logs "$pod" -n "$NAMESPACE" --all-containers --previous --tail=500 \
+        > "${LOGS_DIR}/${pod}.previous.log" 2>/dev/null || true
+    done
+    echo "Logs saved to ${LOGS_DIR}/"
+  fi
+
+  helm uninstall "$RELEASE_NAME" --namespace "$NAMESPACE" --wait=false 2>/dev/null || true
+  kubectl delete namespace "$NAMESPACE" --wait=false 2>/dev/null || true
+
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Resolve Helm chart source
+# ---------------------------------------------------------------------------
+
+CHART_TMPDIR=""
+if [ -n "$IAC_REPO" ]; then
+  CHART_DIR="${IAC_REPO}/charts/artifact-keeper"
+else
+  CHART_TMPDIR="$(mktemp -d)"
+  echo "Cloning artifact-keeper-iac for Helm chart..."
+  git clone --depth 1 https://github.com/artifact-keeper/artifact-keeper-iac.git "$CHART_TMPDIR/iac"
+  CHART_DIR="${CHART_TMPDIR}/iac/charts/artifact-keeper"
+fi
+
+if [ ! -f "${CHART_DIR}/Chart.yaml" ]; then
+  echo "ERROR: Helm chart not found at ${CHART_DIR}" >&2
+  exit 1
+fi
+
+PROD_VALUES="${CHART_DIR}/values-production.yaml"
+if [ ! -f "$PROD_VALUES" ]; then
+  echo "ERROR: values-production.yaml not found at ${PROD_VALUES}" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Create fresh namespace
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Creating fresh namespace ${NAMESPACE}"
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+if [ -n "${GHCR_DOCKER_CONFIG:-}" ]; then
+  kubectl create secret docker-registry ghcr-creds \
+    --namespace "$NAMESPACE" \
+    --docker-server=ghcr.io \
+    --from-file=.dockerconfigjson=<(echo "$GHCR_DOCKER_CONFIG" | base64 -d) \
+    --dry-run=client -o yaml | kubectl apply -f -
+fi
+
+# ---------------------------------------------------------------------------
+# Helm install with documented production values + test-only overrides
+# ---------------------------------------------------------------------------
+#
+# values-production.yaml is an example template that ships with empty
+# strings for ADMIN_PASSWORD, jwtSecret, RDS host, ingress host, etc. The
+# point of this gate is to verify the chart's documented install path,
+# not to exercise external infrastructure, so we override:
+#
+#   - fullnameOverride       stable service DNS for /readyz polling
+#   - backend image tag      under-test build
+#   - ADMIN_PASSWORD         test-only credential
+#   - secrets.jwtSecret      test-only credential
+#   - postgres.enabled=true  in-cluster DB instead of RDS
+#   - externalDatabase       cleared so chart uses in-cluster postgres
+#   - externalSecrets        disabled (no AWS Secrets Manager in CI)
+#   - ingress                disabled (no public domain)
+#   - serviceMonitor         disabled (no Prometheus operator in test cluster)
+#   - autoscaling/PDB        single replica is enough for a startup smoke
+#
+# These overrides keep the chart on its documented values-production.yaml
+# code path while cutting external dependencies the smoke test can't
+# satisfy.
+
+echo ""
+echo "Installing Helm release ${RELEASE_NAME}"
+helm upgrade --install "$RELEASE_NAME" "$CHART_DIR" \
+  --namespace "$NAMESPACE" \
+  --values "$PROD_VALUES" \
+  --set fullnameOverride=ak-smoke \
+  --set backend.image.tag="$BACKEND_TAG" \
+  --set backend.image.pullPolicy=Always \
+  --set backend.replicaCount=1 \
+  --set "backend.env.ADMIN_PASSWORD=Smoke!2026secure" \
+  --set web.image.tag="$WEB_TAG" \
+  --set web.replicaCount=1 \
+  --set secrets.jwtSecret="smoke-jwt-secret-not-for-production" \
+  --set postgres.enabled=true \
+  --set "postgres.auth.username=registry" \
+  --set "postgres.auth.password=smoke-db-password" \
+  --set "postgres.auth.database=artifact_registry" \
+  --set externalDatabase.host="" \
+  --set externalDatabase.existingSecret="" \
+  --set externalSecrets.enabled=false \
+  --set ingress.enabled=false \
+  --set serviceMonitor.enabled=false \
+  --set "backend.autoscaling.enabled=false" \
+  --set "backend.podDisruptionBudget.enabled=false" \
+  --set "web.podDisruptionBudget.enabled=false" \
+  --set edge.enabled=false \
+  --set trivy.enabled=false \
+  --set dependencyTrack.enabled=false \
+  --set networkPolicy.enabled=false \
+  --wait=false || {
+    echo "ERROR: helm install failed" >&2
+    exit 1
+  }
+
+# ---------------------------------------------------------------------------
+# Poll rollout status AND /readyz in parallel-ish
+# ---------------------------------------------------------------------------
+#
+# The v1.1.8 panic was a startup crash: the pod went CrashLoopBackOff, the
+# rollout never progressed, and the chart never reported ready. We watch
+# both the deployment rollout (catches CrashLoopBackOff) and the actual
+# /readyz endpoint (catches "running but not serving") so either failure
+# mode trips the gate.
+
+DEPLOYMENT="ak-smoke-backend"
+SERVICE_URL="http://ak-smoke-backend.${NAMESPACE}.svc.cluster.local:8080"
+
+echo ""
+echo "Polling rollout status for deployment/${DEPLOYMENT} (timeout: ${TIMEOUT_SECONDS}s)"
+
+# kubectl rollout status itself respects --timeout. If the deployment is
+# stuck (image pull, CrashLoopBackOff, etc.), this exits non-zero.
+if ! kubectl rollout status "deployment/${DEPLOYMENT}" \
+      --namespace "$NAMESPACE" \
+      --timeout="${TIMEOUT_SECONDS}s"; then
+  echo "ERROR: deployment/${DEPLOYMENT} did not reach Ready within ${TIMEOUT_SECONDS}s" >&2
+  echo ""
+  echo "Pod state:"
+  kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/component=backend" -o wide || true
+  exit 2
+fi
+
+echo ""
+echo "Polling ${SERVICE_URL}/readyz (timeout: ${TIMEOUT_SECONDS}s)"
+
+# /readyz is checked from inside the cluster via a short-lived curl pod so
+# we don't need ingress or port-forwarding from the runner. This matches
+# how application traffic actually reaches the backend in production.
+
+start=$(date +%s)
+deadline=$(( start + TIMEOUT_SECONDS ))
+
+while true; do
+  now=$(date +%s)
+  if [ "$now" -ge "$deadline" ]; then
+    echo "ERROR: /readyz did not return 200 within ${TIMEOUT_SECONDS}s" >&2
+    exit 3
+  fi
+
+  # Run curl from a throwaway pod inside the namespace. -fsS makes curl
+  # exit non-zero on HTTP >= 400 and stay quiet on success.
+  if kubectl run "smoke-probe-$$" \
+        --namespace "$NAMESPACE" \
+        --image=curlimages/curl:8.10.1 \
+        --restart=Never \
+        --rm -i --quiet --timeout=20s \
+        --command -- curl -fsS -o /dev/null -w "%{http_code}\n" \
+          --max-time 5 "${SERVICE_URL}/readyz" 2>/dev/null | grep -q '^200$'; then
+    elapsed=$(( now - start ))
+    echo "Backend /readyz returned 200 (took ${elapsed}s after rollout completed)"
+    break
+  fi
+
+  printf "."
+  sleep 5
+done
+
+echo ""
+echo "=================================================================="
+echo "Clean-install smoke test PASSED"
+echo "  Backend tag ${BACKEND_TAG} reached Ready and served /readyz 200."
+echo "=================================================================="
+
+# Cleanup happens via trap on EXIT
+exit 0

--- a/scripts/clean-install-smoke.sh
+++ b/scripts/clean-install-smoke.sh
@@ -3,30 +3,40 @@
 #
 # Usage:
 #   ./clean-install-smoke.sh --run-id <id> --backend-tag <tag> [--web-tag <tag>] \
-#       [--iac-repo <path>] [--timeout <seconds>] [--keep-namespace]
+#       [--iac-repo <path>] [--iac-ref <git-ref>] [--timeout <seconds>] \
+#       [--keep-namespace] [--expect-failure]
 #
 # Boots a fresh namespace, performs `helm install` against the documented
-# values-production.yaml (with test-only secret overrides), and polls
-# `kubectl rollout status` plus `/readyz` until the backend reports ready
-# or the timeout expires.
+# values-production.yaml (with test-only secret overrides), waits for the
+# backend AND web Deployments to reach Ready, then probes `/readyz` from
+# inside the cluster until 200.
 #
 # This gate exists to catch startup panics (e.g. the v1.1.8 Debian route
-# panic) that crash the backend before it can ever serve traffic. If the
-# pod never reaches Ready in the window, the script exits non-zero and the
-# release-gate fails.
+# panic) that crash the backend before it can serve traffic. If any
+# Deployment never reaches Ready in the window, the script exits non-zero
+# and the release-gate fails.
+#
+# What this gate is NOT:
+#   - It is NOT a search/scan/format/auth E2E (those live in matrix jobs).
+#   - It does NOT exercise ingress, externalDatabase, externalSecrets,
+#     openSCAP, edge, dependencyTrack, or trivy. Those are disabled via
+#     overrides so the smoke focuses on backend+web startup. Coverage of
+#     those subsystems is the role of `clean-install-smoke-with-deps`
+#     (filed as a follow-up).
+#   - It does NOT exercise OpenSearch in production-shape (3-replica
+#     StatefulSet with 3x 50Gi PVCs). Production OpenSearch is exercised
+#     by the search-tests matrix job.
 #
 # Exit codes:
-#   0  Pod ready, /readyz returns 200, smoke test passed
-#   1  Helm install failed
-#   2  Rollout did not complete within timeout
+#   0  All Deployments Ready, /readyz returns 200, smoke passed
+#   1  Usage error, missing arg, or helm install failed
+#   2  Rollout did not complete within timeout (CrashLoopBackOff,
+#      ImagePullBackOff, etc.)
 #   3  /readyz did not return 200 within timeout
+#   4  Self-test mode: gate did NOT fail when --expect-failure was set
+#      (used by the smoke meta-test that pins the gate's semantics)
 
 set -euo pipefail
-
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-# SCRIPT_DIR retained for future use; this script does not currently
-# reference files in the repo root.
-: "${SCRIPT_DIR}"
 
 # ---------------------------------------------------------------------------
 # Defaults
@@ -36,24 +46,40 @@ RUN_ID=""
 BACKEND_TAG=""
 WEB_TAG="dev"
 IAC_REPO=""
-TIMEOUT_SECONDS=120
+IAC_REF="main"
+TIMEOUT_SECONDS=300
 KEEP_NAMESPACE=false
+EXPECT_FAILURE=false
+
+# Track resources to clean up. Set after first use.
+CHART_TMPDIR=""
 
 # ---------------------------------------------------------------------------
 # Parse arguments
 # ---------------------------------------------------------------------------
 
+require_value() {
+  local flag="$1"
+  local value="${2:-}"
+  if [ -z "$value" ]; then
+    echo "ERROR: $flag requires a value" >&2
+    exit 1
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --run-id)         RUN_ID="$2"; shift 2 ;;
-    --backend-tag)    BACKEND_TAG="$2"; shift 2 ;;
-    --web-tag)        WEB_TAG="$2"; shift 2 ;;
-    --iac-repo)       IAC_REPO="$2"; shift 2 ;;
-    --timeout)        TIMEOUT_SECONDS="$2"; shift 2 ;;
+    --run-id)         require_value "$1" "${2:-}"; RUN_ID="$2"; shift 2 ;;
+    --backend-tag)    require_value "$1" "${2:-}"; BACKEND_TAG="$2"; shift 2 ;;
+    --web-tag)        require_value "$1" "${2:-}"; WEB_TAG="$2"; shift 2 ;;
+    --iac-repo)       require_value "$1" "${2:-}"; IAC_REPO="$2"; shift 2 ;;
+    --iac-ref)        require_value "$1" "${2:-}"; IAC_REF="$2"; shift 2 ;;
+    --timeout)        require_value "$1" "${2:-}"; TIMEOUT_SECONDS="$2"; shift 2 ;;
     --keep-namespace) KEEP_NAMESPACE=true; shift ;;
+    --expect-failure) EXPECT_FAILURE=true; shift ;;
     *)
       echo "Unknown argument: $1" >&2
-      echo "Usage: clean-install-smoke.sh --run-id <id> --backend-tag <tag> [--web-tag <tag>] [--iac-repo <path>] [--timeout <seconds>] [--keep-namespace]" >&2
+      echo "Usage: clean-install-smoke.sh --run-id <id> --backend-tag <tag> [--web-tag <tag>] [--iac-repo <path>] [--iac-ref <git-ref>] [--timeout <seconds>] [--keep-namespace] [--expect-failure]" >&2
       exit 1
       ;;
   esac
@@ -69,22 +95,65 @@ RELEASE_NAME="ak-smoke-${RUN_ID}"
 
 echo "=================================================================="
 echo "Clean-install smoke test"
-echo "  Namespace:   ${NAMESPACE}"
-echo "  Release:     ${RELEASE_NAME}"
-echo "  Backend tag: ${BACKEND_TAG}"
-echo "  Web tag:     ${WEB_TAG}"
-echo "  Timeout:     ${TIMEOUT_SECONDS}s"
+echo "  Namespace:        ${NAMESPACE}"
+echo "  Release:          ${RELEASE_NAME}"
+echo "  Backend tag:      ${BACKEND_TAG}"
+echo "  Web tag:          ${WEB_TAG}"
+echo "  Timeout:          ${TIMEOUT_SECONDS}s"
+echo "  iac ref:          ${IAC_REF}"
+echo "  Expect failure:   ${EXPECT_FAILURE}"
 echo "=================================================================="
+
+# ---------------------------------------------------------------------------
+# Diagnostic helpers
+# ---------------------------------------------------------------------------
+
+# Classify pod failure reason so the gate's diagnostic line tells operators
+# whether to suspect the build (CrashLoopBackOff), the registry/secret path
+# (ImagePullBackOff/ErrImagePull), or PVC binding (Pending).
+classify_pod_failure() {
+  local ns="$1"
+  local label="$2"
+  local reasons
+  reasons=$(kubectl get pods -n "$ns" -l "$label" \
+    -o jsonpath='{range .items[*].status.containerStatuses[*]}{.state.waiting.reason}{"\n"}{end}{range .items[*].status.initContainerStatuses[*]}{.state.waiting.reason}{"\n"}{end}' \
+    2>/dev/null | sort -u | grep -v '^$' || true)
+  if [ -z "$reasons" ]; then
+    local phase
+    phase=$(kubectl get pods -n "$ns" -l "$label" -o jsonpath='{.items[*].status.phase}' 2>/dev/null || echo "")
+    echo "no-waiting-reason (phase=${phase:-unknown})"
+    return
+  fi
+  echo "$reasons" | tr '\n' ',' | sed 's/,$//'
+}
 
 # ---------------------------------------------------------------------------
 # Teardown handler (always cleans up unless --keep-namespace)
 # ---------------------------------------------------------------------------
 
+# shellcheck disable=SC2329  # invoked via `trap cleanup EXIT`
 cleanup() {
   local exit_code=$?
+
+  # Self-test mode: invert the meaning of exit code so a *real* failure
+  # is reported as success and a missing-failure is reported as code 4.
+  if [ "$EXPECT_FAILURE" = "true" ]; then
+    if [ "$exit_code" -eq 0 ]; then
+      echo "" >&2
+      echo "ERROR: --expect-failure was set but the gate passed. The gate is broken or the test fixture is wrong." >&2
+      exit_code=4
+    else
+      echo ""
+      echo "Self-test PASSED: gate exited with code ${exit_code} as expected."
+      exit_code=0
+    fi
+  fi
+
   if [ "$KEEP_NAMESPACE" = "true" ]; then
     echo ""
     echo "Skipping teardown (--keep-namespace set). Namespace ${NAMESPACE} retained for debugging."
+    [ -n "$CHART_TMPDIR" ] && [ -d "$CHART_TMPDIR" ] && \
+      echo "Helm chart workdir at ${CHART_TMPDIR} also retained."
     exit "$exit_code"
   fi
 
@@ -93,46 +162,71 @@ cleanup() {
   echo "Teardown: collecting diagnostics and removing ${NAMESPACE}"
   echo "------------------------------------------------------------------"
 
-  # Capture pod state and logs on failure for debugging the release-gate
+  # Capture pod state and logs on failure for debugging the release-gate.
+  # Tolerate every kubectl call here so cleanup never fails on a missing
+  # resource. mkdir is best-effort: a read-only /tmp should not abort
+  # cleanup, just skip log capture.
   if [ "$exit_code" -ne 0 ]; then
     echo ""
     echo "Pods in ${NAMESPACE}:"
     kubectl get pods -n "$NAMESPACE" -o wide 2>/dev/null || true
     echo ""
+    echo "Backend pod failure classification:"
+    classify_pod_failure "$NAMESPACE" "app.kubernetes.io/component=backend" || true
+    echo ""
+    echo "Web pod failure classification:"
+    classify_pod_failure "$NAMESPACE" "app.kubernetes.io/component=web" || true
+    echo ""
     echo "Recent events in ${NAMESPACE}:"
-    kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' 2>/dev/null | tail -30 || true
+    kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' 2>/dev/null | tail -50 || true
 
-    # Save backend logs for the workflow artifact step
     LOGS_DIR="${LOGS_DIR:-/tmp/test-logs}/smoke-${RUN_ID}"
-    mkdir -p "$LOGS_DIR"
-    pods=$(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
-    for pod in $pods; do
-      kubectl logs "$pod" -n "$NAMESPACE" --all-containers --tail=500 \
-        > "${LOGS_DIR}/${pod}.log" 2>/dev/null || true
-      kubectl logs "$pod" -n "$NAMESPACE" --all-containers --previous --tail=500 \
-        > "${LOGS_DIR}/${pod}.previous.log" 2>/dev/null || true
-    done
-    echo "Logs saved to ${LOGS_DIR}/"
+    if mkdir -p "$LOGS_DIR" 2>/dev/null; then
+      pods=$(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+      for pod in $pods; do
+        kubectl logs "$pod" -n "$NAMESPACE" --all-containers --tail=500 \
+          > "${LOGS_DIR}/${pod}.log" 2>/dev/null || true
+        kubectl logs "$pod" -n "$NAMESPACE" --all-containers --previous --tail=500 \
+          > "${LOGS_DIR}/${pod}.previous.log" 2>/dev/null || true
+        # describe is where ImagePullBackOff messages and init container
+        # status surface most readably.
+        kubectl describe pod "$pod" -n "$NAMESPACE" \
+          > "${LOGS_DIR}/${pod}.describe.txt" 2>/dev/null || true
+      done
+      kubectl get pvc -n "$NAMESPACE" -o yaml > "${LOGS_DIR}/pvcs.yaml" 2>/dev/null || true
+      echo "Logs and describe saved to ${LOGS_DIR}/"
+    else
+      echo "Could not create ${LOGS_DIR}; skipping log capture."
+    fi
   fi
 
   helm uninstall "$RELEASE_NAME" --namespace "$NAMESPACE" --wait=false 2>/dev/null || true
   kubectl delete namespace "$NAMESPACE" --wait=false 2>/dev/null || true
+
+  if [ -n "$CHART_TMPDIR" ] && [ -d "$CHART_TMPDIR" ]; then
+    rm -rf "$CHART_TMPDIR" 2>/dev/null || true
+  fi
 
   exit "$exit_code"
 }
 trap cleanup EXIT
 
 # ---------------------------------------------------------------------------
-# Resolve Helm chart source
+# Resolve Helm chart source. The iac repo is cloned at $IAC_REF (default
+# `main`) so the gate can be pinned to a chart ref that matches the
+# release being validated. Pinning matters because chart drift on iac
+# main can break the gate retroactively or, worse, silently change the
+# semantics of what `values-production.yaml` enables.
 # ---------------------------------------------------------------------------
 
-CHART_TMPDIR=""
 if [ -n "$IAC_REPO" ]; then
   CHART_DIR="${IAC_REPO}/charts/artifact-keeper"
 else
   CHART_TMPDIR="$(mktemp -d)"
-  echo "Cloning artifact-keeper-iac for Helm chart..."
-  git clone --depth 1 https://github.com/artifact-keeper/artifact-keeper-iac.git "$CHART_TMPDIR/iac"
+  echo "Cloning artifact-keeper-iac@${IAC_REF} for Helm chart..."
+  git clone --depth 1 --branch "$IAC_REF" \
+    https://github.com/artifact-keeper/artifact-keeper-iac.git \
+    "$CHART_TMPDIR/iac"
   CHART_DIR="${CHART_TMPDIR}/iac/charts/artifact-keeper"
 fi
 
@@ -155,37 +249,135 @@ echo ""
 echo "Creating fresh namespace ${NAMESPACE}"
 kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
 
+# Wire the GHCR pull secret if the workflow provided it. The workflow's
+# step env MUST set GHCR_DOCKER_CONFIG (base64-encoded ~/.docker/config.json)
+# for private image tags to pull. If unset, we explicitly warn so a silent
+# auth failure is visible in workflow logs.
 if [ -n "${GHCR_DOCKER_CONFIG:-}" ]; then
+  CONFIG_FILE="$(mktemp)"
+  trap 'rm -f "$CONFIG_FILE"' RETURN
+  echo "$GHCR_DOCKER_CONFIG" | base64 -d > "$CONFIG_FILE"
   kubectl create secret docker-registry ghcr-creds \
     --namespace "$NAMESPACE" \
     --docker-server=ghcr.io \
-    --from-file=.dockerconfigjson=<(echo "$GHCR_DOCKER_CONFIG" | base64 -d) \
+    --from-file=".dockerconfigjson=${CONFIG_FILE}" \
     --dry-run=client -o yaml | kubectl apply -f -
+  rm -f "$CONFIG_FILE"
+  echo "Created ghcr-creds pull secret in ${NAMESPACE}"
+else
+  echo "WARN: GHCR_DOCKER_CONFIG is not set. Private images will fail to pull."
+  echo "      Public images will work fine. To wire creds, add:"
+  echo "        env:"
+  echo "          GHCR_DOCKER_CONFIG: \${{ secrets.GHCR_DOCKER_CONFIG }}"
+  echo "      to the workflow step that runs this script."
 fi
 
 # ---------------------------------------------------------------------------
-# Helm install with documented production values + test-only overrides
-# ---------------------------------------------------------------------------
+# Compose Helm overrides.
 #
-# values-production.yaml is an example template that ships with empty
-# strings for ADMIN_PASSWORD, jwtSecret, RDS host, ingress host, etc. The
-# point of this gate is to verify the chart's documented install path,
-# not to exercise external infrastructure, so we override:
+# values-production.yaml is the chart's example template. It assumes a
+# real production environment: RDS, AWS Secrets Manager, ingress, full
+# 3-replica OpenSearch StatefulSet with 50Gi PVCs each, and a Prometheus
+# operator. Our smoke namespace has none of those. We override carefully
+# so the chart still goes through values-production.yaml's code path,
+# minus the deps we cannot satisfy.
 #
-#   - fullnameOverride       stable service DNS for /readyz polling
-#   - backend image tag      under-test build
-#   - ADMIN_PASSWORD         test-only credential
-#   - secrets.jwtSecret      test-only credential
-#   - postgres.enabled=true  in-cluster DB instead of RDS
-#   - externalDatabase       cleared so chart uses in-cluster postgres
-#   - externalSecrets        disabled (no AWS Secrets Manager in CI)
-#   - ingress                disabled (no public domain)
-#   - serviceMonitor         disabled (no Prometheus operator in test cluster)
-#   - autoscaling/PDB        single replica is enough for a startup smoke
+# Overrides and their justification:
 #
-# These overrides keep the chart on its documented values-production.yaml
-# code path while cutting external dependencies the smoke test can't
-# satisfy.
+#   fullnameOverride=ak-smoke
+#     Stable service DNS for /readyz polling (avoids release-name
+#     suffixing). Matches the v1.1.0-rc.6 lesson.
+#
+#   backend.image.tag, web.image.tag
+#     Pin to the build under test.
+#
+#   backend.replicaCount=1, web.replicaCount=1
+#     Single-replica is enough for a startup smoke. Production uses 3.
+#
+#   ADMIN_PASSWORD=Smoke!2026secure
+#     Required by the chart to clear the setup_required flag so /readyz
+#     returns 200. Without this the gate would hang on /readyz forever.
+#
+#   secrets.jwtSecret=...
+#     Test-only credential. Never reuse outside CI.
+#
+#   postgres.enabled=true, externalDatabase.host=""
+#     RDS is unavailable in CI, so use the in-cluster postgres subchart.
+#     This means we exercise a different code path than RDS-backed prod
+#     installs — that gap is documented in the PR body and tracked as a
+#     separate `clean-install-smoke-with-deps` follow-up.
+#
+#   externalSecrets.enabled=false
+#     No External Secrets Operator in CI; secrets come from inline values.
+#
+#   ingress.enabled=false
+#     No public domain in CI; backend is reached via in-cluster Service.
+#
+#   serviceMonitor.enabled=false
+#     No Prometheus operator in the test cluster.
+#
+#   backend.autoscaling.enabled=false, podDisruptionBudget.enabled=false
+#     Single-replica install. HPA + PDB are exercised by the resilience
+#     suite, not here.
+#
+#   edge.enabled=false
+#     The edge image isn't published yet (tracked in iac); leaving on
+#     would ImagePullBackOff every run.
+#
+#   trivy.enabled=false, dependencyTrack.enabled=false
+#     Heavy subsystems with 4-8 GB memory needs. Out of scope for a
+#     startup smoke. Covered by the security-tests matrix.
+#
+#   networkPolicy.enabled=false
+#     Default-deny would block the in-cluster /readyz probe pod.
+#
+#   opensearch.replicaCount=1, persistence.enabled=false, javaOpts heap reduced
+#     OpenSearch can NOT be wholly disabled — the backend has a hard
+#     dependency on the OpenSearch service for indexing. We squash it to
+#     single-node, no PVC, 512m heap so the StatefulSet -> Deployment
+#     switch and the in-memory mode boot in <60s on `local-path`.
+#     Production OpenSearch shape is exercised by search-tests.
+#
+#   cosign.enabled=false (default already)
+#     No signature verification in CI; would block on cosign tooling.
+
+echo ""
+echo "Validating Helm template (catches override drift early)"
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  --namespace "$NAMESPACE" \
+  --values "$PROD_VALUES" \
+  --set fullnameOverride=ak-smoke \
+  --set backend.image.tag="$BACKEND_TAG" \
+  --set backend.image.pullPolicy=Always \
+  --set backend.replicaCount=1 \
+  --set "backend.env.ADMIN_PASSWORD=Smoke!2026secure" \
+  --set web.image.tag="$WEB_TAG" \
+  --set web.replicaCount=1 \
+  --set secrets.jwtSecret="smoke-jwt-secret-not-for-production" \
+  --set postgres.enabled=true \
+  --set "postgres.auth.username=registry" \
+  --set "postgres.auth.password=smoke-db-password" \
+  --set "postgres.auth.database=artifact_registry" \
+  --set externalDatabase.host="" \
+  --set externalDatabase.existingSecret="" \
+  --set externalSecrets.enabled=false \
+  --set ingress.enabled=false \
+  --set serviceMonitor.enabled=false \
+  --set "backend.autoscaling.enabled=false" \
+  --set "backend.podDisruptionBudget.enabled=false" \
+  --set "web.podDisruptionBudget.enabled=false" \
+  --set edge.enabled=false \
+  --set trivy.enabled=false \
+  --set dependencyTrack.enabled=false \
+  --set networkPolicy.enabled=false \
+  --set opensearch.replicaCount=1 \
+  --set opensearch.persistence.enabled=false \
+  --set 'opensearch.javaOpts=-Xms512m -Xmx512m' \
+  --set 'opensearch.resources.requests.memory=1Gi' \
+  --set 'opensearch.resources.limits.memory=1Gi' \
+  --validate \
+  --debug \
+  >/dev/null
 
 echo ""
 echo "Installing Helm release ${RELEASE_NAME}"
@@ -216,78 +408,151 @@ helm upgrade --install "$RELEASE_NAME" "$CHART_DIR" \
   --set trivy.enabled=false \
   --set dependencyTrack.enabled=false \
   --set networkPolicy.enabled=false \
+  --set opensearch.replicaCount=1 \
+  --set opensearch.persistence.enabled=false \
+  --set 'opensearch.javaOpts=-Xms512m -Xmx512m' \
+  --set 'opensearch.resources.requests.memory=1Gi' \
+  --set 'opensearch.resources.limits.memory=1Gi' \
   --wait=false || {
     echo "ERROR: helm install failed" >&2
     exit 1
   }
 
 # ---------------------------------------------------------------------------
-# Poll rollout status AND /readyz in parallel-ish
-# ---------------------------------------------------------------------------
+# Wait for Deployments to exist before polling rollout.
 #
-# The v1.1.8 panic was a startup crash: the pod went CrashLoopBackOff, the
-# rollout never progressed, and the chart never reported ready. We watch
-# both the deployment rollout (catches CrashLoopBackOff) and the actual
-# /readyz endpoint (catches "running but not serving") so either failure
-# mode trips the gate.
+# `helm install --wait=false` returns before the API server has finished
+# creating the Deployment objects. `kubectl rollout status` against a
+# not-yet-existent Deployment fails immediately ("not found") which
+# bypasses the timeout budget entirely. So we poll for existence first.
+# ---------------------------------------------------------------------------
 
-DEPLOYMENT="ak-smoke-backend"
-SERVICE_URL="http://ak-smoke-backend.${NAMESPACE}.svc.cluster.local:8080"
+wait_for_deployment_exists() {
+  local name="$1"
+  local timeout=30
+  local elapsed=0
+  while [ "$elapsed" -lt "$timeout" ]; do
+    if kubectl get deployment "$name" -n "$NAMESPACE" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  echo "ERROR: deployment/${name} did not appear in ${NAMESPACE} within ${timeout}s" >&2
+  return 1
+}
 
 echo ""
-echo "Polling rollout status for deployment/${DEPLOYMENT} (timeout: ${TIMEOUT_SECONDS}s)"
+echo "Waiting for backend and web Deployments to exist"
+wait_for_deployment_exists "ak-smoke-backend"
+wait_for_deployment_exists "ak-smoke-web"
 
-# kubectl rollout status itself respects --timeout. If the deployment is
-# stuck (image pull, CrashLoopBackOff, etc.), this exits non-zero.
-if ! kubectl rollout status "deployment/${DEPLOYMENT}" \
-      --namespace "$NAMESPACE" \
-      --timeout="${TIMEOUT_SECONDS}s"; then
-  echo "ERROR: deployment/${DEPLOYMENT} did not reach Ready within ${TIMEOUT_SECONDS}s" >&2
+# ---------------------------------------------------------------------------
+# Poll rollout status for backend AND web.
+#
+# The v1.1.8 panic was a backend startup crash, but a web crash is also
+# a broken release. We check both. `kubectl rollout status` returns
+# non-zero on CrashLoopBackOff because the new ReplicaSet never reaches
+# `availableReplicas == replicas`.
+# ---------------------------------------------------------------------------
+
+watch_rollout() {
+  local deployment="$1"
+  local component="$2"
   echo ""
-  echo "Pod state:"
-  kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/component=backend" -o wide || true
-  exit 2
-fi
-
-echo ""
-echo "Polling ${SERVICE_URL}/readyz (timeout: ${TIMEOUT_SECONDS}s)"
-
-# /readyz is checked from inside the cluster via a short-lived curl pod so
-# we don't need ingress or port-forwarding from the runner. This matches
-# how application traffic actually reaches the backend in production.
-
-start=$(date +%s)
-deadline=$(( start + TIMEOUT_SECONDS ))
-
-while true; do
-  now=$(date +%s)
-  if [ "$now" -ge "$deadline" ]; then
-    echo "ERROR: /readyz did not return 200 within ${TIMEOUT_SECONDS}s" >&2
-    exit 3
-  fi
-
-  # Run curl from a throwaway pod inside the namespace. -fsS makes curl
-  # exit non-zero on HTTP >= 400 and stay quiet on success.
-  if kubectl run "smoke-probe-$$" \
+  echo "Polling rollout status for deployment/${deployment} (timeout: ${TIMEOUT_SECONDS}s)"
+  if ! kubectl rollout status "deployment/${deployment}" \
         --namespace "$NAMESPACE" \
-        --image=curlimages/curl:8.10.1 \
-        --restart=Never \
-        --rm -i --quiet --timeout=20s \
-        --command -- curl -fsS -o /dev/null -w "%{http_code}\n" \
-          --max-time 5 "${SERVICE_URL}/readyz" 2>/dev/null | grep -q '^200$'; then
-    elapsed=$(( now - start ))
-    echo "Backend /readyz returned 200 (took ${elapsed}s after rollout completed)"
-    break
+        --timeout="${TIMEOUT_SECONDS}s"; then
+    echo "ERROR: deployment/${deployment} did not reach Ready within ${TIMEOUT_SECONDS}s" >&2
+    echo ""
+    echo "Pod state:"
+    kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/component=${component}" -o wide || true
+    echo ""
+    echo "Failure classification: $(classify_pod_failure "$NAMESPACE" "app.kubernetes.io/component=${component}")"
+    return 2
+  fi
+}
+
+watch_rollout "ak-smoke-backend" "backend" || exit $?
+watch_rollout "ak-smoke-web"     "web"     || exit $?
+
+# ---------------------------------------------------------------------------
+# Poll /readyz from inside the cluster.
+#
+# `/readyz` is a deeper probe than `kubectl rollout status`: it verifies
+# the backend can reach Postgres, has applied migrations, and has cleared
+# the setup_required flag (which is why we set ADMIN_PASSWORD via --set
+# above). A backend that booted but cannot serve will trip this even when
+# rollout status reports Ready.
+#
+# We exec into the backend pod itself rather than spinning up a curl pod
+# per iteration. This avoids depending on `curlimages/curl` being pullable
+# (Docker Hub rate limit risk), avoids per-iteration pod-create races,
+# and is faster.
+# ---------------------------------------------------------------------------
+
+readyz_probe_loop() {
+  local service_url="http://ak-smoke-backend.${NAMESPACE}.svc.cluster.local:8080"
+  echo ""
+  echo "Polling ${service_url}/readyz from inside backend pod (timeout: ${TIMEOUT_SECONDS}s)"
+
+  local backend_pod
+  backend_pod=$(kubectl get pods -n "$NAMESPACE" \
+    -l "app.kubernetes.io/component=backend" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+  if [ -z "$backend_pod" ]; then
+    echo "ERROR: no backend pod found for /readyz probe" >&2
+    return 3
   fi
 
-  printf "."
-  sleep 5
-done
+  # The backend image typically has wget or curl; try wget first since
+  # alpine-based images include it. Fall back to /dev/tcp shell builtin
+  # if neither is available.
+  local probe_cmd
+  if kubectl exec -n "$NAMESPACE" "$backend_pod" -- which wget >/dev/null 2>&1; then
+    probe_cmd="wget -q --timeout=5 -O - --server-response ${service_url}/readyz 2>&1 | grep -E '^  HTTP/'"
+  elif kubectl exec -n "$NAMESPACE" "$backend_pod" -- which curl >/dev/null 2>&1; then
+    probe_cmd="curl -fsS -o /dev/null -w '%{http_code}\n' --max-time 5 ${service_url}/readyz"
+  else
+    # Bash builtin /dev/tcp is portable on most distros without curl/wget.
+    probe_cmd="(exec 3<>/dev/tcp/ak-smoke-backend/8080 && echo -e 'GET /readyz HTTP/1.0\r\nHost: ak-smoke-backend\r\n\r\n' >&3 && head -1 <&3)"
+  fi
+
+  local start now elapsed deadline output
+  start=$(date +%s)
+  deadline=$(( start + TIMEOUT_SECONDS ))
+
+  while true; do
+    now=$(date +%s)
+    if [ "$now" -ge "$deadline" ]; then
+      echo "ERROR: /readyz did not return 200 within ${TIMEOUT_SECONDS}s" >&2
+      echo ""
+      echo "Last probe output:"
+      kubectl exec -n "$NAMESPACE" "$backend_pod" -- sh -c "$probe_cmd" 2>&1 | tail -5 || true
+      return 3
+    fi
+
+    if output=$(kubectl exec -n "$NAMESPACE" "$backend_pod" -- sh -c "$probe_cmd" 2>&1); then
+      if echo "$output" | grep -qE '\b200\b'; then
+        elapsed=$(( now - start ))
+        echo "Backend /readyz returned 200 (took ${elapsed}s after rollout completed)"
+        return 0
+      fi
+    fi
+
+    printf "."
+    sleep 5
+  done
+}
+
+readyz_probe_loop || exit $?
 
 echo ""
 echo "=================================================================="
 echo "Clean-install smoke test PASSED"
 echo "  Backend tag ${BACKEND_TAG} reached Ready and served /readyz 200."
+echo "  Web tag ${WEB_TAG} reached Ready."
 echo "=================================================================="
 
 # Cleanup happens via trap on EXIT


### PR DESCRIPTION
## Summary

Adds a `clean-install-smoke` job to the release-gate workflow that performs a clean-cluster `helm install` against the documented `values-production.yaml` and verifies the backend reaches Ready and serves `/readyz` 200 within 120s.

**What this catches that v1.1.8 missed:** the v1.1.8 Debian route panic crashed the backend at startup. The pod went `CrashLoopBackOff`, the deployment rollout never completed, but the release tag promoted anyway because no gate validated a fresh install. This job watches both `kubectl rollout status deployment/<release>-backend` (catches `CrashLoopBackOff`) and a `/readyz` probe from inside the namespace (catches "process running but routes never registered"), so either failure mode trips the gate.

The job:
- Boots a fresh `smoke-<run-id>` namespace, isolated from the existing `deploy`-managed namespace.
- Runs `helm install ak-smoke <chart> -f values-production.yaml` with the chart pulled from `artifact-keeper-iac@main`. Test-only secrets (`ADMIN_PASSWORD`, `secrets.jwtSecret`, postgres password) are passed via `--set` overrides; nothing sensitive is committed. External dependencies that the smoke can't satisfy (RDS, AWS Secrets Manager, ingress, ServiceMonitor) are disabled via overrides while keeping the chart on its documented `values-production.yaml` code path.
- Polls `kubectl rollout status` for up to 120s, then polls `/readyz` from a throwaway curl pod for another 120s.
- Tears down its own namespace cleanly via a trap on EXIT, capturing pod state, events, and logs to the workflow artifact bundle on failure.

It runs independently of the existing `deploy` job (parallel, not sequential) so a startup crash fails the gate fast, before the long-running format/auth/stress matrix burns runner time on a broken build. Failure wires into `collect-results` via `needs[]`, and the existing `contains(needs.*.result, 'failure')` gate check picks it up automatically.

Phase 1 of [Hardening Core](https://github.com/orgs/artifact-keeper/projects/2). Closes #44.

## Test Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (this PR is new release-gate infrastructure)
- [x] Manually tested locally (script syntax-checked with `bash -n` and `shellcheck`; workflow YAML validated with `python -c "import yaml; yaml.safe_load(...)"`)
- [x] No regressions in existing tests (new job is added, existing matrix is unchanged)

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

## Regression Test

N/A - this is not a bug fix. This PR _is_ the regression-test infrastructure that would have caught v1.1.8.

## How to verify

1. Trigger the release-gate workflow with a known-good `:dev` backend tag and confirm `clean-install-smoke` passes in under 5 minutes.
2. On a throwaway test branch, deliberately break startup (e.g. `panic!` in `main`) and confirm the gate fails with a non-zero rollout status and pod logs uploaded as a workflow artifact.