### PR TITLE
test(auth): retarget Epic-11 feature gates from v1.2.0 to v1.1.9

### DIFF
--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -125,12 +125,15 @@ _feature_min_version() {
     # emitting 503 when proxy_queue_timeout_secs fires. Tracked by backend
     # work to land in v1.2.0 (companion to discussion #872 customer pain).
     "proxy_stampede_protection")      echo "1.2.0" ;;
-    # Auth/Epic-11 features (refresh-token rotation, download ticket
-    # consumer endpoint, and is_active flush on user deactivation are
-    # tracked under Epic 11 follow-ups; targeted for 1.2.0).
-    "refresh_token_rotation")         echo "1.2.0" ;;
-    "download_ticket_consumer")       echo "1.2.0" ;;
-    "user_deactivation_token_flush")  echo "1.2.0" ;;
+    # Auth/Epic-11 features. Targeted for v1.1.9 because security-flavoured
+    # work (rotation + token revocation on deactivate) is likely to land on
+    # the release/1.1.x maintenance branch as a backport rather than wait
+    # for the next minor. If a backport ships earlier than 1.1.9, drop the
+    # min-version here; if any of these slip past 1.1.9 to 1.2.0, raise it.
+    # Tracked: artifact-keeper#929, #930, #931 (milestone v1.1.9).
+    "refresh_token_rotation")         echo "1.1.9" ;;
+    "download_ticket_consumer")       echo "1.1.9" ;;
+    "user_deactivation_token_flush")  echo "1.1.9" ;;
     *) return 1 ;;
   esac
 }


### PR DESCRIPTION
## Summary

Retargets the three Epic-11 auth feature gates from v1.2.0 to v1.1.9 in `tests/lib/common.sh::_feature_min_version`. Companion to PR #98 (hardening already merged).

The motivation: refresh-token rotation and user-deactivation token flush are security-flavoured fixes likely to land as backports on `release/1.1.x` rather than wait for the next minor. With the gate at 1.2.0, a backported feature would still skip on a 1.1.9 backend, leaving us blind on a real change.

## Why all three (not just the security-flavoured two)

Keeps the grouping consistent and avoids drift if the download-ticket consumer also gets pulled into 1.1.9. If any of these slip past 1.1.9 to 1.2.0, just raise the min-version here.

## Verified locally

```
1.1.8 + refresh_token_rotation        -> skip (rc=1)
1.1.9 + refresh_token_rotation        -> run  (rc=0)
1.1.9 + user_deactivation_token_flush -> run  (rc=0)
1.1.9 + download_ticket_consumer      -> run  (rc=0)
1.1.9 + proxy_stampede_protection     -> skip (still 1.2.0, unchanged)
```

## Tracking

- Backend issues at v1.1.9 milestone, in Hardening Core project:
  - artifact-keeper/artifact-keeper#929 — refresh-token rotation
  - artifact-keeper/artifact-keeper#930 — download-ticket consumer
  - artifact-keeper/artifact-keeper#931 — API-token cache flush on deactivation

## Test plan

- [x] `bash -n` clean
- [x] require_feature returns rc=1 (skip) on 1.1.8, rc=0 (run) on 1.1.9 and 1.2.0 for all three features
- [x] proxy_stampede_protection unchanged (still 1.2.0)