### PR TITLE
audit(formats): ground-truth handler/test mappings for Epic 5 (#71)

### DIFF
--- a/.github/workflows/format-tests.yml
+++ b/.github/workflows/format-tests.yml
@@ -32,7 +32,7 @@ jobs:
           - name: python
             scripts: "test-pypi.sh test-pypi-native-client.sh test-conda.sh test-huggingface.sh test-mlmodel.sh"
           - name: jvm
-            scripts: "test-maven.sh test-maven-native-client.sh test-maven-virtual-snapshot.sh test-sbt.sh"
+            scripts: "test-maven.sh test-maven-native-client.sh test-maven-virtual-snapshot.sh test-sbt.sh test-gradle-conformance.sh"
           - name: rust-go-swift
             scripts: "test-cargo.sh test-go.sh test-swift.sh test-pub.sh"
           - name: system-packages

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -207,7 +207,7 @@ jobs:
           - name: python
             scripts: "test-pypi.sh test-pypi-native-client.sh test-pypi-remote.sh test-conda.sh test-huggingface.sh test-mlmodel.sh"
           - name: jvm
-            scripts: "test-maven.sh test-maven-native-client.sh test-maven-remote.sh test-maven-virtual-snapshot.sh test-sbt.sh"
+            scripts: "test-maven.sh test-maven-native-client.sh test-maven-remote.sh test-maven-virtual-snapshot.sh test-sbt.sh test-gradle-conformance.sh"
           - name: rust-go-swift
             scripts: "test-cargo.sh test-cargo-remote.sh test-go.sh test-swift.sh test-pub.sh"
           - name: system-packages

--- a/tests/formats/AUDIT-epic-5.md
+++ b/tests/formats/AUDIT-epic-5.md
@@ -30,6 +30,23 @@ There is no separate `/gradle/...` route; Gradle repos are addressed via
 `/maven/{gradle-repo-key}/...`. There is no Gradle-specific E2E test in the
 repo today.
 
+## CI status
+
+A separate gap surfaced while writing this audit: the 40 `*-conformance.sh`
+scripts in `tests/formats/` are not invoked by any GitHub Actions workflow.
+Before this PR, neither `.github/workflows/format-tests.yml` nor
+`.github/workflows/release-gate.yml` referenced any of them. They run only
+when invoked locally.
+
+This PR wires `test-gradle-conformance.sh` into the `jvm` batch in both
+workflows (added by the DevOps agent in parallel to this audit). That covers
+the gradle-specific gap called out below.
+
+The remaining 39 conformance scripts are still orphaned from CI. They are
+not exercised by PR checks or by the release gate. That is a separate gap,
+tracked as a follow-up issue (see Remediation options below). It is out of
+scope for this PR.
+
 ## Method
 
 ### Backend evidence (`/tmp/ak-1.1.x-analysis/backend`)
@@ -94,7 +111,7 @@ repo today.
 | opkg | yes (`formats/opkg.rs`) | no | no native route; `/ext/opkg/...` only when WASM plugin loaded | yes (`test-opkg.sh`, `test-opkg-conformance.sh`) | basic test targets `/ext/opkg/...` and skips on 404; conformance targets generic API | same as mlmodel: conditional native, generic-API conformance is exercised |
 | p2 | yes (`formats/p2.rs`) | no | no native route; `/ext/p2/...` only when WASM plugin loaded | yes (`test-p2.sh`, `test-p2-conformance.sh`) | basic test targets `/ext/p2/...` and skips on 404; conformance targets generic API | same pattern: conditional native, generic-API conformance is exercised |
 | vagrant | yes (`formats/vagrant.rs`) | no | no native route; `/ext/vagrant/...` only when WASM plugin loaded | yes (`test-vagrant.sh`, `test-vagrant-conformance.sh`) | basic test targets `/ext/vagrant/...` and skips on 404; conformance targets generic API | same pattern: conditional native, generic-API conformance is exercised |
-| gradle | aliased onto Maven trait handler (`formats/maven.rs` via `mod.rs`) | aliased onto `api/handlers/maven.rs` (accepts `gradle` as a repo format at the resolver) | yes, addressable through `/maven/{repo_key}/...` for repos with `format=gradle` | no | n/a (no test) | test-but-no-coverage: the alias is real and works, but no test exercises the gradle-specific resolution path |
+| gradle | aliased onto Maven trait handler (`formats/maven.rs` via `mod.rs`) | aliased onto `api/handlers/maven.rs` (accepts `gradle` as a repo format at the resolver) | yes, addressable through `/maven/{repo_key}/...` for repos with `format=gradle` | partial: `test-gradle-conformance.sh` added in this PR, curl-based only | partial: targets `/maven/{repo_key}/...` against a `format=gradle` repo via curl + Basic auth. Does not invoke the `gradle` CLI, so it cannot catch failures that only manifest with Gradle's real HTTP client (User-Agent gating, `.module` discovery semantics, variant selection). | partial coverage: alias resolution path is exercised; native-client behaviour is not. A native-client follow-up test is recommended (parallel to `test-maven-native-client.sh`). |
 
 Legend for the Verdict column:
 
@@ -108,6 +125,9 @@ Legend for the Verdict column:
   format.
 - **test-but-no-coverage**: the format works in the backend but no test
   exercises it from this repo.
+- **partial coverage**: a wire-protocol test exists but does not exercise
+  the format's native client (e.g. curl in place of the real CLI). The
+  alias or routing path is covered; client-specific behaviour is not.
 
 ## Specific claim-by-claim grading
 
@@ -118,7 +138,7 @@ Legend for the Verdict column:
 | `opkg`: no handler file, tests exist | Misleading. There is a trait handler at `src/formats/opkg.rs`. There is no API handler module, which is what the analysis probably meant. Same dual-test pattern as mlmodel. |
 | `p2`: no handler file, tests exist | Same as opkg. Trait handler at `src/formats/p2.rs`; no API handler module. |
 | `vagrant`: no handler file, tests exist | Same as opkg. Trait handler at `src/formats/vagrant.rs`; no API handler module. |
-| `gradle`: zero E2E coverage despite Maven aliasing | Confirmed. The alias is real (resolver and trait both accept gradle). No test exercises a gradle-tagged repository. A starter `test-gradle-conformance.sh` is provided in this branch alongside this audit. |
+| `gradle`: zero E2E coverage despite Maven aliasing | Confirmed. The alias is real (resolver and trait both accept gradle). No test exercised a gradle-tagged repository before this PR. A starter `test-gradle-conformance.sh` is provided in this branch and wired into the `jvm` batch in `.github/workflows/format-tests.yml` and `.github/workflows/release-gate.yml`. The script is curl-based; a native-client test is still missing (see Remediation). |
 
 ## Remediation options (for triage, not done in this PR)
 
@@ -129,8 +149,33 @@ Legend for the Verdict column:
   the generic API and are not WASM-dependent).
 - For jetbrains: working as intended; no action.
 - For gradle: keep the new `test-gradle-conformance.sh` (added in this
-  branch) so the alias is exercised. If a future change adds a `/gradle`
-  router, expand the test to hit it directly.
+  branch) so the alias is exercised. The script is curl-based and does not
+  cover Gradle's real HTTP client. A native-client test (parallel to
+  `test-maven-native-client.sh`, shelling out to the `gradle` CLI) is
+  recommended as a follow-up. If a future change adds a `/gradle` router,
+  expand the test to hit it directly.
+- For the orphaned `*-conformance.sh` scripts: wire the remaining 39 into
+  `.github/workflows/format-tests.yml` so they run on PRs and on the
+  release gate.
+
+### Follow-up issues
+
+Filed in beads on 2026-04-27:
+
+- `ak-un1n` (P3, task): Wire `*-conformance.sh` suite into
+  `format-tests.yml` workflow matrix. Inventories the orphaned scripts and
+  adds them to the matrix so regressions are caught automatically.
+- `ak-2ze2` (P3, task): Add native gradle CLI conformance test (parallel
+  to `test-maven-native-client.sh`). Shells out to a real `gradle` CLI to
+  cover User-Agent gating, `.module` resolution priority over `.pom`, and
+  variant selection.
+- `ak-u3x1` (P3, task): Add gradle remote-repo conformance test. Parallel
+  to `test-maven-remote.sh`. Verifies a `format=gradle` remote repo can
+  proxy and resolve `.module` files (Gradle Module Metadata, JSON) from
+  upstream, including the `.module`-404 / `.pom`-200 fallback.
+- `ak-q8xh` (P3, task): Triage native HTTP handler modules vs WASM-only
+  for mlmodel, opkg, p2, vagrant. Decide whether to add `api/handlers/<format>.rs`
+  modules or retire the basic tests in favour of generic-API conformance.
 
 ## Files referenced
 

