### PR TITLE
fix(test-framework): EXPECT_FAILURE inversion + webhook-tests TEST_TIMEOUT bump

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -610,6 +610,10 @@ jobs:
       # A silently-skipped test in release-gate context is exactly the
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
+      # Per-script timeout for run-suite.sh. Webhook resilience tests
+      # poll for retry/dead-letter behavior on schedules up to 180s
+      # (WEBHOOK_RETRY_TIMEOUT) so the wrapping timeout must exceed that.
+      TEST_TIMEOUT: '300'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/tests/test-expect-failure-self.sh
+++ b/scripts/tests/test-expect-failure-self.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Self-test for the EXPECT_FAILURE=1 inversion in tests/lib/common.sh.
+# Verifies the four truth-table cases:
+#
+#   default   + pass()  -> exit 0
+#   default   + fail()  -> exit 1
+#   EXPECT=1  + pass()  -> exit 1   (test author expected a failure, didn't get one)
+#   EXPECT=1  + fail()  -> exit 0   (test author expected a failure, got it)
+#
+# Run from repo root: bash scripts/tests/test-expect-failure-self.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TMP_OUT=$(mktemp -d)
+trap 'rm -rf "$TMP_OUT"' EXIT
+
+inner_suite() {
+  local outcome="$1"  # "pass" or "fail"
+  cat <<INNER
+source "${REPO_ROOT}/tests/lib/common.sh"
+JUNIT_OUTPUT_DIR="${TMP_OUT}"
+begin_suite "self-test"
+begin_test "stub"
+${outcome} "self-test stub"
+end_suite
+INNER
+}
+
+run_case() {
+  local label="$1" expect="$2" outcome="$3" want_exit="$4"
+  local actual
+  EXPECT_FAILURE="$expect" bash -c "$(inner_suite "$outcome")" >/dev/null 2>&1
+  actual=$?
+  if [ "$actual" = "$want_exit" ]; then
+    echo "  PASS: ${label} (exit=${actual})"
+    return 0
+  fi
+  echo "  FAIL: ${label} expected exit=${want_exit} got exit=${actual}"
+  return 1
+}
+
+fails=0
+run_case "default + pass()       -> exit 0" "0" "pass" "0" || fails=$((fails+1))
+run_case "default + fail()       -> exit 1" "0" "fail" "1" || fails=$((fails+1))
+run_case "EXPECT_FAILURE + fail()-> exit 0" "1" "fail" "0" || fails=$((fails+1))
+run_case "EXPECT_FAILURE + pass()-> exit 1" "1" "pass" "1" || fails=$((fails+1))
+
+echo ""
+if [ "$fails" -eq 0 ]; then
+  echo "All EXPECT_FAILURE truth-table cases passed."
+  exit 0
+fi
+echo "${fails} case(s) failed."
+exit 1


### PR DESCRIPTION
## Summary

Two small test-framework fixes blocking the webhook v2 E2E rewrite (#85):

- `tests/lib/common.sh` — move `EXPECT_FAILURE=1` inversion into `end_suite` where the canonical `_FAIL_COUNT` tally lives. The previous trap-based pattern compared against `$?` which fail() does not set, masking real failures. Adds `scripts/tests/test-expect-failure-self.sh` exercising the four-case truth table.
- `.github/workflows/release-gate.yml` — bump `TEST_TIMEOUT` for the `webhook-tests` job from the default 120s to 300s, since webhook resilience scripts poll on schedules up to `WEBHOOK_RETRY_TIMEOUT=180s`.

Both changes are independent of the webhooks v2 backend epic (artifact-keeper#919) and benefit any test suite, not just webhooks.

## Closes

- Closes #88 (TEST_TIMEOUT bump)
- Closes #89 (EXPECT_FAILURE wiring)
- Part of #85 (webhook E2E rewrite epic)

## Test plan

- [x] `bash -n tests/lib/common.sh` passes
- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `bash scripts/tests/test-expect-failure-self.sh` passes all four cases:
  - default + pass() -> exit 0
  - default + fail() -> exit 1
  - EXPECT_FAILURE + fail() -> exit 0
  - EXPECT_FAILURE + pass() -> exit 1
- [ ] Existing test suites continue to exit 0/1 as expected (smoke run on next CI)