### PR TITLE
fix(release-gate): drop chart-injected TRIVY_URL/SCAN_WORKSPACE_PATH dups in full-stack overlay

### DIFF
--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -31,8 +31,10 @@ backend:
     # See values-test.yaml for rationale (iac#97). Parallel test pods exhaust
     # the default 120/min auth rate-limit on shared admin bootstrap.
     RATE_LIMIT_EXEMPT_USERNAMES: "admin"
-    TRIVY_URL: "http://artifact-keeper-trivy:8090"
-    SCAN_WORKSPACE_PATH: "/data/scan-workspace"
+    # NOTE: TRIVY_URL and SCAN_WORKSPACE_PATH were previously set here, but
+    # the chart's backend-deployment.yaml auto-injects them when
+    # trivy.enabled=true. Setting them here too produces duplicate env keys
+    # and helm rejects the manifest. Kept the chart-side values authoritative.
   persistence:
     size: 2Gi
   scanWorkspace:


### PR DESCRIPTION
## Summary

The chart's backend-deployment.yaml auto-injects \`TRIVY_URL\` and \`SCAN_WORKSPACE_PATH\` when \`trivy.enabled=true\`. The full-stack overlay was also setting them in \`backend.env\`, producing duplicate env keys that helm rejected at deploy time:

\`\`\`
Error: failed to create typed patch object: errors:
  .spec.template.spec.containers[name="backend"].env: duplicate entries for key [name="TRIVY_URL"]
  .spec.template.spec.containers[name="backend"].env: duplicate entries for key [name="SCAN_WORKSPACE_PATH"]
\`\`\`

Confirmed in **both** the v1.2.x (main) and v1.1.x (just-cut release/1.1.x) charts: both auto-inject when trivy is enabled. So the overlay change is correct against either iac branch.

Surfaced after #105 (postgres.auth fix) unblocked the deploy phase to reach this next failure. Run [25190312169](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25190312169).

## Bigger context: chart-backend version lockstep

While diagnosing this we found the v1.1.9 release-gate had been running v1.1.x backend (\`:1.1-dev\`) against v1.2.x chart (\`iac_ref=main\`). The v1.2.x chart dropped Meilisearch in artifact-keeper-iac#67 and only deploys OpenSearch, while the v1.1.x backend still expects Meilisearch. We just cut \`release/1.1.x\` on artifact-keeper-iac at SHA \`a9595176\` (parent of #67). Future v1.1.x release-gate runs should pass \`iac_ref=release/1.1.x\` to get the matching chart.

This PR's TRIVY_URL fix is independently correct against both branches, but the next gate run will use the v1.1.x chart so the search backend lines up too.

## Regression test

- [ ] This PR is a \`fix/*\` AND adds/updates a test that would have caught the bug
- [x] N/A — test-infrastructure values change. Regression test is the next release-gate run getting past deploy.

## Test Checklist

- [x] N/A — yaml-only change.
- [x] \`helm lint\` clean against the chart with this overlay.

## Related

- Sibling test-infra fixes for v1.1.9: #102, #103, #105, artifact-keeper-iac#99
- artifact-keeper#886 v1.1.9 stability release tracking
- Architectural follow-up: \`iac_ref\` convention should be documented + automated based on backend_tag