--- a/tests/formats/AUDIT-epic-5.md
+++ b/tests/formats/AUDIT-epic-5.md
@@ -1,0 +1,153 @@
+# Epic 5 Format/Test Mismatch Audit
+
+Tracking issue: artifact-keeper-test#71
+
+This document grounds the gap-analysis claims about handler/test mismatches by
+inspecting the `release/1.1.x` backend at `/tmp/ak-1.1.x-analysis` and the
+`main` branch of this test repo. It is descriptive, not prescriptive.
+
+## TL;DR
+
+The original gap analysis conflated two distinct artifacts in the backend:
+
+1. The `FormatHandler` trait in `backend/src/formats/*.rs` (parse_metadata,
+   validate, generate_index). Every format in the matrix has one of these,
+   including mlmodel, opkg, p2, vagrant, and jetbrains.
+2. HTTP handler/router modules in `backend/src/api/handlers/*.rs`. Only
+   formats with a native wire protocol have these. mlmodel, opkg, p2 and
+   vagrant do not have a dedicated HTTP handler module; jetbrains does.
+
+So none of these handlers are missing in the trait sense, and only one
+(`/jetbrains`) is wired as a native-protocol HTTP route. The rest are reachable
+either via the WASM proxy at `/ext/{format_key}/{repo_key}/...` (when a WASM
+plugin is loaded), or via the generic artifact API at
+`/api/v1/repositories/{key}/artifacts/{path}`. The conformance tests already
+take the second path; the basic tests take the first and skip cleanly when no
+plugin is loaded.
+
+Gradle is fully aliased onto the Maven handler at the repo-resolution layer.
+There is no separate `/gradle/...` route; Gradle repos are addressed via
+`/maven/{gradle-repo-key}/...`. There is no Gradle-specific E2E test in the
+repo today.
+
+## Method
+
+### Backend evidence (`/tmp/ak-1.1.x-analysis/backend`)
+
+- `src/formats/` directory listing shows individual files for every format in
+  the matrix:
+  - `jetbrains_plugins.rs`
+  - `mlmodel.rs`
+  - `opkg.rs`
+  - `p2.rs`
+  - `vagrant.rs`
+  Each implements `FormatHandler` (parse_path/parse_metadata, validate,
+  generate_index). These are domain logic, not HTTP routes.
+- `src/formats/mod.rs` registers all of these in both `get_core_handler`
+  (string keyed) and `get_handler_for_format` (enum keyed). All five are
+  reachable from the format registry.
+- `src/api/handlers/mod.rs` declares HTTP handler modules. Of the formats in
+  scope, only `jetbrains` is declared. There is no `mlmodel`, `opkg`, `p2`,
+  `vagrant`, or `gradle` HTTP handler module.
+- `src/api/routes.rs` mounts the format-routing tree. Only `/jetbrains` is
+  mounted from this group. Native-protocol routes for mlmodel, opkg, p2,
+  vagrant, gradle are not mounted because the modules do not exist.
+- `src/api/handlers/wasm_proxy.rs` mounts `/ext` and dispatches
+  `/ext/:format_key/:repo_key/*path` to whichever WASM plugin is loaded for
+  that format key. This is the only path through which mlmodel, opkg, p2,
+  vagrant can serve native protocols.
+- `src/api/handlers/maven.rs` line 47:
+  `proxy_helpers::resolve_repo_by_key(db, repo_key, &["maven", "gradle"], "a Maven")`.
+  Repos created with `format=gradle` are resolvable through `/maven/{key}/...`.
+- `src/formats/mod.rs::get_handler_for_format` line 197:
+  `RepositoryFormat::Maven | RepositoryFormat::Gradle => MavenHandler::new()`.
+  Confirms the alias at the trait layer too.
+- The generic artifact API is mounted at `/api/v1/repositories/:key/artifacts`
+  and `/api/v1/repositories/:key/download/*path` (see
+  `src/api/handlers/repositories.rs` lines 117 to 130). Any repo regardless of
+  format can store and serve files through this API.
+
+### Test repo evidence (`tests/formats/`)
+
+- `test-jetbrains.sh` and `test-jetbrains-conformance.sh` hit
+  `${BASE_URL}/jetbrains/${REPO_KEY}/...`.
+- `test-mlmodel.sh` hits `${BASE_URL}/ext/mlmodel/${REPO_KEY}/...` and skips
+  if it gets a 404 on the probe. `test-mlmodel-conformance.sh` uses
+  `/api/v1/repositories/{key}/artifacts/{path}` instead.
+- `test-opkg.sh` hits `${BASE_URL}/ext/opkg/${REPO_KEY}/...` for upload and
+  `${BASE_URL}/ext/opkg/${REPO_KEY}/Packages` for the index, with a similar
+  WASM-availability probe and skip. `test-opkg-conformance.sh` notes
+  explicitly `OPKG does not have a dedicated native handler with custom
+  routes` and uses the generic API.
+- `test-p2.sh` and `test-vagrant.sh` follow the same pattern as opkg and
+  mlmodel (probe `/ext/{format}/{repo}/`, skip on 404, otherwise upload).
+  Conformance versions use the generic API and explicitly note the lack of a
+  native handler.
+- No `test-gradle*.sh` files exist.
+
+## Per-format verdict
+
+| Format | Trait handler? | API handler module? | Route mounted? | Native test file? | Test endpoint matches? | Verdict |
+| --- | --- | --- | --- | --- | --- | --- |
+| jetbrains_plugins | yes (`formats/jetbrains_plugins.rs`) | yes (`api/handlers/jetbrains.rs`) | yes (`/jetbrains` in `routes.rs`) | yes (`test-jetbrains.sh`, `test-jetbrains-conformance.sh`) | yes, both target `/jetbrains/{repo_key}/...` | works |
+| mlmodel | yes (`formats/mlmodel.rs`) | no | no native route; reachable via `/ext/mlmodel/...` only when WASM plugin loaded | yes (`test-mlmodel.sh`, `test-mlmodel-conformance.sh`) | basic test targets `/ext/mlmodel/...` and skips on 404; conformance test targets generic `/api/v1/repositories/{key}/artifacts/{path}` | basic test conditionally works (depends on WASM plugin); conformance works against generic API. Not an orphan; not full-coverage either. |
+| opkg | yes (`formats/opkg.rs`) | no | no native route; `/ext/opkg/...` only when WASM plugin loaded | yes (`test-opkg.sh`, `test-opkg-conformance.sh`) | basic test targets `/ext/opkg/...` and skips on 404; conformance targets generic API | same as mlmodel: conditional native, generic-API conformance is exercised |
+| p2 | yes (`formats/p2.rs`) | no | no native route; `/ext/p2/...` only when WASM plugin loaded | yes (`test-p2.sh`, `test-p2-conformance.sh`) | basic test targets `/ext/p2/...` and skips on 404; conformance targets generic API | same pattern: conditional native, generic-API conformance is exercised |
+| vagrant | yes (`formats/vagrant.rs`) | no | no native route; `/ext/vagrant/...` only when WASM plugin loaded | yes (`test-vagrant.sh`, `test-vagrant-conformance.sh`) | basic test targets `/ext/vagrant/...` and skips on 404; conformance targets generic API | same pattern: conditional native, generic-API conformance is exercised |
+| gradle | aliased onto Maven trait handler (`formats/maven.rs` via `mod.rs`) | aliased onto `api/handlers/maven.rs` (accepts `gradle` as a repo format at the resolver) | yes, addressable through `/maven/{repo_key}/...` for repos with `format=gradle` | no | n/a (no test) | test-but-no-coverage: the alias is real and works, but no test exercises the gradle-specific resolution path |
+
+Legend for the Verdict column:
+
+- **works**: handler exists, is routed, and tests target the matching endpoint.
+- **conditional native**: native protocol is only available when a WASM
+  plugin for that format is loaded. The test probes for it and skips
+  cleanly. Not strictly an orphan, but the native protocol is uncovered when
+  no plugin is loaded.
+- **generic-API conformance is exercised**: the conformance test exists and
+  uses `/api/v1/repositories/{key}/artifacts/{path}`, which works for any
+  format.
+- **test-but-no-coverage**: the format works in the backend but no test
+  exercises it from this repo.
+
+## Specific claim-by-claim grading
+
+| Claim from gap analysis | Reality |
+| --- | --- |
+| `jetbrains_plugins`: tests reference a handler that may not be wired into the format registry | False. The handler is in the registry (`get_core_handler` returns `JetbrainsHandler` for `"jetbrains"`) and the API module is mounted at `/jetbrains`. Tests pass. |
+| `mlmodel`: handler unclear, tests exist | The trait handler exists. There is no API handler module. Tests target the WASM proxy and skip cleanly when no plugin is loaded. The conformance test uses the generic API. |
+| `opkg`: no handler file, tests exist | Misleading. There is a trait handler at `src/formats/opkg.rs`. There is no API handler module, which is what the analysis probably meant. Same dual-test pattern as mlmodel. |
+| `p2`: no handler file, tests exist | Same as opkg. Trait handler at `src/formats/p2.rs`; no API handler module. |
+| `vagrant`: no handler file, tests exist | Same as opkg. Trait handler at `src/formats/vagrant.rs`; no API handler module. |
+| `gradle`: zero E2E coverage despite Maven aliasing | Confirmed. The alias is real (resolver and trait both accept gradle). No test exercises a gradle-tagged repository. A starter `test-gradle-conformance.sh` is provided in this branch alongside this audit. |
+
+## Remediation options (for triage, not done in this PR)
+
+- For mlmodel/opkg/p2/vagrant: decide whether the project intends to ship
+  native protocols. If yes, add API handler modules and routes and convert
+  the basic tests from `/ext/...` (WASM proxy) to the native path. If no,
+  retire the basic tests and keep the conformance tests (which already use
+  the generic API and are not WASM-dependent).
+- For jetbrains: working as intended; no action.
+- For gradle: keep the new `test-gradle-conformance.sh` (added in this
+  branch) so the alias is exercised. If a future change adds a `/gradle`
+  router, expand the test to hit it directly.
+
+## Files referenced
+
+- `/tmp/ak-1.1.x-analysis/backend/src/formats/mod.rs` (lines 1 to 306)
+- `/tmp/ak-1.1.x-analysis/backend/src/formats/jetbrains_plugins.rs`
+- `/tmp/ak-1.1.x-analysis/backend/src/formats/mlmodel.rs`
+- `/tmp/ak-1.1.x-analysis/backend/src/formats/opkg.rs`
+- `/tmp/ak-1.1.x-analysis/backend/src/formats/p2.rs`
+- `/tmp/ak-1.1.x-analysis/backend/src/formats/vagrant.rs`
+- `/tmp/ak-1.1.x-analysis/backend/src/api/routes.rs` (lines 44 to 80)
+- `/tmp/ak-1.1.x-analysis/backend/src/api/handlers/mod.rs`
+- `/tmp/ak-1.1.x-analysis/backend/src/api/handlers/maven.rs` (line 47)
+- `/tmp/ak-1.1.x-analysis/backend/src/api/handlers/jetbrains.rs`
+- `/tmp/ak-1.1.x-analysis/backend/src/api/handlers/wasm_proxy.rs`
+- `/tmp/ak-1.1.x-analysis/backend/src/api/handlers/repositories.rs` (lines 117 to 135)
+- `tests/formats/test-jetbrains.sh`, `test-jetbrains-conformance.sh`
+- `tests/formats/test-mlmodel.sh`, `test-mlmodel-conformance.sh`
+- `tests/formats/test-opkg.sh`, `test-opkg-conformance.sh`
+- `tests/formats/test-p2.sh`, `test-p2-conformance.sh`
+- `tests/formats/test-vagrant.sh`, `test-vagrant-conformance.sh`

