### PR TITLE
feat(security): cache poisoning + stampede E2E gates (#67)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -316,11 +316,23 @@ jobs:
 
   # -------------------------------------------------------------------
   # Security tests
+  #
+  # cache-poisoning + cache-stampede boot a Python mock upstream on the
+  # runner pod and need the backend to dial the runner pod by hostname.
+  # We compute the runner's pod IP at runtime and translate it to the
+  # cluster-DNS pod-DNS form (10-1-2-3.<ns>.pod.cluster.local) which the
+  # backend pod can resolve via ClusterFirst.
+  #
+  # PROXY_MAX_CONCURRENT_FETCHES / PROXY_QUEUE_TIMEOUT_SECS pin the
+  # values the test asserts against so chart-default drift doesn't
+  # silently make the assertion measure the wrong limit. They MUST match
+  # the values the deployed backend was configured with.
   # -------------------------------------------------------------------
   security-tests:
     needs: deploy
     if: inputs.test_suite == 'all' || inputs.test_suite == 'security'
     runs-on: ak-e2e-runners
+    timeout-minutes: 15
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
@@ -330,10 +342,47 @@ jobs:
       # A silently-skipped test in release-gate context is exactly the
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
+      # Stampede / poisoning test knobs. Must match the values the chart
+      # rendered for the backend Deployment (see helm values-test.yaml).
+      PROXY_MAX_CONCURRENT_FETCHES: '20'
+      PROXY_QUEUE_TIMEOUT_SECS: '5'
+      STAMPEDE_UPSTREAM_DELAY_MS: '2000'
     steps:
       - uses: actions/checkout@v4
         with:
           repository: artifact-keeper/artifact-keeper-test
+
+      - name: Resolve runner pod address for backend dial-back
+        id: mock-host
+        run: |
+          # The runner is a Pod inside the cluster; its pod IP is reachable
+          # from the backend Pod over the cluster network. We pass the bare
+          # IP as MOCK_UPSTREAM_HOSTNAME so the backend's upstream-URL
+          # resolver does not need cluster DNS to be configured for the
+          # `<ip-dashed>.<ns>.pod.cluster.local` form (which depends on
+          # CoreDNS `pods` plugin mode).
+          #
+          # ARC runners with `spec.template.spec.containers[].env.POD_IP`
+          # via the downward API populate $POD_IP. We fall back to
+          # `hostname -i` if the env var is missing.
+          POD_IP="${POD_IP:-$(hostname -i 2>/dev/null | awk '{print $1}')}"
+          if [ -z "$POD_IP" ]; then
+            echo "ERROR: could not determine runner pod IP for mock dial-back" >&2
+            exit 1
+          fi
+          # Sanity: must look like an IPv4. Reject 127.* (loopback would
+          # only be reachable from inside the runner pod itself, not from
+          # the backend pod across the cluster network).
+          if ! echo "$POD_IP" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: POD_IP '${POD_IP}' is not an IPv4 address" >&2
+            exit 1
+          fi
+          if echo "$POD_IP" | grep -Eq '^127\.'; then
+            echo "ERROR: POD_IP '${POD_IP}' is loopback; backend pod cannot reach this" >&2
+            exit 1
+          fi
+          echo "Runner pod IP: ${POD_IP}"
+          echo "MOCK_UPSTREAM_HOSTNAME=${POD_IP}" >> "$GITHUB_ENV"
 
       - name: Run security tests
         run: |

--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -115,11 +115,16 @@ get_backend_version() {
 # Add entries here in the same PR that ships the feature.
 _feature_min_version() {
   case "$1" in
-    "conan_remote_search_forward")  echo "1.3.0" ;;
+    "conan_remote_search_forward")    echo "1.3.0" ;;
     "conan_virtual_search_aggregate") echo "1.3.0" ;;
-    "maven_virtual_snapshot")       echo "1.2.0" ;;
-    "guest_access_toggle")          echo "1.2.0" ;;
-    "opensearch_indexing")          echo "1.2.0" ;;
+    "maven_virtual_snapshot")         echo "1.2.0" ;;
+    "guest_access_toggle")            echo "1.2.0" ;;
+    "opensearch_indexing")            echo "1.2.0" ;;
+    # proxy_stampede_protection: ProxyService gains a per-(repo,path) semaphore
+    # capping concurrent upstream fetches at proxy_max_concurrent_fetches and
+    # emitting 503 when proxy_queue_timeout_secs fires. Tracked by backend
+    # work to land in v1.2.0 (companion to discussion #872 customer pain).
+    "proxy_stampede_protection")      echo "1.2.0" ;;
     *) return 1 ;;
   esac
 }
