### PR TITLE
fix(smoke): fall back to ephemeral curl pod when backend image lacks curl/wget

### DIFF
--- a/scripts/clean-install-smoke.sh
+++ b/scripts/clean-install-smoke.sh
@@ -506,7 +506,6 @@ watch_rollout "ak-smoke-web"     "web"     || exit $?
 readyz_probe_loop() {
   local service_url="http://ak-smoke-backend.${NAMESPACE}.svc.cluster.local:8080"
   echo ""
-  echo "Polling ${service_url}/readyz from inside backend pod (timeout: ${TIMEOUT_SECONDS}s)"
 
   local backend_pod
   backend_pod=$(kubectl get pods -n "$NAMESPACE" \
@@ -517,27 +516,51 @@ readyz_probe_loop() {
     return 3
   fi
 
-  # The backend image is RHEL ubi-micro + curl-minimal (per the backend
-  # Dockerfile). It does NOT ship `which`, so we use POSIX `command -v`
-  # for detection. wget is checked first because Alpine-style images that
-  # might be used in development tend to have it; curl is the production
-  # default and is also fine.
-  local probe_cmd
+  # Pick a probe pod. Preference order:
+  #   1. Backend pod if it has wget or curl (no extra image pull)
+  #   2. Ephemeral curl pod in the same namespace (one image pull, reused
+  #      across all probe iterations)
+  #
+  # Production backend images on the v1.1.x line are slim and may have
+  # neither curl nor wget. Falling back to a curl pod keeps the smoke
+  # test functional without requiring shell utilities in production
+  # images. The ephemeral pod is reaped automatically when the namespace
+  # is torn down.
+  local probe_pod="$backend_pod"
+  local probe_cmd=""
   if kubectl exec -n "$NAMESPACE" "$backend_pod" -- sh -c 'command -v wget >/dev/null' 2>/dev/null; then
     # GNU wget indents response headers with two spaces; busybox wget
     # uses one. Match either with `-i 'HTTP/'`.
     probe_cmd="wget -q --timeout=5 -O - --server-response ${service_url}/readyz 2>&1 | grep -i 'HTTP/'"
+    echo "Polling ${service_url}/readyz from backend pod (wget; timeout: ${TIMEOUT_SECONDS}s)"
   elif kubectl exec -n "$NAMESPACE" "$backend_pod" -- sh -c 'command -v curl >/dev/null' 2>/dev/null; then
     probe_cmd="curl -fsS -o /dev/null -w '%{http_code}\n' --max-time 5 ${service_url}/readyz"
+    echo "Polling ${service_url}/readyz from backend pod (curl; timeout: ${TIMEOUT_SECONDS}s)"
   else
-    # No portable fallback — `/dev/tcp` is a bash builtin and busybox sh
-    # in Alpine-based images does not support it. If neither curl nor
-    # wget is present, fail with a clear classification rather than a
-    # silent timeout. Adding a probe tool to the backend image is the
-    # right fix.
-    echo "ERROR: backend pod has neither curl nor wget; cannot probe /readyz" >&2
-    echo "       fix: add curl or wget to the backend image" >&2
-    return 3
+    # Backend image has neither curl nor wget. Provision a long-lived
+    # ephemeral curl pod to use for the probe loop. Single image pull
+    # (cached by the ARC runner pull-through cache when configured), and
+    # exec into the same pod each iteration for speed.
+    local probe_pod_name="ak-smoke-probe-${RUN_ID}"
+    echo "Backend image has no curl/wget; provisioning ephemeral curl pod ${probe_pod_name}"
+    if ! kubectl run "$probe_pod_name" -n "$NAMESPACE" \
+        --image=curlimages/curl:8.10.1 \
+        --restart=Never \
+        --labels="app.kubernetes.io/component=smoke-probe" \
+        --command -- sleep 600 >/dev/null 2>&1; then
+      echo "ERROR: failed to create ephemeral curl pod for /readyz probe" >&2
+      return 3
+    fi
+    if ! kubectl wait --for=condition=Ready \
+        -n "$NAMESPACE" "pod/${probe_pod_name}" \
+        --timeout=60s >/dev/null 2>&1; then
+      echo "ERROR: ephemeral curl pod did not become Ready within 60s" >&2
+      kubectl describe pod -n "$NAMESPACE" "$probe_pod_name" 2>&1 | tail -20 >&2 || true
+      return 3
+    fi
+    probe_pod="$probe_pod_name"
+    probe_cmd="curl -fsS -o /dev/null -w '%{http_code}\n' --max-time 5 ${service_url}/readyz"
+    echo "Polling ${service_url}/readyz from ${probe_pod_name} (curl; timeout: ${TIMEOUT_SECONDS}s)"
   fi
 
   local start now elapsed deadline output
@@ -550,11 +573,11 @@ readyz_probe_loop() {
       echo "ERROR: /readyz did not return 200 within ${TIMEOUT_SECONDS}s" >&2
       echo ""
       echo "Last probe output:"
-      kubectl exec -n "$NAMESPACE" "$backend_pod" -- sh -c "$probe_cmd" 2>&1 | tail -5 || true
+      kubectl exec -n "$NAMESPACE" "$probe_pod" -- sh -c "$probe_cmd" 2>&1 | tail -5 || true
       return 3
     fi
 
-    if output=$(kubectl exec -n "$NAMESPACE" "$backend_pod" -- sh -c "$probe_cmd" 2>&1); then
+    if output=$(kubectl exec -n "$NAMESPACE" "$probe_pod" -- sh -c "$probe_cmd" 2>&1); then
       if echo "$output" | grep -qE '\b200\b'; then
         elapsed=$(( now - start ))
         echo "Backend /readyz returned 200 (took ${elapsed}s after rollout completed)"


### PR DESCRIPTION
## Summary

The clean-install smoke gate was failing on the v1.1.9 release-gate run with:

```
ERROR: backend pod has neither curl nor wget; cannot probe /readyz
       fix: add curl or wget to the backend image
```

The script's `readyz_probe_loop` execs into the backend pod and runs `wget` or `curl` against the in-cluster `/readyz` endpoint. v1.1.x backend images are slim production containers that ship with neither tool. Adding curl/wget to the production image is the wrong fix (bloats prod containers for a test concern).

This change adds a fallback: when the backend pod has neither curl nor wget, provision a long-lived ephemeral `curlimages/curl:8.10.1` pod in the same namespace and exec into that for the probe loop. One image pull (cached by the ARC runner pull-through cache when configured), reused across every probe iteration. The pod is labeled `app.kubernetes.io/component=smoke-probe` so it gets reaped automatically with the rest of the namespace at teardown.

The optimistic path (probe from the backend pod) is preserved when curl or wget is present, so this only adds cost when actually needed.

## Discovery context

Found while running release-gate against backend `:1.1-dev` for the v1.1.9 candidate (https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25178527181). Backend rollout reached Ready (kubelet's own probe succeeded), but the script's redundant in-pod probe failed because the image is slim.

This is a class of test-infrastructure papercut, not a backend bug. Same shape as #102 (rate-limit values fix).

## Regression test (required for `fix/*` PRs)

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — test-infrastructure shell-script change. The regression test is the next release-gate run going green where the previous one failed.

## Test Checklist

- [x] N/A — bash test-script change.
- [x] `bash -n` syntax check passes.

## Verification plan

After merge:
1. Re-trigger release-gate against `:1.1-dev` (backend `:1.1-dev`, web `:dev`).
2. Confirm `clean-install-smoke` reaches the `Backend /readyz returned 200` line via the ephemeral curl pod path.
3. Confirm namespace teardown reaps the smoke-probe pod (no orphan).

## Related

- artifact-keeper#886 v1.1.9 stability release tracking
- #102 rate-limit values fix (sibling test-infra fix in this milestone)
- The slim backend image is the right shape; this PR adapts the test infrastructure to cope rather than adding curl/wget to production images