--- a/tests/formats/test-gradle-conformance.sh
+++ b/tests/formats/test-gradle-conformance.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# test-gradle-conformance.sh - Gradle (Maven-aliased) repository conformance test
+#
+# Gradle does not have a dedicated HTTP route. The backend aliases gradle
+# repos onto the Maven handler at the resolver layer:
+#   src/api/handlers/maven.rs
+#     proxy_helpers::resolve_repo_by_key(db, repo_key, &["maven", "gradle"], "a Maven")
+# and at the trait layer:
+#   src/formats/mod.rs
+#     RepositoryFormat::Maven | RepositoryFormat::Gradle => MavenHandler::new()
+#
+# This test creates a repository with format=gradle and exercises the Maven
+# wire protocol against it via /maven/{repo_key}/..., covering:
+#   - Gradle Module Metadata file (.module JSON, Gradle-specific)
+#   - POM upload (Gradle publishes alongside POM in maven-publish plugin)
+#   - JAR upload and SHA-256 round trip
+#   - maven-metadata.xml resolution
+#   - Listing through the generic management API
+#
+# Endpoints: ${BASE_URL}/maven/{repo_key}/... and /api/v1/repositories/{key}/...
+#
+# Requires: curl, jq, jar or zip (optional, for .jar creation)
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "gradle-conformance"
+auth_admin
+setup_workdir
+
+REPO_KEY="test-gradle-conf-${RUN_ID}"
+GROUP_ID="com.example.gradle"
+ARTIFACT_ID="gradle-lib"
+VERSION="1.0.0"
+GRADLE_URL="${BASE_URL}/maven/${REPO_KEY}"
+
+GROUP_PATH=$(echo "$GROUP_ID" | tr '.' '/')
+ARTIFACT_BASE="${GROUP_PATH}/${ARTIFACT_ID}/${VERSION}"
+
+# ---------------------------------------------------------------------------
+# Create repository with format=gradle (NOT maven)
+# ---------------------------------------------------------------------------
+
+begin_test "Create gradle local repository"
+if create_local_repo "$REPO_KEY" "gradle"; then
+  pass
+else
+  fail "could not create gradle repository (gradle format may not be accepted)"
+fi
+
+# ---------------------------------------------------------------------------
+# Confirm gradle repo is reachable through the Maven router
+# ---------------------------------------------------------------------------
+
+begin_test "Probe gradle repo via /maven/{key} alias"
+PROBE_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+  -u "${ADMIN_USER}:${ADMIN_PASS}" \
+  "${GRADLE_URL}/${GROUP_PATH}/${ARTIFACT_ID}/maven-metadata.xml") || true
+# Empty repo: expect 404 from a working router, NOT a 400 (format mismatch)
+# or 500 (no route). Anything in {200, 401, 403, 404} confirms the route is
+# wired and the resolver accepts gradle.
+case "$PROBE_CODE" in
+  200|401|403|404)
+    pass
+    ;;
+  *)
+    fail "unexpected status $PROBE_CODE from /maven/{gradle-repo} probe"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Build artifacts: JAR, POM, and Gradle Module Metadata (.module)
+# ---------------------------------------------------------------------------
+
+begin_test "Create test JAR, POM, and Gradle Module Metadata"
+
+cd "$WORK_DIR"
+
+# Minimal JAR
+mkdir -p jar-content/META-INF
+cat > jar-content/META-INF/MANIFEST.MF <<EOF
+Manifest-Version: 1.0
+Created-By: artifact-keeper-test (gradle conformance)
+Implementation-Title: ${ARTIFACT_ID}
+Implementation-Version: ${VERSION}
+EOF
+mkdir -p jar-content/com/example/gradle
+echo "placeholder" > jar-content/com/example/gradle/Lib.class
+
+JAR_FILE="${WORK_DIR}/${ARTIFACT_ID}-${VERSION}.jar"
+(cd jar-content && (jar cf "$JAR_FILE" META-INF/ com/ 2>/dev/null || zip -qr "$JAR_FILE" META-INF/ com/))
+
+# POM (Gradle's maven-publish plugin emits this alongside the .module file)
+POM_FILE="${WORK_DIR}/${ARTIFACT_ID}-${VERSION}.pom"
+cat > "$POM_FILE" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>${GROUP_ID}</groupId>
+  <artifactId>${ARTIFACT_ID}</artifactId>
+  <version>${VERSION}</version>
+  <packaging>jar</packaging>
+</project>
+EOF
+
+# Gradle Module Metadata (.module) - this is the Gradle-specific format that
+# the maven-publish Gradle plugin emits next to the POM.
+# See: https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html
+MODULE_FILE="${WORK_DIR}/${ARTIFACT_ID}-${VERSION}.module"
+cat > "$MODULE_FILE" <<EOF
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "${GROUP_ID}",
+    "module": "${ARTIFACT_ID}",
+    "version": "${VERSION}",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "createdBy": {
+    "gradle": { "version": "8.5" }
+  },
+  "variants": [
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": "17",
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-api"
+      },
+      "files": [
+        {
+          "name": "${ARTIFACT_ID}-${VERSION}.jar",
+          "url": "${ARTIFACT_ID}-${VERSION}.jar"
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+if [ -f "$JAR_FILE" ] && [ -f "$POM_FILE" ] && [ -f "$MODULE_FILE" ]; then
+  pass
+else
+  fail "failed to create JAR, POM, or .module file"
+fi
+
+# ---------------------------------------------------------------------------
+# Upload all three through the Maven-aliased route
+# ---------------------------------------------------------------------------
+
+ORIG_SHA256=$(shasum -a 256 "$JAR_FILE" | awk '{print $1}')
+
+begin_test "Upload JAR via PUT /maven/{gradle-repo-key}/..."
+JAR_PATH="${ARTIFACT_BASE}/${ARTIFACT_ID}-${VERSION}.jar"
+if curl -sf $CURL_TIMEOUT -X PUT "${GRADLE_URL}/${JAR_PATH}" \
+  -u "${ADMIN_USER}:${ADMIN_PASS}" \
+  -H "Content-Type: application/java-archive" \
+  --data-binary "@${JAR_FILE}" > /dev/null 2>&1; then
+  pass
+else
+  fail "PUT JAR to gradle-aliased route failed"
+fi
+
+begin_test "Upload POM via PUT /maven/{gradle-repo-key}/..."
+POM_PATH="${ARTIFACT_BASE}/${ARTIFACT_ID}-${VERSION}.pom"
+if curl -sf $CURL_TIMEOUT -X PUT "${GRADLE_URL}/${POM_PATH}" \
+  -u "${ADMIN_USER}:${ADMIN_PASS}" \
+  -H "Content-Type: application/xml" \
+  --data-binary "@${POM_FILE}" > /dev/null 2>&1; then
+  pass
+else
+  fail "PUT POM to gradle-aliased route failed"
+fi
+
+begin_test "Upload Gradle Module Metadata (.module) via PUT"
+MODULE_PATH="${ARTIFACT_BASE}/${ARTIFACT_ID}-${VERSION}.module"
+if curl -sf $CURL_TIMEOUT -X PUT "${GRADLE_URL}/${MODULE_PATH}" \
+  -u "${ADMIN_USER}:${ADMIN_PASS}" \
+  -H "Content-Type: application/json" \
+  --data-binary "@${MODULE_FILE}" > /dev/null 2>&1; then
+  pass
+else
+  # If the Maven handler rejects unknown extensions, this is the place where
+  # the alias is incomplete for Gradle. Mark as fail so the gap is visible.
+  fail "PUT .module to gradle-aliased route failed - Maven handler may not accept Gradle Module Metadata"
+fi
+
+# ---------------------------------------------------------------------------
+# Round-trip JAR and verify SHA-256
+# ---------------------------------------------------------------------------
+
+begin_test "Download JAR and verify SHA-256 round trip"
+DL_FILE="${WORK_DIR}/downloaded.jar"
+if curl -sf $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" -o "$DL_FILE" \
+  "${GRADLE_URL}/${JAR_PATH}"; then
+  DL_SHA256=$(shasum -a 256 "$DL_FILE" | awk '{print $1}')
+  if assert_eq "$DL_SHA256" "$ORIG_SHA256" "SHA256 mismatch after gradle-aliased round-trip"; then
+    pass
+  fi
+else
+  fail "GET JAR from gradle-aliased route failed"
+fi
+
+# ---------------------------------------------------------------------------
+# Round-trip the .module file (Gradle-specific, this is the real test)
+# ---------------------------------------------------------------------------
+
+begin_test "Download Gradle Module Metadata and verify content"
+DL_MODULE="${WORK_DIR}/downloaded.module"
+if curl -sf $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" -o "$DL_MODULE" \
+  "${GRADLE_URL}/${MODULE_PATH}"; then
+  if assert_contains "$(cat "$DL_MODULE")" "\"formatVersion\": \"1.1\"" \
+       "downloaded .module should preserve Gradle Module Metadata"; then
+    pass
+  fi
+else
+  fail "GET .module from gradle-aliased route failed"
+fi
+
+# ---------------------------------------------------------------------------
+# Confirm via management API that the artifacts are listed against the gradle repo
+# ---------------------------------------------------------------------------
+
+begin_test "List artifacts via management API for gradle repo"
+sleep 1
+if resp=$(api_get "/api/v1/repositories/${REPO_KEY}/artifacts"); then
+  if assert_contains "$resp" "$ARTIFACT_ID" \
+       "artifact list for gradle repo should contain artifact"; then
+    pass
+  fi
+else
+  fail "GET /api/v1/repositories/${REPO_KEY}/artifacts returned error"
+fi
+
+# ---------------------------------------------------------------------------
+# maven-metadata.xml is generated on demand for the Maven layout. This is
+# the same code path used for plain Maven repos, so a passing assertion
+# also confirms the Gradle alias does not bypass index generation.
+# ---------------------------------------------------------------------------
+
+begin_test "Resolve maven-metadata.xml against gradle-aliased repo"
+METADATA_PATH="${GROUP_PATH}/${ARTIFACT_ID}/maven-metadata.xml"
+if resp=$(curl -sf $CURL_TIMEOUT "${GRADLE_URL}/${METADATA_PATH}" \
+  -u "${ADMIN_USER}:${ADMIN_PASS}"); then
+  if assert_contains "$resp" "$VERSION" "metadata should list the uploaded version"; then
+    pass
+  fi
+else
+  # Some builds only auto-generate metadata after a deploy. Skip is acceptable.
+  skip "maven-metadata.xml not generated for gradle-aliased repo (may require explicit deploy)"
+fi
+
+end_suite

--- a/tests/formats/test-gradle-conformance.sh
+++ b/tests/formats/test-gradle-conformance.sh
@@ -64,8 +64,10 @@ begin_test "Probe gradle repo via /maven/{key} alias"
 PROBE_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
   -u "${ADMIN_USER}:${ADMIN_PASS}" \
   "${GRADLE_URL}/${GROUP_PATH}/${ARTIFACT_ID}/maven-metadata.xml") || true
-# auth_admin already ran, so 401/403 here would mean auth blew up after the
-# fact, NOT that the resolver rejected gradle. Treat those as failures.
+# auth_admin validated ${ADMIN_USER}:${ADMIN_PASS} via /auth/login, and the
+# probe re-presents the same Basic credentials. A 401/403 here means the
+# Maven router rejected the request after the fact (e.g. middleware order
+# bug or visibility check), NOT that the resolver rejected gradle. Fail.
 # An empty gradle repo should return 404 (resolver accepted gradle, but no
 # artifact exists yet). 200 is allowed only if the backend ever auto-generates
 # an empty maven-metadata.xml for new repos. 400/500 indicate the resolver
@@ -90,6 +92,11 @@ esac
 # ---------------------------------------------------------------------------
 
 begin_test "Create test JAR, POM, and Gradle Module Metadata"
+
+if ! command -v jar >/dev/null 2>&1 && ! command -v zip >/dev/null 2>&1; then
+  fail "neither 'jar' nor 'zip' is installed; cannot build a test JAR"
+  end_suite
+fi
 
 cd "$WORK_DIR"
 
@@ -245,14 +252,26 @@ fi
 # ---------------------------------------------------------------------------
 
 begin_test "List artifacts via management API for gradle repo"
-sleep 1
-if resp=$(api_get "/api/v1/repositories/${REPO_KEY}/artifacts"); then
-  if assert_contains "$resp" "$ARTIFACT_ID" \
-       "artifact list for gradle repo should contain artifact"; then
-    pass
+# Indexing is async; poll up to 10s at 500ms cadence rather than a fixed
+# sleep. Under release-gate parallel load, indexing routinely exceeds 1s.
+LIST_FOUND=""
+for _ in $(seq 1 20); do
+  if resp=$(api_get "/api/v1/repositories/${REPO_KEY}/artifacts" 2>/dev/null); then
+    if echo "$resp" | grep -q "$ARTIFACT_ID"; then
+      LIST_FOUND=1
+      break
+    fi
   fi
+  sleep 0.5
+done
+if [ -n "$LIST_FOUND" ]; then
+  pass
 else
-  fail "GET /api/v1/repositories/${REPO_KEY}/artifacts returned error"
+  if [ -z "${resp:-}" ]; then
+    fail "GET /api/v1/repositories/${REPO_KEY}/artifacts returned error"
+  else
+    fail "artifact ${ARTIFACT_ID} not listed for gradle repo within 10s (indexing race?)"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -265,7 +284,10 @@ begin_test "Resolve maven-metadata.xml against gradle-aliased repo"
 METADATA_PATH="${GROUP_PATH}/${ARTIFACT_ID}/maven-metadata.xml"
 if resp=$(curl -sf $CURL_TIMEOUT "${GRADLE_URL}/${METADATA_PATH}" \
   -u "${ADMIN_USER}:${ADMIN_PASS}"); then
-  if assert_contains "$resp" "$VERSION" "metadata should list the uploaded version"; then
+  # Match the structured element, not a bare "1.0.0" substring (xsi:schemaLocation,
+  # namespaces, or comments could otherwise false-positive).
+  if assert_contains "$resp" "<version>${VERSION}</version>" \
+       "metadata should list <version>${VERSION}</version> as a published version"; then
     pass
   fi
 else

--- a/tests/formats/test-gradle-conformance.sh
+++ b/tests/formats/test-gradle-conformance.sh
@@ -14,8 +14,18 @@
 #   - Gradle Module Metadata file (.module JSON, Gradle-specific)
 #   - POM upload (Gradle publishes alongside POM in maven-publish plugin)
 #   - JAR upload and SHA-256 round trip
+#   - .module upload and SHA-256 round trip
 #   - maven-metadata.xml resolution
 #   - Listing through the generic management API
+#
+# CI wiring: this script is invoked by the `jvm` batch in
+# .github/workflows/format-tests.yml and .github/workflows/release-gate.yml.
+#
+# Limitation: this exercises the Maven wire protocol via curl + Basic auth.
+# It does not invoke the `gradle` CLI, so it cannot catch failures that only
+# manifest with Gradle's actual HTTP client (User-Agent gating, .module
+# discovery semantics, variant attribute matching). A native-client follow-up
+# (parallel to test-maven-native-client.sh) is tracked as a follow-up issue.
 #
 # Endpoints: ${BASE_URL}/maven/{repo_key}/... and /api/v1/repositories/{key}/...
 #
@@ -54,15 +64,24 @@ begin_test "Probe gradle repo via /maven/{key} alias"
 PROBE_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
   -u "${ADMIN_USER}:${ADMIN_PASS}" \
   "${GRADLE_URL}/${GROUP_PATH}/${ARTIFACT_ID}/maven-metadata.xml") || true
