### PR TITLE
chore(ci): SHA-pin all GitHub Actions in release-gate workflows (#55)

### DIFF
--- a/.github/workflows/format-tests.yml
+++ b/.github/workflows/format-tests.yml
@@ -53,7 +53,7 @@ jobs:
       # Local-dev runs don't set this and keep graceful skip behavior.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run ${{ matrix.batch.name }} tests
         if: inputs.batch == 'all' || inputs.batch == matrix.batch.name
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-formats-${{ matrix.batch.name }}
           path: /tmp/test-results/*.xml

--- a/.github/workflows/mesh-tests.yml
+++ b/.github/workflows/mesh-tests.yml
@@ -25,7 +25,7 @@ jobs:
       RUN_ID: ${{ inputs.run_id }}
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Deploy mesh topology (4 instances)
         id: deploy
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-mesh
           path: /tmp/test-results/*.xml

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -88,15 +88,15 @@ jobs:
     runs-on: ak-e2e-runners
     timeout-minutes: 12
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Run clean-install smoke test
         env:
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload smoke diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: clean-install-smoke-logs
           path: /tmp/test-logs/
@@ -148,15 +148,15 @@ jobs:
       namespace: ${{ steps.setup.outputs.namespace }}
       backend_url: ${{ steps.deploy.outputs.backend_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Generate run ID
         id: setup
@@ -245,7 +245,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -325,7 +325,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-formats-${{ matrix.batch.name }}
           path: /tmp/test-results/*.xml
@@ -365,7 +365,7 @@ jobs:
       PROXY_QUEUE_TIMEOUT_SECS: '5'
       STAMPEDE_UPSTREAM_DELAY_MS: '2000'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -409,7 +409,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-security
           # Directory upload (not *.xml glob) so per-test diagnostic
@@ -436,7 +436,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -448,7 +448,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-compatibility
           path: /tmp/test-results/*.xml
@@ -471,7 +471,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -483,7 +483,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-repos
           path: /tmp/test-results/*.xml
@@ -506,7 +506,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -518,7 +518,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-promotion
           path: /tmp/test-results/*.xml
@@ -541,7 +541,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -553,7 +553,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-rbac
           path: /tmp/test-results/*.xml
@@ -576,7 +576,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -588,7 +588,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-lifecycle
           path: /tmp/test-results/*.xml
@@ -615,7 +615,7 @@ jobs:
       # (WEBHOOK_RETRY_TIMEOUT) so the wrapping timeout must exceed that.
       TEST_TIMEOUT: '300'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -627,7 +627,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-webhooks
           path: /tmp/test-results/*.xml
@@ -650,7 +650,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -662,7 +662,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-search
           path: /tmp/test-results/*.xml
@@ -685,7 +685,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -697,7 +697,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-platform
           path: /tmp/test-results/*.xml
@@ -720,7 +720,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -732,7 +732,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-auth
           path: /tmp/test-results/*.xml
@@ -758,7 +758,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -770,7 +770,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-stress
           path: /tmp/test-results/*.xml
@@ -797,12 +797,12 @@ jobs:
       NAMESPACE: ${{ needs.deploy.outputs.namespace }}
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Run ${{ matrix.category }} resilience tests
         continue-on-error: true
@@ -824,7 +824,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-resilience-${{ matrix.category }}
           path: /tmp/test-results/*.xml
@@ -849,15 +849,15 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Deploy mesh topology
         id: mesh-deploy
@@ -914,7 +914,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-mesh
           path: /tmp/test-results/*.xml
@@ -929,7 +929,7 @@ jobs:
     runs-on: ak-e2e-runners
     steps:
       - name: Download all test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: junit-*
           path: /tmp/all-results
@@ -972,7 +972,7 @@ jobs:
 
       - name: Upload combined results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-gate-results
           path: /tmp/all-results/
@@ -995,15 +995,15 @@ jobs:
     if: always() && inputs.skip_teardown != true
     runs-on: ak-e2e-runners
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Teardown test namespace
         env:
@@ -1014,7 +1014,7 @@ jobs:
 
       - name: Upload pod logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pod-logs
           path: /tmp/test-logs/

--- a/.github/workflows/resilience-tests.yml
+++ b/.github/workflows/resilience-tests.yml
@@ -30,7 +30,7 @@ jobs:
       NAMESPACE: ${{ inputs.namespace }}
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run ${{ matrix.category }} resilience tests
         if: inputs.category == 'all' || inputs.category == matrix.category
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-resilience-${{ matrix.category }}
           path: /tmp/test-results/*.xml

--- a/.github/workflows/smoke-self-test.yml
+++ b/.github/workflows/smoke-self-test.yml
@@ -54,13 +54,13 @@ jobs:
     runs-on: ak-e2e-runners
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Run gate against nonexistent image and expect failure
         env:
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload self-test diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: smoke-self-test-pull-logs-${{ github.run_attempt }}
           path: /tmp/test-logs/
@@ -93,13 +93,13 @@ jobs:
     runs-on: ak-e2e-runners
     timeout-minutes: 12
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       # Fixture: tag a public busybox image as the "backend" via a
       # transient ImageStreamTag-style alias. busybox does not have
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload self-test diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: smoke-self-test-crash-logs-${{ github.run_attempt }}
           path: /tmp/test-logs/

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -18,7 +18,7 @@ jobs:
       RUN_ID: ${{ inputs.run_id }}
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run stress tests
         run: |
@@ -28,7 +28,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-stress
           path: /tmp/test-results/*.xml


### PR DESCRIPTION
## Summary

Pins every third-party GitHub Action reference in `.github/workflows/` to an immutable commit SHA, with a trailing comment preserving the human-readable tag. This is the GitHub-recommended practice for security-sensitive workflows.

Tag references like `actions/checkout@v4` are mutable: a compromised maintainer or a tag rewrite could swap the code that runs in CI without our visibility. Pinning to a commit SHA forecloses that supply-chain vector. The trailing-tag comment (`# v4`) keeps the file readable and makes future bumps straightforward (find by tag, resolve new SHA, replace).

Fixes #55

## Pinned Actions

| Action | Tag | Commit SHA |
|---|---|---|
| `actions/checkout` | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/upload-artifact` | v4 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/download-artifact` | v4 | `d3f86a106a0bac45b974a628896c90dbdf5c8093` |
| `azure/setup-helm` | v4 | `1a275c3b69536ee54be43f2070a358922e12c8d4` |
| `azure/setup-kubectl` | v4 | `776406bce94f63e41d621b960d78ee25c8b76ede` |

## Files Touched

- `.github/workflows/format-tests.yml`
- `.github/workflows/mesh-tests.yml`
- `.github/workflows/release-gate.yml`
- `.github/workflows/resilience-tests.yml`
- `.github/workflows/smoke-self-test.yml`
- `.github/workflows/stress-tests.yml`

Total references pinned: **60**.

## Convention

Each pinned reference keeps the original tag in a trailing comment, e.g.:

```yaml
- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
```

This means future updates can:
1. `grep` for `# v4` to find call sites,
2. resolve the new SHA via `gh api repos/<org>/<action>/git/refs/tags/<newtag>`,
3. swap the SHA and update the trailing comment.

## Validation

- `grep -nE "uses: [^@]+@[^#]" .github/workflows/*.yml | grep -vE "@[a-f0-9]{40}"` returns **zero unpinned references**.
- `actionlint` passes with no new findings (pre-existing self-hosted runner label warnings are unrelated to this change).
- No functional/runtime change: each replacement is a pure SHA swap of the same tag, so workflow behavior is unchanged.

## Test Plan

- [ ] Release-gate workflow runs cleanly on next dispatch (no resolution failures from the pinned SHAs).
- [ ] Format-tests, mesh-tests, resilience-tests, smoke-self-test, stress-tests workflows all dispatch successfully.