@@ -567,6 +572,19 @@ end_suite() {
 ${_JUNIT_CASES}</testsuite>
 EOF
 
+  # EXPECT_FAILURE self-test mode: inverts the exit code so an author can
+  # point the suite at a known-broken backend (e.g. semaphore disabled) and
+  # confirm the load-bearing assertion actually catches it. See the
+  # "EXPECT_FAILURE self-test mode" block above for full semantics.
+  if [ "${EXPECT_FAILURE:-0}" = "1" ]; then
+    if [ "$_FAIL_COUNT" -gt 0 ]; then
+      echo "EXPECT_FAILURE=1: at least one test failed as expected; exiting 0"
+      exit 0
+    fi
+    echo "EXPECT_FAILURE=1: every test passed but a failure was expected; exiting 1"
+    exit 1
+  fi
+
   if [ "$_FAIL_COUNT" -gt 0 ]; then
     exit 1
   fi
@@ -682,6 +700,42 @@ require_cmd() {
 }
 
 # ---------------------------------------------------------------------------
+# Composable EXIT trap (LIFO)
+# ---------------------------------------------------------------------------
+#
+# Bash only supports one EXIT trap per shell, so multiple `trap '...' EXIT`
+# calls clobber each other. Tests that boot fixtures (mock upstreams, sidecar
+# processes) need to chain cleanups onto whatever setup_workdir already
+# registered.
+#
+# Usage:
+#   add_exit_handler 'stop_mock_upstream'
+#   add_exit_handler 'rm -rf "$STATE_DIR"'
+# Handlers run in LIFO order (last-added first), each in a subshell-safe form
+# so a failing handler does not block subsequent cleanups.
+
+_EXIT_HANDLERS=()
+_EXIT_HANDLERS_INSTALLED=0
+
+_run_exit_handlers() {
+  local rc=$?
+  local i
+  for (( i=${#_EXIT_HANDLERS[@]}-1; i>=0; i-- )); do
+    eval "${_EXIT_HANDLERS[$i]}" || true
+  done
+  return $rc
+}
+
+add_exit_handler() {
+  local cmd="$1"
+  _EXIT_HANDLERS+=("$cmd")
+  if [ "$_EXIT_HANDLERS_INSTALLED" -eq 0 ]; then
+    trap _run_exit_handlers EXIT
+    _EXIT_HANDLERS_INSTALLED=1
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Temp directory with automatic cleanup
 # ---------------------------------------------------------------------------
 
@@ -689,9 +743,203 @@ WORK_DIR=""
 
 setup_workdir() {
   WORK_DIR="$(mktemp -d)"
-  # shellcheck disable=SC2064
-  trap "rm -rf \"$WORK_DIR\"" EXIT
+  add_exit_handler "rm -rf \"$WORK_DIR\""
 }
+
+# ---------------------------------------------------------------------------
+# Mock HTTP upstream fixture
+# ---------------------------------------------------------------------------
+#
+# Boots tests/lib/mock-upstream.py as a controllable HTTP upstream the backend
+# can dial. Used by proxy/cache tests (cache-poisoning, cache-stampede, ETag,
+# stale-on-error, etc.) to seed bytes, swap content mid-flight, and read
+# per-request counters.
+#
+# Globals set on success:
+#   MOCK_PID            background server PID
+#   MOCK_PORT           bound port (random by default; honors MOCK_PORT env)
+#   MOCK_STATE_DIR      state directory the mock reads from / writes to
+#   MOCK_BASE_URL       URL the *backend pod* should use (uses MOCK_UPSTREAM_HOSTNAME)
+#   MOCK_LOCAL_URL      URL the test runner should use (127.0.0.1)
+#
+# Auto-cleanup is registered via add_exit_handler so callers don't have to
+# manage trap stacks. Honors skip_teardown (env: SKIP_TEARDOWN=1) for debugging.
+#
+# Usage:
+#   setup_workdir
+#   start_mock_upstream "${WORK_DIR}/mock-state" || skip_suite "mock did not boot"
+#   echo "payload" > "${MOCK_STATE_DIR}/files/pkg/v1/payload.bin"
+
+# shellcheck disable=SC2034 # consumed by tests that source this file
+MOCK_PID=""
+# shellcheck disable=SC2034
+MOCK_PORT=""
+# shellcheck disable=SC2034
+MOCK_STATE_DIR=""
+# shellcheck disable=SC2034
+MOCK_BASE_URL=""
+# shellcheck disable=SC2034
+MOCK_LOCAL_URL=""
+
+# Pick an unused TCP port. Honors MOCK_PORT env (CI can pin); otherwise asks
+# the kernel for a free port via getsockname(). Avoids the 18080 collision
+# class when multiple suites run on the same runner pod.
+_pick_mock_port() {
+  if [ -n "${MOCK_PORT_OVERRIDE:-}" ]; then
+    echo "$MOCK_PORT_OVERRIDE"
+    return 0
+  fi
+  python3 -c '
+import socket
+s = socket.socket()
+s.bind(("0.0.0.0", 0))
+print(s.getsockname()[1])
+s.close()
+'
+}
+
+# start_mock_upstream STATE_DIR
+# Boots the mock, waits up to 10s for /__readyz, registers an EXIT handler.
+# Returns 0 on success; non-zero (and prints diagnostics) on failure.
+start_mock_upstream() {
+  local state_dir="$1"
+  MOCK_STATE_DIR="$state_dir"
+  mkdir -p "${MOCK_STATE_DIR}/files"
+  MOCK_PORT="$(_pick_mock_port)"
+
+  local mock_script
+  mock_script="$(dirname "${BASH_SOURCE[0]}")/mock-upstream.py"
+  if [ ! -f "$mock_script" ]; then
+    echo "start_mock_upstream: mock-upstream.py not found at $mock_script" >&2
+    return 1
+  fi
+
+  MOCK_STATE_DIR="$MOCK_STATE_DIR" MOCK_PORT="$MOCK_PORT" \
+    python3 "$mock_script" \
+    > "${WORK_DIR:-/tmp}/mock.out" 2> "${WORK_DIR:-/tmp}/mock.err" &
+  MOCK_PID=$!
+  # Disown so a bare `wait` in the caller (e.g. fan-out concurrency loops)
+  # does not block on the long-lived mock process. Cleanup is still handled
+  # via add_exit_handler -> stop_mock_upstream.
+  disown "$MOCK_PID" 2>/dev/null || true
+
+  MOCK_LOCAL_URL="http://127.0.0.1:${MOCK_PORT}"
+  if [ -n "${MOCK_UPSTREAM_HOSTNAME:-}" ]; then
+    MOCK_BASE_URL="http://${MOCK_UPSTREAM_HOSTNAME}:${MOCK_PORT}"
+  else
+    # shellcheck disable=SC2034 # consumed by sourcing test scripts
+    MOCK_BASE_URL="$MOCK_LOCAL_URL"
+  fi
+
+  add_exit_handler "stop_mock_upstream"
+
+  # Readiness probe: __readyz bypasses logging/counters/delay so the wait
+  # itself doesn't pollute mock state.
+  local code
+  for _ in $(seq 1 20); do
+    if ! kill -0 "$MOCK_PID" 2>/dev/null; then
+      echo "start_mock_upstream: mock died during boot" >&2
+      [ -f "${WORK_DIR:-/tmp}/mock.err" ] && cat "${WORK_DIR:-/tmp}/mock.err" >&2 || true
+      return 1
+    fi
+    code=$(curl -s --max-time 2 -o /dev/null -w '%{http_code}' "${MOCK_LOCAL_URL}/__readyz" 2>/dev/null) || code="000"
+    if [ "$code" = "200" ]; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "start_mock_upstream: not ready on ${MOCK_LOCAL_URL} after 10s" >&2
+  return 1
+}
+
+stop_mock_upstream() {
+  if [ -n "${MOCK_PID:-}" ] && kill -0 "$MOCK_PID" 2>/dev/null; then
+    kill "$MOCK_PID" 2>/dev/null || true
+    # SIGTERM, then escalate after 2s if the handler is mid-sleep (stampede
+    # tests can have requests blocked in time.sleep at shutdown).
+    local i
+    for i in 1 2 3 4; do
+      kill -0 "$MOCK_PID" 2>/dev/null || break
+      sleep 0.5
+    done
+    if kill -0 "$MOCK_PID" 2>/dev/null; then
+      kill -9 "$MOCK_PID" 2>/dev/null || true
+    fi
+    wait "$MOCK_PID" 2>/dev/null || true
+  fi
+  MOCK_PID=""
+}
+
+# wait_for_file_value FILE EXPECTED_REGEX TIMEOUT_SECS
+# Polls FILE every 0.2s until its content matches EXPECTED_REGEX or the
+# timeout fires. Replaces ad-hoc `sleep N` waits for fixture state changes.
+# Returns 0 on match, 1 on timeout.
+wait_for_file_value() {
+  local file="$1"
+  local pattern="$2"
+  local timeout="${3:-5}"
+  local elapsed=0
+  local step=0.2
+  local steps
+  steps=$(awk -v t="$timeout" -v s="$step" 'BEGIN{print int(t/s)}')
+  for _ in $(seq 1 "$steps"); do
+    if [ -f "$file" ] && grep -qE "$pattern" "$file" 2>/dev/null; then
+      return 0
+    fi
+    sleep "$step"
+    elapsed=$((elapsed + 1))
+  done
+  return 1
+}
+
+# wait_for_counter_stable FILE TIMEOUT_SECS [STABLE_WINDOW_SECS]
+# Polls a numeric counter file (e.g. mock peak-inflight) until its value has
+# not changed for STABLE_WINDOW_SECS (default 0.6s) or TIMEOUT_SECS fires.
+# Use this in place of `sleep 1` when reading mock-upstream peak counters.
+# Echoes the final value on stdout. Returns 0 if stable; 1 on timeout.
+wait_for_counter_stable() {
+  local file="$1"
+  local timeout="${2:-5}"
+  local stable_window="${3:-0.6}"
+  local last="" cur=""
+  local stable_for=0
+  local elapsed=0
+  local steps
+  steps=$(awk -v t="$timeout" 'BEGIN{print int(t/0.2)}')
+  local stable_steps
+  stable_steps=$(awk -v t="$stable_window" 'BEGIN{print int(t/0.2)}')
+  for _ in $(seq 1 "$steps"); do
+    cur=$(cat "$file" 2>/dev/null || echo "")
+    if [ -n "$cur" ] && [ "$cur" = "$last" ]; then
+      stable_for=$((stable_for + 1))
+      if [ "$stable_for" -ge "$stable_steps" ]; then
+        echo "$cur"
+        return 0
+      fi
+    else
+      stable_for=0
+      last="$cur"
+    fi
+    sleep 0.2
+    elapsed=$((elapsed + 1))
+  done
+  echo "$last"
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# EXPECT_FAILURE self-test mode
+# ---------------------------------------------------------------------------
+#
+# When EXPECT_FAILURE=1 is set, the *suite-level* exit code is inverted at
+# end_suite: a passing suite returns non-zero and a failing suite returns 0.
+# Use this to verify that a load-bearing assertion actually catches a known
+# breakage (e.g. point the test at a backend image with the semaphore
+# disabled and confirm EXIT=0 with the inversion). Without this, "the test
+# passed" is indistinguishable from "the test could never fail".
+#
+# This only inverts the exit code; it does NOT silence per-test failure
+# output, so logs still tell you which assertion fired.
 
 # ---------------------------------------------------------------------------
 # Internal helpers

--- a/tests/lib/mock-upstream.py
+++ b/tests/lib/mock-upstream.py
@@ -5,39 +5,95 @@
 # assert "the backend only fetched once" for stampede tests, or "the backend
 # rejected tampered content" for poisoning tests.
 #
-# Layout under STATE_DIR (env MOCK_STATE_DIR, default /tmp/mock-upstream):
+# State directory MUST be supplied via MOCK_STATE_DIR. Each test run picks a
+# unique mktemp -d path under WORK_DIR (which is itself mktemp -d) so parallel
+# release-gate jobs and concurrent local invocations cannot collide. There is
+# deliberately no default: if the env var is unset we exit 2 rather than
+# scribble into a shared /tmp path.
+#
+# Layout under STATE_DIR:
 #   files/<path>          bytes returned for GET /<path>
 #   files/<path>.headers  optional. Lines like "Header-Name: value".
 #   request-log.txt       one line per request: "<unix_ts> <METHOD> <path>"
 #   request-count.<key>   counter incremented per GET. <key> is the URL path
-#                         with slashes replaced by underscores.
+#                         with slashes replaced by underscores; only
+#                         [A-Za-z0-9_.-] are kept and the result is truncated
+#                         to 128 chars to defeat path-traversal/long-name abuse.
 #   peak-inflight         peak concurrent in-flight handlers. Used by stampede
 #                         tests to assert the backend's semaphore caps upstream
-#                         concurrency.
+#                         concurrency. Written via os.replace() for atomicity.
 #   delay-ms              optional. Per-request artificial delay (server-wide).
+#   error-status          optional. Integer HTTP code (e.g. "503" or "500").
+#                         When present, the mock returns this status with a
+#                         short text body for every non-readyz request. Used
+#                         by stale-on-error / 5xx-handling tests.
 #
 # GET /__readyz is a readiness probe that bypasses logging, counters, and
 # delay so test fixtures can wait on TCP readiness without polluting state.
 #
-# Bind: 0.0.0.0:<MOCK_PORT> (default 18080).
-#
-# Tests should write files into STATE_DIR before triggering proxy fetches,
-# then read request-log.txt / request-count.* to assert behavior.
+# Bind: 0.0.0.0:<MOCK_PORT>. MOCK_PORT is required; tests/lib/common.sh's
+# start_mock_upstream picks a free port via getsockname() and passes it in.
 
 import http.server
 import os
+import re
 import sys
+import tempfile
 import threading
 import time
 from pathlib import Path
 
-STATE_DIR = Path(os.environ.get("MOCK_STATE_DIR", "/tmp/mock-upstream"))
-PORT = int(os.environ.get("MOCK_PORT", "18080"))
+_STATE_ENV = os.environ.get("MOCK_STATE_DIR")
+if not _STATE_ENV:
+    sys.stderr.write(
+        "mock-upstream: MOCK_STATE_DIR is required (use tests/lib/common.sh's "
+        "start_mock_upstream which provides a unique mktemp path)\n"
+    )
+    sys.exit(2)
+STATE_DIR = Path(_STATE_ENV)
+
+_PORT_ENV = os.environ.get("MOCK_PORT")
+if not _PORT_ENV:
+    sys.stderr.write("mock-upstream: MOCK_PORT is required\n")
+    sys.exit(2)
+PORT = int(_PORT_ENV)
+
 FILES_DIR = STATE_DIR / "files"
 LOG_PATH = STATE_DIR / "request-log.txt"
 PEAK_PATH = STATE_DIR / "peak-inflight"
 LOG_LOCK = threading.Lock()
 INFLIGHT = {"current": 0, "peak": 0}
+
+_KEY_SAFE = re.compile(r"[^A-Za-z0-9_.-]")
+
+
+def _safe_counter_key(path: str) -> str:
+    """Sanitize a URL path into a counter filename component.
+
+    Strips query strings, replaces slashes with underscores, drops anything
+    outside [A-Za-z0-9_.-], and truncates to 128 chars. Defends against
+    request-count.<key> writes escaping STATE_DIR via path traversal or
+    blowing up the filesystem with overlong keys.
+    """
+    base = path.split("?", 1)[0].lstrip("/")
+    base = base.replace("/", "_") or "_root"
+    base = _KEY_SAFE.sub("_", base)
+    return base[:128]
+
+
+def _atomic_write(path: Path, value: str) -> None:
+    """Write VALUE to PATH atomically via tempfile + os.replace."""
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".tmp-", suffix=".swap")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(value)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 class Handler(http.server.BaseHTTPRequestHandler):
@@ -50,13 +106,12 @@ class Handler(http.server.BaseHTTPRequestHandler):
             INFLIGHT["current"] += 1
             if INFLIGHT["current"] > INFLIGHT["peak"]:
                 INFLIGHT["peak"] = INFLIGHT["current"]
-                PEAK_PATH.write_text(str(INFLIGHT["peak"]))
+                _atomic_write(PEAK_PATH, str(INFLIGHT["peak"]))
             with LOG_PATH.open("a") as f:
                 f.write(f"{ts:.6f} {self.command} {path}\n")
-            key = path.lstrip("/").replace("/", "_") or "_root"
-            counter = STATE_DIR / f"request-count.{key}"
+            counter = STATE_DIR / f"request-count.{_safe_counter_key(path)}"
             n = int(counter.read_text()) if counter.exists() else 0
-            counter.write_text(str(n + 1))
+            _atomic_write(counter, str(n + 1))
 
     def _release_inflight(self):
         with LOG_LOCK:
@@ -85,6 +140,17 @@ class Handler(http.server.BaseHTTPRequestHandler):
         self._log_request(self.path)
         try:
             self._maybe_delay()
+            err_path = STATE_DIR / "error-status"
+            if err_path.exists():
+                try:
+                    code = int(err_path.read_text().strip())
+                except ValueError:
+                    code = 500
+                self.send_response(code)
+                self.send_header("Content-Type", "text/plain")
+                self.end_headers()
+                self.wfile.write(f"injected error {code}\n".encode())
+                return
             rel = self.path.lstrip("/").split("?", 1)[0]
             body_path = FILES_DIR / rel
             if not body_path.is_file():

--- a/tests/lib/mock-upstream.py
+++ b/tests/lib/mock-upstream.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# mock-upstream.py - Controllable HTTP upstream for proxy/cache tests.
+#
+# Serves bytes from a state directory and counts every request so tests can
+# assert "the backend only fetched once" for stampede tests, or "the backend
+# rejected tampered content" for poisoning tests.
+#
+# Layout under STATE_DIR (env MOCK_STATE_DIR, default /tmp/mock-upstream):
+#   files/<path>          bytes returned for GET /<path>
+#   files/<path>.headers  optional. Lines like "Header-Name: value".
+#   request-log.txt       one line per request: "<unix_ts> <METHOD> <path>"
+#   request-count.<key>   counter incremented per GET. <key> is the URL path
+#                         with slashes replaced by underscores.
+#   peak-inflight         peak concurrent in-flight handlers. Used by stampede
+#                         tests to assert the backend's semaphore caps upstream
+#                         concurrency.
+#   delay-ms              optional. Per-request artificial delay (server-wide).
+#
+# GET /__readyz is a readiness probe that bypasses logging, counters, and
+# delay so test fixtures can wait on TCP readiness without polluting state.
+#
+# Bind: 0.0.0.0:<MOCK_PORT> (default 18080).
+#
+# Tests should write files into STATE_DIR before triggering proxy fetches,
+# then read request-log.txt / request-count.* to assert behavior.
+
+import http.server
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+STATE_DIR = Path(os.environ.get("MOCK_STATE_DIR", "/tmp/mock-upstream"))
+PORT = int(os.environ.get("MOCK_PORT", "18080"))
+FILES_DIR = STATE_DIR / "files"
+LOG_PATH = STATE_DIR / "request-log.txt"
+PEAK_PATH = STATE_DIR / "peak-inflight"
+LOG_LOCK = threading.Lock()
+INFLIGHT = {"current": 0, "peak": 0}
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):  # noqa: A003 - silence default stderr spam
+        pass
+
+    def _log_request(self, path):
+        ts = time.time()
+        with LOG_LOCK:
+            INFLIGHT["current"] += 1
+            if INFLIGHT["current"] > INFLIGHT["peak"]:
+                INFLIGHT["peak"] = INFLIGHT["current"]
+                PEAK_PATH.write_text(str(INFLIGHT["peak"]))
+            with LOG_PATH.open("a") as f:
+                f.write(f"{ts:.6f} {self.command} {path}\n")
+            key = path.lstrip("/").replace("/", "_") or "_root"
+            counter = STATE_DIR / f"request-count.{key}"
+            n = int(counter.read_text()) if counter.exists() else 0
+            counter.write_text(str(n + 1))
+
+    def _release_inflight(self):
+        with LOG_LOCK:
+            if INFLIGHT["current"] > 0:
+                INFLIGHT["current"] -= 1
+
+    def _maybe_delay(self):
+        delay_path = STATE_DIR / "delay-ms"
+        if delay_path.exists():
+            try:
+                ms = int(delay_path.read_text().strip())
+                if ms > 0:
+                    time.sleep(ms / 1000.0)
+            except ValueError:
+                pass
+
+    def do_GET(self):  # noqa: N802 - http.server contract
+        # Readiness probe path is excluded from logging, counters, and delay
+        # so test fixtures can wait on TCP readiness without polluting state.
+        if self.path.split("?", 1)[0] == "/__readyz":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"ok\n")
+            return
+        self._log_request(self.path)
+        try:
+            self._maybe_delay()
+            rel = self.path.lstrip("/").split("?", 1)[0]
+            body_path = FILES_DIR / rel
+            if not body_path.is_file():
+                self.send_response(404)
+                self.send_header("Content-Type", "text/plain")
+                self.end_headers()
+                self.wfile.write(b"not found\n")
+                return
+            body = body_path.read_bytes()
+            headers_path = body_path.with_suffix(body_path.suffix + ".headers")
+            extra_headers = []
+            if headers_path.is_file():
+                for line in headers_path.read_text().splitlines():
+                    if ":" in line:
+                        k, v = line.split(":", 1)
+                        extra_headers.append((k.strip(), v.strip()))
+            self.send_response(200)
+            seen = {k.lower() for k, _ in extra_headers}
+            if "content-type" not in seen:
+                self.send_header("Content-Type", "application/octet-stream")
+            if "content-length" not in seen:
+                self.send_header("Content-Length", str(len(body)))
+            for k, v in extra_headers:
+                self.send_header(k, v)
+            self.end_headers()
+            self.wfile.write(body)
+        finally:
+            self._release_inflight()
+
+
+class ThreadedServer(http.server.ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def main():
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    FILES_DIR.mkdir(parents=True, exist_ok=True)
+    LOG_PATH.touch()
+    srv = ThreadedServer(("0.0.0.0", PORT), Handler)
+    sys.stdout.write(f"mock-upstream listening on 0.0.0.0:{PORT} state={STATE_DIR}\n")
+    sys.stdout.flush()
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/security/test-cache-poisoning.sh
+++ b/tests/security/test-cache-poisoning.sh
@@ -8,23 +8,22 @@
 # Customer pain #1 (https://github.com/orgs/artifact-keeper/discussions/872):
 # the prior version of this suite skipped the load-bearing assertion with
 # "requires controllable mock HTTP upstream". This version stands up a real
-# mock upstream (tests/lib/mock-upstream.py), seeds known bytes, primes the
-# cache, swaps the upstream content for a different payload, and asserts that
-# the proxy serves the originally-cached bytes (or 502/503), never the
-# tampered payload.
+# mock upstream (tests/lib/mock-upstream.py via start_mock_upstream), seeds
+# known bytes, primes the cache, swaps the upstream content for a different
+# payload, and asserts that the proxy serves the originally-cached bytes
+# (or 502/503), never the tampered payload.
 #
 # Hard constraint (issue artifact-keeper-test#67): this test must FAIL when
 # the backend is broken. Run with EXPECT_FAILURE=1 against a known-broken
-# build to validate the assertion is load-bearing.
+# build to validate the assertion is load-bearing (see common.sh).
 
 source "$(dirname "$0")/../lib/common.sh"
 
 begin_suite "cache-poisoning"
 
-# Pre-flight: the mock upstream needs python3, and the backend has to be able
-# to dial the mock from the cluster. We pass MOCK_UPSTREAM_HOSTNAME from CI;
-# in local-dev runs we skip with a clear reason rather than silently passing.
-# RELEASE_GATE=1 turns the skip into a hard fail (silent-success class).
+# Pre-flight: the mock upstream needs python3 and the backend has to be able
+# to dial the mock from the cluster (MOCK_UPSTREAM_HOSTNAME, set by CI).
+# RELEASE_GATE=1 turns these skips into hard fails (silent-success class).
 if ! command -v python3 >/dev/null 2>&1; then
   skip_suite "python3 not available; cache-poisoning needs the mock upstream fixture"
 fi
@@ -36,52 +35,26 @@ fi
 auth_admin
 setup_workdir
 
-MOCK_PORT="${MOCK_UPSTREAM_PORT:-18080}"
-MOCK_STATE_DIR="${WORK_DIR}/mock-upstream"
-MOCK_BASE_URL="http://${MOCK_UPSTREAM_HOSTNAME}:${MOCK_PORT}"
 REMOTE_KEY="sec-cache-poison-${RUN_ID}"
 LOCAL_KEY="sec-cache-ref-${RUN_ID}"
 ARTIFACT_PATH="pkg/v1/payload.bin"
+ETAG_PATH="pkg/v1/etagged.bin"
+CL_PATH="pkg/v1/clmismatch.bin"
 
 # ---------------------------------------------------------------------------
 # Boot the mock upstream
 # ---------------------------------------------------------------------------
 
-mkdir -p "${MOCK_STATE_DIR}/files/$(dirname "$ARTIFACT_PATH")"
-GOOD_CONTENT="known-good-content-${RUN_ID}"
-TAMPERED_CONTENT="tampered-by-attacker-${RUN_ID}"
-printf '%s\n' "$GOOD_CONTENT" > "${MOCK_STATE_DIR}/files/${ARTIFACT_PATH}"
-GOOD_SHA256=$(shasum -a 256 "${MOCK_STATE_DIR}/files/${ARTIFACT_PATH}" | awk '{print $1}')
-
-MOCK_PID=""
-start_mock() {
-  MOCK_STATE_DIR="$MOCK_STATE_DIR" MOCK_PORT="$MOCK_PORT" \
-    python3 "$(dirname "$0")/../lib/mock-upstream.py" \
-    > "${WORK_DIR}/mock.out" 2> "${WORK_DIR}/mock.err" &
-  MOCK_PID=$!
-  # Wait until the mock answers locally before announcing it to the backend.
-  for _ in $(seq 1 20); do
-    if curl -sf --max-time 2 "http://127.0.0.1:${MOCK_PORT}/${ARTIFACT_PATH}" >/dev/null 2>&1; then
-      return 0
-    fi
-    sleep 0.5
-  done
-  return 1
-}
-
-stop_mock() {
-  if [ -n "$MOCK_PID" ] && kill -0 "$MOCK_PID" 2>/dev/null; then
-    kill "$MOCK_PID" 2>/dev/null || true
-    wait "$MOCK_PID" 2>/dev/null || true
-  fi
-}
-trap 'stop_mock; rm -rf "$WORK_DIR"' EXIT
-
 begin_test "Mock upstream starts and serves seeded content"
-if start_mock; then
+if start_mock_upstream "${WORK_DIR}/mock-state"; then
+  GOOD_CONTENT="known-good-content-${RUN_ID}"
+  TAMPERED_CONTENT="tampered-by-attacker-${RUN_ID}"
+  mkdir -p "${MOCK_STATE_DIR}/files/$(dirname "$ARTIFACT_PATH")"
+  printf '%s\n' "$GOOD_CONTENT" > "${MOCK_STATE_DIR}/files/${ARTIFACT_PATH}"
+  GOOD_SHA256=$(shasum -a 256 "${MOCK_STATE_DIR}/files/${ARTIFACT_PATH}" | awk '{print $1}')
   pass
 else
-  fail "mock upstream did not become reachable on 127.0.0.1:${MOCK_PORT} within 10s"
+  fail "mock upstream did not boot"
   end_suite
 fi
 
@@ -154,7 +127,7 @@ fi
 # saw between prime and shutdown.
 # ---------------------------------------------------------------------------
 
-stop_mock
+stop_mock_upstream
 
 begin_test "Proxy serves cached good bytes (or 5xx) when upstream is unreachable"
 offline_status=$(curl -s -o "${WORK_DIR}/offline.bin" -w '%{http_code}' $CURL_TIMEOUT \
@@ -174,6 +147,91 @@ elif [ "$offline_status" = "502" ] || [ "$offline_status" = "503" ] || [ "$offli
   pass
 else
   fail "offline fetch returned HTTP ${offline_status} sha=${offline_sha:-<empty>} (neither cached-good nor 5xx)"
+fi
+
+# ---------------------------------------------------------------------------
+# Bring the mock back up for the remaining content-integrity probes.
+# ---------------------------------------------------------------------------
+
+begin_test "Mock upstream restarts (continues with content-integrity probes)"
+if start_mock_upstream "${WORK_DIR}/mock-state-2"; then
+  pass
+else
+  fail "mock upstream did not restart"
+  end_suite
+fi
+
+# ---------------------------------------------------------------------------
+# Coverage: upstream lies about Content-Length. A fetch that returns fewer
+# bytes than advertised must NOT be silently cached as if it were complete.
+# Acceptable: 200 (curl handles short read) followed by an integrity reject;
+# OR 502/503 from the proxy; OR a successful fetch with the actual bytes.
+# Forbidden: cache a partial as if complete and serve it as the full artifact.
+# ---------------------------------------------------------------------------
+
+begin_test "Upstream Content-Length mismatch is not silently cached as complete"
+mkdir -p "${MOCK_STATE_DIR}/files/$(dirname "$CL_PATH")"
+CL_BODY="full-body-content-${RUN_ID}"
+printf '%s\n' "$CL_BODY" > "${MOCK_STATE_DIR}/files/${CL_PATH}"
+# Lie: claim the body is twice as long. Real curl will detect short read and
+# either error or truncate; the question is whether the backend caches the
+# (potentially short) bytes as if they were the canonical artifact.
+real_len=$(wc -c < "${MOCK_STATE_DIR}/files/${CL_PATH}" | tr -d ' ')
+echo "Content-Length: $((real_len * 2))" > "${MOCK_STATE_DIR}/files/${CL_PATH}.headers"
+
+cl_status=$(curl -s -o "${WORK_DIR}/cl.bin" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/${CL_PATH}") || true
+
+# Now repair the upstream and re-fetch. If the proxy cached the lying response
+# as if complete, the second fetch returns the (broken) cached copy. If it
+# refused to cache, the second fetch sees the corrected upstream.
+rm -f "${MOCK_STATE_DIR}/files/${CL_PATH}.headers"
+followup_status=$(curl -s -o "${WORK_DIR}/cl-followup.bin" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/${CL_PATH}") || true
+
+if assert_http_2xx "$followup_status" "follow-up fetch should succeed once upstream is honest"; then
+  followup_sha=$(shasum -a 256 "${WORK_DIR}/cl-followup.bin" | awk '{print $1}')
+  expected_sha=$(shasum -a 256 "${MOCK_STATE_DIR}/files/${CL_PATH}" | awk '{print $1}')
+  if [ "$followup_sha" = "$expected_sha" ]; then
+    pass
+  else
+    fail "after Content-Length-lie-then-repair, proxy served sha=${followup_sha} but upstream now serves sha=${expected_sha}: a partial response was cached as canonical"
+  fi
+fi
+echo "  (initial mismatch fetch: HTTP ${cl_status})"
+
+# ---------------------------------------------------------------------------
+# Coverage: upstream sends a forged X-Checksum-Sha256 header that does not
+# match the body. If the backend trusts the header without recomputing, an
+# attacker who controls the upstream can poison the cache with a deceptive
+# checksum. The proxy should either ignore the header (recompute locally) or
+# reject the fetch.
+# ---------------------------------------------------------------------------
+
+begin_test "Forged upstream X-Checksum-Sha256 does not override on-disk hash"
+mkdir -p "${MOCK_STATE_DIR}/files/$(dirname "$ETAG_PATH")"
+HONEST_BODY="honest-payload-${RUN_ID}"
+printf '%s\n' "$HONEST_BODY" > "${MOCK_STATE_DIR}/files/${ETAG_PATH}"
+HONEST_SHA=$(shasum -a 256 "${MOCK_STATE_DIR}/files/${ETAG_PATH}" | awk '{print $1}')
+# Plant a wrong sha256 in the headers file.
+cat > "${MOCK_STATE_DIR}/files/${ETAG_PATH}.headers" <<EOF
+X-Checksum-Sha256: 0000000000000000000000000000000000000000000000000000000000000000
+ETag: "fake-etag"
+EOF
+
+forged_status=$(curl -s -o "${WORK_DIR}/forged.bin" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/${ETAG_PATH}") || true
+
+if assert_http_2xx "$forged_status" "fetch should succeed; integrity must be enforced from bytes, not header"; then
+  forged_sha=$(shasum -a 256 "${WORK_DIR}/forged.bin" | awk '{print $1}')
+  if [ "$forged_sha" = "$HONEST_SHA" ]; then
+    pass
+  else
+    fail "served bytes (sha=${forged_sha}) do not match upstream body (sha=${HONEST_SHA}); proxy may have honored forged X-Checksum-Sha256 header"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -201,17 +259,13 @@ cross_status=$(curl -s -o "${WORK_DIR}/cross.bin" -w '%{http_code}' $CURL_TIMEOU
   -H "$(auth_header)" \
   "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/${ARTIFACT_PATH}") || true
 
-# Whatever bytes (if any) the remote serves must NOT be the local repo's
-# content. Either 5xx/404 (mock is down, no cache hit) or the previously-
-# cached good bytes from the mock are acceptable.
+# Cross-repo isolation invariant: a remote repo can only serve paths the
+# upstream actually had. Probe a path the local repo could conceivably leak
+# via a global cache table but the mock has never seen. A 2xx here proves a
+# cross-repo or unauthenticated cache leak.
 if [ -s "${WORK_DIR}/cross.bin" ] && [ "$cross_status" -ge 200 ] 2>/dev/null && [ "$cross_status" -lt 300 ] 2>/dev/null; then
   cross_sha=$(shasum -a 256 "${WORK_DIR}/cross.bin" | awk '{print $1}')
   ref_sha=$(shasum -a 256 "${WORK_DIR}/reference.bin" | awk '{print $1}')
-  # If the cached upstream content happened to be byte-equal to the local
-  # reference (we deliberately chose the same string for both -- the test
-  # is about isolation, not byte-distinguishability), distinguishing
-  # repos requires a different probe. Use a path that the local repo has
-  # but the mock NEVER served.
   status_only_local=$(curl -s -o "${WORK_DIR}/cross-only.bin" -w '%{http_code}' $CURL_TIMEOUT \
     -H "$(auth_header)" \
     "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/never-fetched-from-mock-${RUN_ID}.bin") || true

--- a/tests/security/test-cache-poisoning.sh
+++ b/tests/security/test-cache-poisoning.sh
@@ -1,102 +1,233 @@
 #!/usr/bin/env bash
 # test-cache-poisoning.sh - T2-11: Proxy/remote repo cache poisoning prevention
 #
-# Verifies that content fetched through a remote (proxy) repo is integrity-checked.
-# Without a controllable mock upstream, the test validates the remote repo's behavior
-# with an unreachable upstream and checks that cached content is not served from
-# unexpected sources.
+# Verifies that content fetched through a remote (proxy) repo is integrity-checked
+# and that an attacker who briefly controls the upstream cannot retroactively
+# corrupt previously-cached, known-good content.
+#
+# Customer pain #1 (https://github.com/orgs/artifact-keeper/discussions/872):
+# the prior version of this suite skipped the load-bearing assertion with
+# "requires controllable mock HTTP upstream". This version stands up a real
+# mock upstream (tests/lib/mock-upstream.py), seeds known bytes, primes the
+# cache, swaps the upstream content for a different payload, and asserts that
+# the proxy serves the originally-cached bytes (or 502/503), never the
+# tampered payload.
+#
+# Hard constraint (issue artifact-keeper-test#67): this test must FAIL when
+# the backend is broken. Run with EXPECT_FAILURE=1 against a known-broken
+# build to validate the assertion is load-bearing.
 
 source "$(dirname "$0")/../lib/common.sh"
 
 begin_suite "cache-poisoning"
+
+# Pre-flight: the mock upstream needs python3, and the backend has to be able
+# to dial the mock from the cluster. We pass MOCK_UPSTREAM_HOSTNAME from CI;
+# in local-dev runs we skip with a clear reason rather than silently passing.
+# RELEASE_GATE=1 turns the skip into a hard fail (silent-success class).
+if ! command -v python3 >/dev/null 2>&1; then
+  skip_suite "python3 not available; cache-poisoning needs the mock upstream fixture"
+fi
+
+if [ -z "${MOCK_UPSTREAM_HOSTNAME:-}" ]; then
+  skip_suite "MOCK_UPSTREAM_HOSTNAME unset; CI must set this to a name the backend can resolve to the test runner pod (e.g. <pod-ip-dashed>.<ns>.pod.cluster.local)"
+fi
+
 auth_admin
 setup_workdir
 
+MOCK_PORT="${MOCK_UPSTREAM_PORT:-18080}"
+MOCK_STATE_DIR="${WORK_DIR}/mock-upstream"
+MOCK_BASE_URL="http://${MOCK_UPSTREAM_HOSTNAME}:${MOCK_PORT}"
 REMOTE_KEY="sec-cache-poison-${RUN_ID}"
 LOCAL_KEY="sec-cache-ref-${RUN_ID}"
+ARTIFACT_PATH="pkg/v1/payload.bin"
 
 # ---------------------------------------------------------------------------
-# Create a remote repo pointing to a nonexistent upstream
+# Boot the mock upstream
 # ---------------------------------------------------------------------------
 
-begin_test "Create remote repo with unreachable upstream"
-if create_remote_repo "$REMOTE_KEY" "generic" "https://nonexistent-upstream.invalid/repo"; then
+mkdir -p "${MOCK_STATE_DIR}/files/$(dirname "$ARTIFACT_PATH")"
+GOOD_CONTENT="known-good-content-${RUN_ID}"
+TAMPERED_CONTENT="tampered-by-attacker-${RUN_ID}"
+printf '%s\n' "$GOOD_CONTENT" > "${MOCK_STATE_DIR}/files/${ARTIFACT_PATH}"
+GOOD_SHA256=$(shasum -a 256 "${MOCK_STATE_DIR}/files/${ARTIFACT_PATH}" | awk '{print $1}')
+
+MOCK_PID=""
+start_mock() {
+  MOCK_STATE_DIR="$MOCK_STATE_DIR" MOCK_PORT="$MOCK_PORT" \
+    python3 "$(dirname "$0")/../lib/mock-upstream.py" \
+    > "${WORK_DIR}/mock.out" 2> "${WORK_DIR}/mock.err" &
+  MOCK_PID=$!
+  # Wait until the mock answers locally before announcing it to the backend.
+  for _ in $(seq 1 20); do
+    if curl -sf --max-time 2 "http://127.0.0.1:${MOCK_PORT}/${ARTIFACT_PATH}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
+stop_mock() {
+  if [ -n "$MOCK_PID" ] && kill -0 "$MOCK_PID" 2>/dev/null; then
+    kill "$MOCK_PID" 2>/dev/null || true
+    wait "$MOCK_PID" 2>/dev/null || true
+  fi
+}
+trap 'stop_mock; rm -rf "$WORK_DIR"' EXIT
+
+begin_test "Mock upstream starts and serves seeded content"
+if start_mock; then
   pass
 else
-  fail "could not create remote repo"
+  fail "mock upstream did not become reachable on 127.0.0.1:${MOCK_PORT} within 10s"
+  end_suite
 fi
 
 # ---------------------------------------------------------------------------
-# Attempt to fetch through the remote repo (should fail gracefully)
+# Create a remote repo pointing at the mock
 # ---------------------------------------------------------------------------
 
-begin_test "Fetch from remote repo with unreachable upstream returns error"
-status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+begin_test "Create remote repo pointing at the mock upstream"
+if create_remote_repo "$REMOTE_KEY" "generic" "$MOCK_BASE_URL"; then
+  pass
+else
+  fail "could not create remote repo for upstream ${MOCK_BASE_URL}"
+  end_suite
+fi
+
+# ---------------------------------------------------------------------------
+# Prime the cache: fetch the artifact through the proxy. The backend should
+# pull from the mock, store the bytes, and remember the sha256.
+# ---------------------------------------------------------------------------
+
+begin_test "Prime the proxy cache with known-good upstream content"
+prime_status=$(curl -s -o "${WORK_DIR}/prime.bin" -w '%{http_code}' $CURL_TIMEOUT \
   -H "$(auth_header)" \
-  "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/artifacts/nonexistent/pkg.tar.gz") || true
+  "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/${ARTIFACT_PATH}") || true
 
-if [ "$status" = "404" ] || [ "$status" = "502" ] || [ "$status" = "503" ] || [ "$status" = "504" ]; then
-  pass
-elif [ "$status" -ge 200 ] 2>/dev/null && [ "$status" -lt 300 ] 2>/dev/null; then
-  fail "remote repo returned 2xx for artifact from unreachable upstream (possible stale cache)"
-else
-  # Any other client/server error is acceptable
-  pass
+if assert_http_2xx "$prime_status" "prime fetch should succeed against a healthy mock upstream"; then
+  prime_sha=$(shasum -a 256 "${WORK_DIR}/prime.bin" | awk '{print $1}')
+  if assert_eq "$prime_sha" "$GOOD_SHA256" "primed cache should contain the seeded upstream bytes"; then
+    pass
+  fi
 fi
 
 # ---------------------------------------------------------------------------
-# Create a local repo and upload a reference artifact for comparison
+# Attacker step: swap the upstream payload for a different sha256. The mock
+# now serves the tampered content with a 200 OK. A correctly-implemented
+# proxy must NOT propagate the new bytes silently for the same cache key
+# while a known-good copy is on disk. Acceptable behaviors:
+#   - serve the previously-cached good bytes (cache hit, ignore upstream)
+#   - reject with 502/503 (refuse to overwrite verified content)
+# Forbidden behavior:
+#   - return 200 OK with the tampered bytes
 # ---------------------------------------------------------------------------
 
-begin_test "Create local reference repo"
-if create_local_repo "$LOCAL_KEY" "generic"; then
+printf '%s\n' "$TAMPERED_CONTENT" > "${MOCK_STATE_DIR}/files/${ARTIFACT_PATH}"
+TAMPERED_SHA256=$(shasum -a 256 "${MOCK_STATE_DIR}/files/${ARTIFACT_PATH}" | awk '{print $1}')
+
+begin_test "Tampered upstream content does not poison the proxy cache"
+post_status=$(curl -s -o "${WORK_DIR}/post.bin" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/${ARTIFACT_PATH}") || true
+
+post_sha=""
+if [ -f "${WORK_DIR}/post.bin" ]; then
+  post_sha=$(shasum -a 256 "${WORK_DIR}/post.bin" | awk '{print $1}')
+fi
+
+if [ "$post_sha" = "$TAMPERED_SHA256" ]; then
+  fail "proxy returned tampered upstream bytes (sha=${post_sha}) for previously-cached artifact: cache poisoning"
+elif [ "$post_status" = "502" ] || [ "$post_status" = "503" ] || [ "$post_status" = "504" ]; then
   pass
+elif [ "$post_sha" = "$GOOD_SHA256" ]; then
+  pass
+else
+  fail "post-tamper fetch returned HTTP ${post_status} sha=${post_sha:-<empty>} (neither cached-good nor 5xx)"
+fi
+
+# ---------------------------------------------------------------------------
+# When the upstream goes away entirely, the proxy must still serve the
+# known-good cached bytes (or fail loudly) -- never the tampered ones it
+# saw between prime and shutdown.
+# ---------------------------------------------------------------------------
+
+stop_mock
+
+begin_test "Proxy serves cached good bytes (or 5xx) when upstream is unreachable"
+offline_status=$(curl -s -o "${WORK_DIR}/offline.bin" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/${ARTIFACT_PATH}") || true
+
+offline_sha=""
+if [ -f "${WORK_DIR}/offline.bin" ]; then
+  offline_sha=$(shasum -a 256 "${WORK_DIR}/offline.bin" | awk '{print $1}')
+fi
+
+if [ "$offline_sha" = "$TAMPERED_SHA256" ]; then
+  fail "proxy served tampered bytes after upstream went offline: tampered payload was cached"
+elif [ "$offline_sha" = "$GOOD_SHA256" ]; then
+  pass
+elif [ "$offline_status" = "502" ] || [ "$offline_status" = "503" ] || [ "$offline_status" = "504" ] || [ "$offline_status" = "404" ]; then
+  pass
+else
+  fail "offline fetch returned HTTP ${offline_status} sha=${offline_sha:-<empty>} (neither cached-good nor 5xx)"
+fi
+
+# ---------------------------------------------------------------------------
+# Cross-repo isolation: a remote repo MUST NOT serve content from an unrelated
+# local repo even when the path matches. This catches the "cross-repo cache
+# leak" class of bugs where the storage layer keys cache entries by path
+# alone instead of (repo_id, path).
+# ---------------------------------------------------------------------------
+
+begin_test "Create local reference repo and upload distinct content"
+if create_local_repo "$LOCAL_KEY" "generic"; then
+  echo "${GOOD_CONTENT}" > "${WORK_DIR}/reference.bin"
+  if api_upload "/api/v1/repositories/${LOCAL_KEY}/artifacts/${ARTIFACT_PATH}" \
+      "${WORK_DIR}/reference.bin"; then
+    pass
+  else
+    fail "could not upload reference artifact"
+  fi
 else
   fail "could not create local reference repo"
 fi
 
-begin_test "Upload reference artifact to local repo"
-echo "reference-content-${RUN_ID}" > "${WORK_DIR}/reference.bin"
-REF_SHA256=$(shasum -a 256 "${WORK_DIR}/reference.bin" | awk '{print $1}')
-if api_upload "/api/v1/repositories/${LOCAL_KEY}/artifacts/ref-pkg/v1/reference.bin" \
-    "${WORK_DIR}/reference.bin"; then
-  pass
-else
-  fail "could not upload reference artifact"
-fi
-
-# ---------------------------------------------------------------------------
-# Verify that remote repo does not serve local repo content (cross-repo leak)
-# ---------------------------------------------------------------------------
-
 begin_test "Remote repo does not serve content from unrelated local repo"
-status=$(curl -s -o "${WORK_DIR}/cross-check.bin" -w '%{http_code}' $CURL_TIMEOUT \
+cross_status=$(curl -s -o "${WORK_DIR}/cross.bin" -w '%{http_code}' $CURL_TIMEOUT \
   -H "$(auth_header)" \
-  "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/artifacts/ref-pkg/v1/reference.bin") || true
+  "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/${ARTIFACT_PATH}") || true
 
-if [ "$status" = "404" ] || [ "$status" = "502" ] || [ "$status" = "503" ]; then
-  pass
-elif [ "$status" -ge 200 ] 2>/dev/null && [ "$status" -lt 300 ] 2>/dev/null; then
-  # Check if it somehow returned the local repo's content
-  if [ -f "${WORK_DIR}/cross-check.bin" ]; then
-    cross_sha=$(shasum -a 256 "${WORK_DIR}/cross-check.bin" | awk '{print $1}')
-    if [ "$cross_sha" = "$REF_SHA256" ]; then
-      fail "remote repo served content from unrelated local repo (cross-repo cache poisoning)"
-    else
-      fail "remote repo served unknown content for artifact from unreachable upstream"
-    fi
+# Whatever bytes (if any) the remote serves must NOT be the local repo's
+# content. Either 5xx/404 (mock is down, no cache hit) or the previously-
+# cached good bytes from the mock are acceptable.
+if [ -s "${WORK_DIR}/cross.bin" ] && [ "$cross_status" -ge 200 ] 2>/dev/null && [ "$cross_status" -lt 300 ] 2>/dev/null; then
+  cross_sha=$(shasum -a 256 "${WORK_DIR}/cross.bin" | awk '{print $1}')
+  ref_sha=$(shasum -a 256 "${WORK_DIR}/reference.bin" | awk '{print $1}')
+  # If the cached upstream content happened to be byte-equal to the local
+  # reference (we deliberately chose the same string for both -- the test
+  # is about isolation, not byte-distinguishability), distinguishing
+  # repos requires a different probe. Use a path that the local repo has
+  # but the mock NEVER served.
+  status_only_local=$(curl -s -o "${WORK_DIR}/cross-only.bin" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/never-fetched-from-mock-${RUN_ID}.bin") || true
+  if [ "$status_only_local" -ge 200 ] 2>/dev/null && [ "$status_only_local" -lt 300 ] 2>/dev/null; then
+    fail "remote repo served content for a path the mock never had (cross-repo or unauthenticated cache leak)"
   else
-    fail "remote repo returned 2xx but no content"
+    if [ "$cross_sha" = "$ref_sha" ] && [ "$cross_sha" != "$GOOD_SHA256" ]; then
+      fail "remote repo served local-repo-only content"
+    else
+      pass
+    fi
   fi
+elif [ "$cross_status" = "404" ] || [ "$cross_status" = "502" ] || [ "$cross_status" = "503" ] || [ "$cross_status" = "504" ]; then
+  pass
 else
   pass
 fi
-
-# ---------------------------------------------------------------------------
-# Note: full cache poisoning test requires a controllable mock upstream
-# ---------------------------------------------------------------------------
-
-begin_test "Full upstream content tampering verification"
-skip "requires a controllable mock HTTP upstream to inject tampered content; deploy a mock server in the test namespace to enable this test"
 
 end_suite

--- a/tests/security/test-cache-stampede.sh
+++ b/tests/security/test-cache-stampede.sh
@@ -16,14 +16,19 @@
 #
 #   2. When the queue saturates and queue_timeout fires, the backend rejects
 #      with 503 (queue full) -- it does NOT silently dispatch every request.
-#      We can only assert this if PROXY_QUEUE_TIMEOUT_SECS was set short
-#      enough relative to the per-request mock delay; tests pass-through if
-#      the env wasn't tuned.
+#      We only assert this when PROXY_QUEUE_TIMEOUT_SECS is short enough
+#      relative to the per-request mock delay; otherwise informational.
+#
+# Backend dependency: this test exercises a semaphore that does not exist in
+# v1.1.x. It is gated behind require_feature "proxy_stampede_protection"
+# (minimum backend version: 1.2.0) so older builds skip cleanly. When the
+# backend feature lands, bump the version in tests/lib/common.sh's
+# _feature_min_version map.
 #
 # Hard constraint (issue artifact-keeper-test#67): this test must FAIL when
-# the backend is broken. To self-verify, run against a backend image with
-# the semaphore disabled and confirm the assertion at line ~155 fails with
-# "peak in-flight ${peak} exceeded limit ${LIMIT}".
+# the backend is broken. To self-verify, run with EXPECT_FAILURE=1 against
+# a backend image with the semaphore disabled and confirm the assertion
+# at "Peak upstream in-flight does not exceed..." fails.
 
 source "$(dirname "$0")/../lib/common.sh"
 
@@ -40,67 +45,41 @@ fi
 auth_admin
 setup_workdir
 
+# Feature gate: skip if the backend version does not ship the proxy semaphore.
+# require_feature emits a SKIP testcase via skip(); under RELEASE_GATE=1 this
+# is fine because the suite-level skip (skip_suite) is what hard-fails, not
+# individual feature-gated tests on older backends.
+begin_test "Backend supports proxy stampede protection"
+require_feature "proxy_stampede_protection" || { end_suite; }
+pass
+
 # Knobs. Tests honor PROXY_MAX_CONCURRENT_FETCHES if CI passed it through so
-# we know what limit to assert against; otherwise we use the documented
-# default of 20 and just verify peak <= 20 with N strictly greater.
+# we know what limit to assert against. CI MUST set this for the assertion to
+# be deterministic across chart default changes.
 LIMIT="${PROXY_MAX_CONCURRENT_FETCHES:-20}"
 N="${STAMPEDE_CONCURRENCY:-$(( LIMIT * 2 + 5 ))}"
 UPSTREAM_DELAY_MS="${STAMPEDE_UPSTREAM_DELAY_MS:-2000}"
 QUEUE_TIMEOUT_SECS="${PROXY_QUEUE_TIMEOUT_SECS:-30}"
 
-MOCK_PORT="${MOCK_UPSTREAM_PORT:-18080}"
-MOCK_STATE_DIR="${WORK_DIR}/mock-upstream"
-MOCK_BASE_URL="http://${MOCK_UPSTREAM_HOSTNAME}:${MOCK_PORT}"
 REMOTE_KEY="sec-stampede-${RUN_ID}"
-
-mkdir -p "${MOCK_STATE_DIR}/files"
 ARTIFACT_PATH="herd/v1/payload.bin"
-mkdir -p "${MOCK_STATE_DIR}/files/$(dirname "$ARTIFACT_PATH")"
-# Distinct payload per run so prior cache state from a flaky prior run can't
-# satisfy the stampede locally and silently zero out the assertion.
-PAYLOAD="stampede-payload-${RUN_ID}"
-printf '%s\n' "$PAYLOAD" > "${MOCK_STATE_DIR}/files/${ARTIFACT_PATH}"
-printf '%s\n' "$UPSTREAM_DELAY_MS" > "${MOCK_STATE_DIR}/delay-ms"
 
 # ---------------------------------------------------------------------------
-# Boot the mock upstream
+# Boot the mock upstream, seed a per-run-unique payload, and inject a delay
+# so concurrent fetches actually overlap on the upstream side.
 # ---------------------------------------------------------------------------
-
-MOCK_PID=""
-start_mock() {
-  MOCK_STATE_DIR="$MOCK_STATE_DIR" MOCK_PORT="$MOCK_PORT" \
-    python3 "$(dirname "$0")/../lib/mock-upstream.py" \
-    > "${WORK_DIR}/mock.out" 2> "${WORK_DIR}/mock.err" &
-  MOCK_PID=$!
-  for _ in $(seq 1 20); do
-    # Probe with a path the mock has zero-delay handling for: it doesn't,
-    # so we just wait on TCP readiness.
-    if curl -sf --max-time 2 -o /dev/null "http://127.0.0.1:${MOCK_PORT}/__readyz" 2>/dev/null; then
-      return 0
-    fi
-    # 404 also means "server up". Accept any response that isn't connect-refused.
-    code=$(curl -s --max-time 2 -o /dev/null -w '%{http_code}' "http://127.0.0.1:${MOCK_PORT}/__readyz" 2>/dev/null) || code="000"
-    if [ "$code" != "000" ]; then
-      return 0
-    fi
-    sleep 0.5
-  done
-  return 1
-}
-
-stop_mock() {
-  if [ -n "$MOCK_PID" ] && kill -0 "$MOCK_PID" 2>/dev/null; then
-    kill "$MOCK_PID" 2>/dev/null || true
-    wait "$MOCK_PID" 2>/dev/null || true
-  fi
-}
-trap 'stop_mock; rm -rf "$WORK_DIR"' EXIT
 
 begin_test "Mock upstream starts"
-if start_mock; then
+if start_mock_upstream "${WORK_DIR}/mock-state"; then
+  mkdir -p "${MOCK_STATE_DIR}/files/$(dirname "$ARTIFACT_PATH")"
+  # Distinct payload per run so prior cache state from a flaky prior run
+  # cannot satisfy the stampede locally and silently zero out the assertion.
+  PAYLOAD="stampede-payload-${RUN_ID}"
+  printf '%s\n' "$PAYLOAD" > "${MOCK_STATE_DIR}/files/${ARTIFACT_PATH}"
+  printf '%s\n' "$UPSTREAM_DELAY_MS" > "${MOCK_STATE_DIR}/delay-ms"
   pass
 else
-  fail "mock upstream did not become reachable on 127.0.0.1:${MOCK_PORT}"
+  fail "mock upstream did not boot"
   end_suite
 fi
 
@@ -125,18 +104,31 @@ fi
 begin_test "Fire ${N} concurrent GETs against cold proxy cache (limit=${LIMIT}, delay=${UPSTREAM_DELAY_MS}ms)"
 mkdir -p "${WORK_DIR}/results"
 
+# Per-curl timeout: queue wait + upstream RTT + slack. Keep this tight enough
+# that a wedged backend produces "000" rather than blocking until the job
+# timeout.
+PER_REQ_TIMEOUT=$(( QUEUE_TIMEOUT_SECS + UPSTREAM_DELAY_MS / 1000 + 30 ))
+
 START_TS=$(date +%s)
+# Collect only the curl subshell PIDs so we can wait on them specifically.
+# A bare `wait` would also block on the mock-upstream python child that
+# start_mock_upstream backgrounded earlier (the mock is long-lived and never
+# exits during the test), wedging the script forever.
+declare -a curl_pids=()
 for i in $(seq 1 "$N"); do
   (
     status=$(curl -s -o /dev/null -w '%{http_code}' \
-      --max-time $(( QUEUE_TIMEOUT_SECS + UPSTREAM_DELAY_MS / 1000 + 30 )) \
+      --max-time "$PER_REQ_TIMEOUT" \
       --connect-timeout 10 \
       -H "$(auth_header)" \
       "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/${ARTIFACT_PATH}") || status="000"
     echo "$status" > "${WORK_DIR}/results/req-${i}.status"
   ) &
+  curl_pids+=($!)
 done
-wait
+for pid in "${curl_pids[@]}"; do
+  wait "$pid" || true
+done
 END_TS=$(date +%s)
 echo "  elapsed: $(( END_TS - START_TS ))s"
 pass
@@ -162,16 +154,14 @@ done
 echo "  outcomes: success=${success_count} queue_full=${queue_full_count} other=${other_count}"
 
 # ---------------------------------------------------------------------------
-# Read mock counters: peak concurrent in-flight upstream fetches and the
-# total number of upstream GETs the backend issued for this artifact.
+# Read mock counters via bounded poll. wait_for_counter_stable returns once
+# peak-inflight has not changed for ~0.6s, which is strictly safer than the
+# previous `sleep 1` and bounds the wait at 5s.
 # ---------------------------------------------------------------------------
 
-# Mock writes peak-inflight and request-count.* during request handling.
-# Allow a brief flush window since file writes are async w.r.t. our wait.
-sleep 1
-
-peak=$(cat "${MOCK_STATE_DIR}/peak-inflight" 2>/dev/null || echo 0)
-upstream_count_key=$(echo "$ARTIFACT_PATH" | tr '/' '_')
+peak=$(wait_for_counter_stable "${MOCK_STATE_DIR}/peak-inflight" 5 0.6 || true)
+peak="${peak:-0}"
+upstream_count_key=$(echo "$ARTIFACT_PATH" | tr '/' '_' | tr -dc 'A-Za-z0-9_.-' | cut -c1-128)
 upstream_count=$(cat "${MOCK_STATE_DIR}/request-count.${upstream_count_key}" 2>/dev/null || echo 0)
 echo "  upstream peak in-flight: ${peak}"
 echo "  upstream total fetches:  ${upstream_count}"
@@ -187,7 +177,7 @@ if [ "$peak" -le "$LIMIT" ]; then
   if [ "$peak" -gt 0 ]; then
     pass
   else
-    fail "mock recorded zero upstream traffic; either backend served from a stale cache, the proxy never dialed the mock, or the mock-upstream hostname is unreachable from the backend pod"
+    fail "mock recorded zero upstream traffic; either the proxy never dialed the mock or MOCK_UPSTREAM_HOSTNAME is unreachable from the backend pod (mock.err: $(tail -3 "${WORK_DIR}/mock.err" 2>/dev/null | tr '\n' ' '))"
   fi
 else
   fail "peak upstream in-flight ${peak} exceeded configured limit ${LIMIT}: stampede protection is off"
@@ -216,8 +206,6 @@ fi
 
 begin_test "When N > limit and queue_timeout is short, queue-full responses appear"
 expected_queueing=0
-# Heuristic: if N > LIMIT and the per-request delay times the overflow exceeds
-# queue_timeout, requests should hit the timeout path.
 overflow=$(( N - LIMIT ))
 projected_wait_secs=$(( overflow * UPSTREAM_DELAY_MS / 1000 / LIMIT ))
 if [ "$overflow" -gt 0 ] && [ "$projected_wait_secs" -gt "$QUEUE_TIMEOUT_SECS" ]; then
@@ -236,9 +224,8 @@ fi
 
 # ---------------------------------------------------------------------------
 # Assertion #4: a follow-up fetch hits the cache. Coalescing (single-flight)
-# is not implemented in v1.1.x, so upstream_count >= 1 is acceptable; what
-# matters is that ONCE the cache is warm, no additional upstream traffic
-# is generated.
+# is not required for this assertion; what matters is that ONCE the cache is
+# warm, no additional upstream traffic is generated for a repeat fetch.
 # ---------------------------------------------------------------------------
 
 begin_test "Post-stampede fetch is served from cache (no additional upstream traffic)"
@@ -246,14 +233,38 @@ pre_count="$upstream_count"
 followup_status=$(curl -s -o "${WORK_DIR}/followup.bin" -w '%{http_code}' $CURL_TIMEOUT \
   -H "$(auth_header)" \
   "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/${ARTIFACT_PATH}") || true
-sleep 1
-post_count=$(cat "${MOCK_STATE_DIR}/request-count.${upstream_count_key}" 2>/dev/null || echo 0)
+
+# Bounded poll for counter stability instead of sleep 1.
+post_count=$(wait_for_counter_stable "${MOCK_STATE_DIR}/request-count.${upstream_count_key}" 3 0.4 || true)
+post_count="${post_count:-$pre_count}"
 
 if assert_http_2xx "$followup_status" "follow-up fetch should hit cache and return 2xx"; then
   if [ "$post_count" = "$pre_count" ]; then
     pass
   else
     fail "follow-up fetch generated extra upstream traffic (pre=${pre_count} post=${post_count}): cache write/read path is broken"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion #5: content integrity check across the stampede. The successful
+# 2xx responses must each have returned the seeded payload bytes; an empty
+# or upstream-error body that the proxy mistook for "200 OK" would slip past
+# status-code-only checks.
+# ---------------------------------------------------------------------------
+
+begin_test "Stampede response body matches seeded payload"
+verify_status=$(curl -s -o "${WORK_DIR}/verify.bin" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/${ARTIFACT_PATH}") || true
+
+if assert_http_2xx "$verify_status" "verification fetch should return 2xx"; then
+  expected_sha=$(shasum -a 256 "${MOCK_STATE_DIR}/files/${ARTIFACT_PATH}" | awk '{print $1}')
+  got_sha=$(shasum -a 256 "${WORK_DIR}/verify.bin" | awk '{print $1}')
+  if [ "$got_sha" = "$expected_sha" ]; then
+    pass
+  else
+    fail "stampede 2xx body sha=${got_sha} != upstream sha=${expected_sha}: cache may have stored a partial or upstream-error body"
   fi
 fi
 

--- a/tests/security/test-cache-stampede.sh
+++ b/tests/security/test-cache-stampede.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# test-cache-stampede.sh - T2-12: Cache stampede / thundering-herd prevention
+#
+# When N concurrent clients ask the proxy for the same uncached artifact, a
+# correctly-sized backend bounds peak upstream concurrency at
+# `proxy_max_concurrent_fetches` (default 20). A broken backend forwards all
+# N requests upstream simultaneously and either drowns the upstream, blows
+# its memory budget, or both. Customer pain #1
+# (https://github.com/orgs/artifact-keeper/discussions/872) was triggered by
+# this exact failure mode in v1.1.7.
+#
+# This suite verifies two assertions, in order of importance:
+#
+#   1. Peak upstream in-flight count <= proxy_max_concurrent_fetches.
+#      Measured by the mock upstream's own per-handler counter.
+#
+#   2. When the queue saturates and queue_timeout fires, the backend rejects
+#      with 503 (queue full) -- it does NOT silently dispatch every request.
+#      We can only assert this if PROXY_QUEUE_TIMEOUT_SECS was set short
+#      enough relative to the per-request mock delay; tests pass-through if
+#      the env wasn't tuned.
+#
+# Hard constraint (issue artifact-keeper-test#67): this test must FAIL when
+# the backend is broken. To self-verify, run against a backend image with
+# the semaphore disabled and confirm the assertion at line ~155 fails with
+# "peak in-flight ${peak} exceeded limit ${LIMIT}".
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "cache-stampede"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  skip_suite "python3 not available; cache-stampede needs the mock upstream fixture"
+fi
+
+if [ -z "${MOCK_UPSTREAM_HOSTNAME:-}" ]; then
+  skip_suite "MOCK_UPSTREAM_HOSTNAME unset; CI must set this to a name the backend can resolve to the test runner pod"
+fi
+
+auth_admin
+setup_workdir
+
+# Knobs. Tests honor PROXY_MAX_CONCURRENT_FETCHES if CI passed it through so
+# we know what limit to assert against; otherwise we use the documented
+# default of 20 and just verify peak <= 20 with N strictly greater.
+LIMIT="${PROXY_MAX_CONCURRENT_FETCHES:-20}"
+N="${STAMPEDE_CONCURRENCY:-$(( LIMIT * 2 + 5 ))}"
+UPSTREAM_DELAY_MS="${STAMPEDE_UPSTREAM_DELAY_MS:-2000}"
+QUEUE_TIMEOUT_SECS="${PROXY_QUEUE_TIMEOUT_SECS:-30}"
+
+MOCK_PORT="${MOCK_UPSTREAM_PORT:-18080}"
+MOCK_STATE_DIR="${WORK_DIR}/mock-upstream"
+MOCK_BASE_URL="http://${MOCK_UPSTREAM_HOSTNAME}:${MOCK_PORT}"
+REMOTE_KEY="sec-stampede-${RUN_ID}"
+
+mkdir -p "${MOCK_STATE_DIR}/files"
+ARTIFACT_PATH="herd/v1/payload.bin"
+mkdir -p "${MOCK_STATE_DIR}/files/$(dirname "$ARTIFACT_PATH")"
+# Distinct payload per run so prior cache state from a flaky prior run can't
+# satisfy the stampede locally and silently zero out the assertion.
+PAYLOAD="stampede-payload-${RUN_ID}"
+printf '%s\n' "$PAYLOAD" > "${MOCK_STATE_DIR}/files/${ARTIFACT_PATH}"
+printf '%s\n' "$UPSTREAM_DELAY_MS" > "${MOCK_STATE_DIR}/delay-ms"
+
+# ---------------------------------------------------------------------------
+# Boot the mock upstream
+# ---------------------------------------------------------------------------
+
+MOCK_PID=""
+start_mock() {
+  MOCK_STATE_DIR="$MOCK_STATE_DIR" MOCK_PORT="$MOCK_PORT" \
+    python3 "$(dirname "$0")/../lib/mock-upstream.py" \
+    > "${WORK_DIR}/mock.out" 2> "${WORK_DIR}/mock.err" &
+  MOCK_PID=$!
+  for _ in $(seq 1 20); do
+    # Probe with a path the mock has zero-delay handling for: it doesn't,
+    # so we just wait on TCP readiness.
+    if curl -sf --max-time 2 -o /dev/null "http://127.0.0.1:${MOCK_PORT}/__readyz" 2>/dev/null; then
+      return 0
+    fi
+    # 404 also means "server up". Accept any response that isn't connect-refused.
+    code=$(curl -s --max-time 2 -o /dev/null -w '%{http_code}' "http://127.0.0.1:${MOCK_PORT}/__readyz" 2>/dev/null) || code="000"
+    if [ "$code" != "000" ]; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
+stop_mock() {
+  if [ -n "$MOCK_PID" ] && kill -0 "$MOCK_PID" 2>/dev/null; then
+    kill "$MOCK_PID" 2>/dev/null || true
+    wait "$MOCK_PID" 2>/dev/null || true
+  fi
+}
+trap 'stop_mock; rm -rf "$WORK_DIR"' EXIT
+
+begin_test "Mock upstream starts"
+if start_mock; then
+  pass
+else
+  fail "mock upstream did not become reachable on 127.0.0.1:${MOCK_PORT}"
+  end_suite
+fi
+
+# ---------------------------------------------------------------------------
+# Create the remote repo. We deliberately do NOT prime the cache: the test
+# is about what happens when N concurrent clients all hit a cold cache key.
+# ---------------------------------------------------------------------------
+
+begin_test "Create remote repo pointing at slow mock upstream"
+if create_remote_repo "$REMOTE_KEY" "generic" "$MOCK_BASE_URL"; then
+  pass
+else
+  fail "could not create remote repo for upstream ${MOCK_BASE_URL}"
+  end_suite
+fi
+
+# ---------------------------------------------------------------------------
+# Fire N concurrent GETs at the cold cache. Capture each request's HTTP
+# status so we can classify outcomes.
+# ---------------------------------------------------------------------------
+
+begin_test "Fire ${N} concurrent GETs against cold proxy cache (limit=${LIMIT}, delay=${UPSTREAM_DELAY_MS}ms)"
+mkdir -p "${WORK_DIR}/results"
+
+START_TS=$(date +%s)
+for i in $(seq 1 "$N"); do
+  (
+    status=$(curl -s -o /dev/null -w '%{http_code}' \
+      --max-time $(( QUEUE_TIMEOUT_SECS + UPSTREAM_DELAY_MS / 1000 + 30 )) \
+      --connect-timeout 10 \
+      -H "$(auth_header)" \
+      "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/${ARTIFACT_PATH}") || status="000"
+    echo "$status" > "${WORK_DIR}/results/req-${i}.status"
+  ) &
+done
+wait
+END_TS=$(date +%s)
+echo "  elapsed: $(( END_TS - START_TS ))s"
+pass
+
+# ---------------------------------------------------------------------------
+# Classify outcomes.
+# ---------------------------------------------------------------------------
+
+success_count=0
+queue_full_count=0
+other_count=0
+for i in $(seq 1 "$N"); do
+  s=$(cat "${WORK_DIR}/results/req-${i}.status" 2>/dev/null || echo "000")
+  if [ "$s" -ge 200 ] 2>/dev/null && [ "$s" -lt 300 ] 2>/dev/null; then
+    success_count=$(( success_count + 1 ))
+  elif [ "$s" = "503" ]; then
+    queue_full_count=$(( queue_full_count + 1 ))
+  else
+    other_count=$(( other_count + 1 ))
+    echo "  req-${i}: HTTP ${s}"
+  fi
+done
+echo "  outcomes: success=${success_count} queue_full=${queue_full_count} other=${other_count}"
+
+# ---------------------------------------------------------------------------
+# Read mock counters: peak concurrent in-flight upstream fetches and the
+# total number of upstream GETs the backend issued for this artifact.
+# ---------------------------------------------------------------------------
+
+# Mock writes peak-inflight and request-count.* during request handling.
+# Allow a brief flush window since file writes are async w.r.t. our wait.
+sleep 1
+
+peak=$(cat "${MOCK_STATE_DIR}/peak-inflight" 2>/dev/null || echo 0)
+upstream_count_key=$(echo "$ARTIFACT_PATH" | tr '/' '_')
+upstream_count=$(cat "${MOCK_STATE_DIR}/request-count.${upstream_count_key}" 2>/dev/null || echo 0)
+echo "  upstream peak in-flight: ${peak}"
+echo "  upstream total fetches:  ${upstream_count}"
+
+# ---------------------------------------------------------------------------
+# Load-bearing assertion #1: peak upstream concurrency must not exceed the
+# configured semaphore limit. This is THE assertion that fails on a broken
+# backend (semaphore disabled / limit raised / fetch path bypassed).
+# ---------------------------------------------------------------------------
+
+begin_test "Peak upstream in-flight does not exceed proxy_max_concurrent_fetches (${LIMIT})"
+if [ "$peak" -le "$LIMIT" ]; then
+  if [ "$peak" -gt 0 ]; then
+    pass
+  else
+    fail "mock recorded zero upstream traffic; either backend served from a stale cache, the proxy never dialed the mock, or the mock-upstream hostname is unreachable from the backend pod"
+  fi
+else
+  fail "peak upstream in-flight ${peak} exceeded configured limit ${LIMIT}: stampede protection is off"
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion #2: at least one request was served. With a working semaphore
+# and a non-trivial delay, the first wave succeeds; the rest either queue
+# (and succeed once a permit frees up) or 503 if queue_timeout fires.
+# ---------------------------------------------------------------------------
+
+begin_test "At least one client receives a successful proxy response"
+if [ "$success_count" -ge 1 ]; then
+  pass
+else
+  fail "no client got a 2xx response (success=${success_count} queue_full=${queue_full_count} other=${other_count}): proxy is wedged"
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion #3: if N exceeds limit AND queue_timeout was tuned short, we
+# expect SOME 503s. This is informational on default settings (queue
+# timeout of 30s usually long enough that everyone eventually gets in) so
+# we treat it as a soft assertion: skip when N <= LIMIT or the timeout is
+# generous.
+# ---------------------------------------------------------------------------
+
+begin_test "When N > limit and queue_timeout is short, queue-full responses appear"
+expected_queueing=0
+# Heuristic: if N > LIMIT and the per-request delay times the overflow exceeds
+# queue_timeout, requests should hit the timeout path.
+overflow=$(( N - LIMIT ))
+projected_wait_secs=$(( overflow * UPSTREAM_DELAY_MS / 1000 / LIMIT ))
+if [ "$overflow" -gt 0 ] && [ "$projected_wait_secs" -gt "$QUEUE_TIMEOUT_SECS" ]; then
+  expected_queueing=1
+fi
+
+if [ "$expected_queueing" -eq 1 ]; then
+  if [ "$queue_full_count" -ge 1 ]; then
+    pass
+  else
+    fail "expected at least one 503 (overflow=${overflow}, projected_wait=${projected_wait_secs}s, queue_timeout=${QUEUE_TIMEOUT_SECS}s) but saw none: queue_timeout enforcement may be broken"
+  fi
+else
+  skip "queueing not expected with N=${N}, LIMIT=${LIMIT}, delay=${UPSTREAM_DELAY_MS}ms, queue_timeout=${QUEUE_TIMEOUT_SECS}s; tune PROXY_QUEUE_TIMEOUT_SECS or STAMPEDE_UPSTREAM_DELAY_MS to exercise this branch"
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion #4: a follow-up fetch hits the cache. Coalescing (single-flight)
+# is not implemented in v1.1.x, so upstream_count >= 1 is acceptable; what
+# matters is that ONCE the cache is warm, no additional upstream traffic
+# is generated.
+# ---------------------------------------------------------------------------
+
+begin_test "Post-stampede fetch is served from cache (no additional upstream traffic)"
+pre_count="$upstream_count"
+followup_status=$(curl -s -o "${WORK_DIR}/followup.bin" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REMOTE_KEY}/download/${ARTIFACT_PATH}") || true
+sleep 1
+post_count=$(cat "${MOCK_STATE_DIR}/request-count.${upstream_count_key}" 2>/dev/null || echo 0)
+
+if assert_http_2xx "$followup_status" "follow-up fetch should hit cache and return 2xx"; then
+  if [ "$post_count" = "$pre_count" ]; then
+    pass
+  else
+    fail "follow-up fetch generated extra upstream traffic (pre=${pre_count} post=${post_count}): cache write/read path is broken"
+  fi
+fi
+
+end_suite


### PR DESCRIPTION
## Summary

Closes the load-bearing assertion gap in `tests/security/test-cache-poisoning.sh` and adds a new stampede / thundering-herd gate. Both target the cache-reliability epic for v1.1.9 (issue #67), which traces back to customer pain #1 (org discussion #872).

The previous poisoning test ended with `skip "requires a controllable mock HTTP upstream"`, so the assertion that actually catches a poisoned cache never ran. A regression that propagated tampered upstream bytes for a previously-cached artifact would have stayed green.

## Changes

- `tests/lib/mock-upstream.py` (new, ~110 lines)
  - Serves bytes from a state directory
  - Logs every request with a unix timestamp
  - Tracks peak concurrent in-flight handlers (the metric the stampede test asserts on)
  - `/__readyz` bypass for fixture readiness probes (no log/counter/delay pollution)

- `tests/security/test-cache-poisoning.sh` (rewritten)
  - Stands up the mock upstream
  - Primes the proxy cache with known-good bytes
  - Swaps the upstream payload for a different sha256
  - Asserts the proxy serves the cached good bytes (or 5xx), never the tampered ones
  - Exercises the upstream-offline branch
  - Adds a cross-repo isolation probe (no shared cache leak)

- `tests/security/test-cache-stampede.sh` (new)
  - Fires `N = 2 * LIMIT + 5` concurrent GETs at a cold cache key against a slow upstream
  - Load-bearing assertion: peak upstream in-flight <= `proxy_max_concurrent_fetches`. Fails when the semaphore is removed or the limit is bypassed.
  - Soft assertions: at least one 2xx, expected 503s when overflow exceeds `queue_timeout`, follow-up fetch hits cache.

## Skip semantics (silent-success guard)

Both tests honor the existing `skip_suite` contract: if `MOCK_UPSTREAM_HOSTNAME` is unset (local dev), the suite skips with a precise reason. Under `RELEASE_GATE=1`, the same skip turns into a hard fail so a misconfigured CI run cannot silently pass.

## Test plan

- [ ] CI green on a healthy backend image
- [ ] Run against a backend with `proxy_max_concurrent_fetches` removed and confirm test-cache-stampede.sh fails on the peak-in-flight assertion
- [ ] Run against a backend that drops the cache-checksum check and confirm test-cache-poisoning.sh fails on the tampered-payload assertion
- [ ] Local dev run (no `MOCK_UPSTREAM_HOSTNAME`) skips cleanly
- [ ] `bash -n` and `shellcheck` pass on both scripts (verified)