-# Empty repo: expect 404 from a working router, NOT a 400 (format mismatch)
-# or 500 (no route). Anything in {200, 401, 403, 404} confirms the route is
-# wired and the resolver accepts gradle.
+# auth_admin already ran, so 401/403 here would mean auth blew up after the
+# fact, NOT that the resolver rejected gradle. Treat those as failures.
+# An empty gradle repo should return 404 (resolver accepted gradle, but no
+# artifact exists yet). 200 is allowed only if the backend ever auto-generates
+# an empty maven-metadata.xml for new repos. 400/500 indicate the resolver
+# does not accept gradle as a Maven-compatible format.
 case "$PROBE_CODE" in
-  200|401|403|404)
+  404)
     pass
     ;;
+  200)
+    pass
+    ;;
+  401|403)
+    fail "auth failure ($PROBE_CODE) from /maven/{gradle-repo} probe; auth_admin should have authenticated already"
+    ;;
   *)
-    fail "unexpected status $PROBE_CODE from /maven/{gradle-repo} probe"
+    fail "unexpected status $PROBE_CODE from /maven/{gradle-repo} probe (expected 404 for empty repo)"
     ;;
 esac
 
@@ -151,6 +170,7 @@ fi
 # ---------------------------------------------------------------------------
 
 ORIG_SHA256=$(shasum -a 256 "$JAR_FILE" | awk '{print $1}')
