### PR TITLE
fix(release-gate): exempt admin user from auth rate-limit in test values

### DIFF
--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -28,6 +28,9 @@ backend:
     RUST_LOG: info
     ADMIN_PASSWORD: TestRunner!2026secure
     ACCOUNT_LOCKOUT_THRESHOLD: "0"
+    # See values-test.yaml for rationale (iac#97). Parallel test pods exhaust
+    # the default 120/min auth rate-limit on shared admin bootstrap.
+    RATE_LIMIT_EXEMPT_USERNAMES: "admin"
     TRIVY_URL: "http://artifact-keeper-trivy:8090"
     SCAN_WORKSPACE_PATH: "/data/scan-workspace"
   persistence:

--- a/helm/values-test-mesh.yaml
+++ b/helm/values-test-mesh.yaml
@@ -29,6 +29,9 @@ backend:
     RUST_LOG: info
     ADMIN_PASSWORD: TestRunner!2026secure
     ACCOUNT_LOCKOUT_THRESHOLD: "0"
+    # See values-test.yaml for rationale (iac#97). Parallel test pods exhaust
+    # the default 120/min auth rate-limit on shared admin bootstrap.
+    RATE_LIMIT_EXEMPT_USERNAMES: "admin"
   persistence:
     size: 2Gi
 

--- a/helm/values-test.yaml
+++ b/helm/values-test.yaml
@@ -30,6 +30,13 @@ backend:
     RUST_LOG: info
     ADMIN_PASSWORD: TestRunner!2026secure
     ACCOUNT_LOCKOUT_THRESHOLD: "0"
+    # Release-gate runs 20+ test pods in parallel. Each calls auth_admin to
+    # bootstrap via POST /api/v1/auth/login with the shared admin user, which
+    # exhausts the default 120/min auth rate-limit bucket and trips HTTP 429
+    # (the failing-on-main pattern in iac#97). Exempt the admin user so the
+    # bootstrap flow doesn't compete with itself across parallel pods. Per-test
+    # users that the suites create are still rate-limited normally.
+    RATE_LIMIT_EXEMPT_USERNAMES: "admin"
   persistence:
     size: 2Gi
 


### PR DESCRIPTION
## Summary

Release-gate has been failing on `main` for 8 consecutive runs (2026-04-24 to 2026-04-26). Root cause: 20+ test pods running in parallel each call `auth_admin` to bootstrap via `POST /api/v1/auth/login` with the shared admin user, exhausting the default `RATE_LIMIT_AUTH_PER_MIN=120` bucket. After `HTTP 429`, subsequent retries see `401` because the bucket stays exhausted longer than the 12x5s retry budget added in commit `a5bfbda`.

This change exempts the `admin` username from the auth rate limiter across the three test overlays (`values-test.yaml`, `values-test-full.yaml`, `values-test-mesh.yaml`). The backend already supports `RATE_LIMIT_EXEMPT_USERNAMES` (see `backend/src/config.rs:541-549`); the chart already passes `.Values.backend.env` straight through to the container. So this is a pure values change.

Per-test users that suites create are still rate-limited normally; only the shared bootstrap account is exempt.

## Why exempt vs. raise the limit

Two viable shapes were considered:

1. Exempt `admin` (this PR) — targeted, small blast radius, doesn't change the behaviour for any other user.
2. Raise `RATE_LIMIT_AUTH_PER_MIN` to e.g. `10000` — broader, also affects per-test user creation flows.

Exempt is preferred because the shared `admin` bootstrap is the only account that legitimately gets called by every parallel pod. Raising the global limit would mask future regressions where per-test code accidentally hammers the same user.

## Regression test

The "regression test" here is release-gate itself: with this change applied, the `security-tests`, `auth-tests`, `rbac-tests`, and `compatibility-tests` jobs that have been failing on `auth_admin` bootstrap should pass. After merge, run release-gate manually against `:dev` (or `:1.1-dev` for the 1.1.x line) to confirm.

## Test Checklist

- [x] N/A — test-infrastructure values change, regression test is a green release-gate run.
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually inspected: backend config keys (`backend/src/config.rs:541`) and chart deployment template (`backend-deployment.yaml:170-171`) confirm the env var is wired end-to-end.

## Related

- iac#97 (this issue was originally filed against artifact-keeper-iac before the test values file location was confirmed; the actual fix lives in this repo)
- artifact-keeper#969 long-term: backend trusted-CIDR allowlist (post-1.1.9, v1.2.0)
- artifact-keeper#886 v1.1.9 stability release tracking
- artifact-keeper#887 1.1.9-rc.N validation policy
- commit `a5bfbda` retry-budget extension (symptom relief, this PR addresses the cause)