### PR TITLE
fix(release-gate): nest postgres password under auth: in full-stack overlay

### DIFF
--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -64,7 +64,12 @@ postgres:
       memory: 512Mi
   persistence:
     size: 2Gi
-  password: "test-db-password"
+  # The chart's secrets.yaml validation expects auth.password (not a flat
+  # password key). Mirrors the structure used in values-test.yaml.
+  auth:
+    username: registry
+    password: "test-db-password"
+    database: artifact_registry
 
 meilisearch:
   enabled: true


### PR DESCRIPTION
## Summary

The chart's `templates/secrets.yaml` validates `postgres.auth.password` is set when `postgres.enabled=true`. `values-test.yaml` already has the correct nested shape, but `values-test-full.yaml` had the password at the wrong top level (`postgres.password` flat). When `create-test-namespace.sh --full-stack` rendered the chart, the `required` template directive failed:

```
Error: execution error at (artifact-keeper/templates/secrets.yaml:11:3):
postgres.auth.password is required when postgres is enabled.
```

Surfaced when the v1.1.9 release-gate finally got past the smoke + RBAC + curl-pod hurdles (iac#99, test#103) and reached the `deploy` phase for the first time. Run [25188400655](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25188400655).

## Change

Mirror the structure used in the sibling `values-test.yaml`. Add `auth: { username, password, database }` to the `postgres:` block in `values-test-full.yaml`. Drop the misnamed flat `password:` key.

```yaml
  auth:
    username: registry
    password: "test-db-password"
    database: artifact_registry
```

## Regression test

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — test-infrastructure values change. Regression test is the next release-gate run getting past `deploy` instead of failing on the `required` validation.

## Test Checklist

- [x] N/A — bash/yaml only.
- [x] `helm lint` against the chart with this overlay clean (1 chart linted, 0 failed).

## Related

- Sibling test-infra fixes for v1.1.9: #102 (rate-limit), #103 (smoke probe), artifact-keeper-iac#99 (RBAC pods/exec)
- artifact-keeper#886 v1.1.9 stability release tracking

## After merge

Re-trigger release-gate against `:1.1-dev`. Run 6 should finally exercise the format-tests / security-tests / auth-tests / etc. matrix on the v1.1.9 backend.