+ORIG_MODULE_SHA256=$(shasum -a 256 "$MODULE_FILE" | awk '{print $1}')
 
 begin_test "Upload JAR via PUT /maven/{gradle-repo-key}/..."
 JAR_PATH="${ARTIFACT_BASE}/${ARTIFACT_ID}-${VERSION}.jar"
@@ -207,12 +227,13 @@ fi
 # Round-trip the .module file (Gradle-specific, this is the real test)
 # ---------------------------------------------------------------------------
 
-begin_test "Download Gradle Module Metadata and verify content"
+begin_test "Download Gradle Module Metadata and verify SHA-256 round trip"
 DL_MODULE="${WORK_DIR}/downloaded.module"
 if curl -sf $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" -o "$DL_MODULE" \
   "${GRADLE_URL}/${MODULE_PATH}"; then
-  if assert_contains "$(cat "$DL_MODULE")" "\"formatVersion\": \"1.1\"" \
-       "downloaded .module should preserve Gradle Module Metadata"; then
+  DL_MODULE_SHA256=$(shasum -a 256 "$DL_MODULE" | awk '{print $1}')
+  if assert_eq "$DL_MODULE_SHA256" "$ORIG_MODULE_SHA256" \
+       "SHA256 mismatch on .module after gradle-aliased round-trip (storage layer normalized JSON?)"; then
     pass
   fi
 else
@@ -251,5 +272,10 @@ else
   # Some builds only auto-generate metadata after a deploy. Skip is acceptable.
   skip "maven-metadata.xml not generated for gradle-aliased repo (may require explicit deploy)"
 fi
+
+# TODO: cleanup the test repository when a teardown helper exists in
+# tests/lib/common.sh. Today there is no cleanup_repo helper; the namespace
+# teardown in scripts/teardown-test-namespace.sh removes the entire stack
+# at the end of a CI run.
 
 end_suite


### PR DESCRIPTION
## Summary

Investigation PR for artifact-keeper-test#71 (Epic 5). Grounds the gap-analysis claims about handler/test mismatches by inspecting the `release/1.1.x` backend and this repo's `tests/formats/` directory.

Adds two files:

- `tests/formats/AUDIT-epic-5.md` - per-format audit table covering jetbrains, mlmodel, opkg, p2, vagrant, and gradle. Cites specific lines in the backend.
- `tests/formats/test-gradle-conformance.sh` - the missing Gradle conformance test. Uses `format=gradle` for the repo and hits `/maven/{repo_key}/...` to confirm the Maven alias works end to end, including a Gradle Module Metadata (`.module`) round trip.

No backend or test-runner code is changed.

## Findings

The original gap analysis conflated two distinct artifacts in the backend:

1. The `FormatHandler` trait impls in `backend/src/formats/*.rs` (parse_metadata, validate, generate_index). Every format in scope has one of these.
2. HTTP handler/router modules in `backend/src/api/handlers/*.rs`. Only formats with a native wire protocol have these.

Per-format verdicts:

| Format | Trait handler | API handler module | Route | Tests | Verdict |
| --- | --- | --- | --- | --- | --- |
| jetbrains_plugins | yes | yes | `/jetbrains` mounted | 2 tests on `/jetbrains/...` | works |
| mlmodel | yes | no | only via `/ext/mlmodel/...` (WASM) | 2 tests; basic skips on 404, conformance uses generic API | conditional native, conformance covered |
| opkg | yes | no | only via `/ext/opkg/...` (WASM) | same pattern as mlmodel | same |
| p2 | yes | no | only via `/ext/p2/...` (WASM) | same pattern as mlmodel | same |
| vagrant | yes | no | only via `/ext/vagrant/...` (WASM) | same pattern as mlmodel | same |
| gradle | aliased onto Maven trait | aliased onto Maven handler | addressable via `/maven/{repo_key}/...` for `format=gradle` repos | none on `main` | this PR adds `test-gradle-conformance.sh` |

Detail and remediation options are in `AUDIT-epic-5.md`.

## Test plan

- [ ] CI runs `tests/formats/test-gradle-conformance.sh` against a deployed backend in the matrix.
- [ ] Manual review of `AUDIT-epic-5.md` to confirm the backend citations match `release/1.1.x`.
- [ ] Triage step: decide whether mlmodel/opkg/p2/vagrant should grow native HTTP handler modules, or whether the basic tests should be retired in favour of the generic-API conformance tests.

Closes nothing automatically; the audit is meant to inform follow-up issues filed under #71.