### PR TITLE
fix(smoke): provide meilisearch.masterKey override for v1.1.x chart

### DIFF
--- a/scripts/clean-install-smoke.sh
+++ b/scripts/clean-install-smoke.sh
@@ -393,6 +393,13 @@ HELM_OVERRIDES=(
   --set 'opensearch.javaOpts=-Xms512m -Xmx512m'
   --set 'opensearch.resources.requests.memory=1Gi'
   --set 'opensearch.resources.limits.memory=1Gi'
+  # v1.1.x charts: values-production.yaml ships meilisearch.masterKey=""
+  # and env="production" so operators must provide the key out-of-band.
+  # The smoke gate is a transient test deploy: provide a hardcoded test
+  # key (>= 16 bytes) so Meilisearch boots. Harmless on v1.2.x charts
+  # (which dropped Meilisearch in artifact-keeper-iac#67) since the keys
+  # have no template binding there.
+  --set 'meilisearch.masterKey=ak-smoke-meilisearch-test-master-key'
 )
 
 # Fixture override: when SMOKE_BACKEND_REPO_OVERRIDE is set (used by the


### PR DESCRIPTION
## Summary

The release/1.1.x chart's \`values-production.yaml\` ships \`meilisearch.masterKey=""\` and \`env: "production"\`: production deployments must provide the master key out-of-band (SOPS, external secret manager, etc.). The smoke gate uses \`values-production.yaml\` plus a \`HELM_OVERRIDES\` list for test-only secrets, but never set \`meilisearch.masterKey\`.

In production mode, Meilisearch enforces a 16-byte minimum on the master key. With an empty key it refuses to start:

\`\`\`
ERROR meilisearch: error=The master key must be at least 16 bytes in a production environment. The provided key is only 0 bytes.
\`\`\`

Result: Meilisearch hit \`CrashLoopBackOff\`, the backend's init container blocked waiting for it, and the smoke gate timed out at "deployment did not reach Ready within 300s".

## Discovery

Surfaced when v1.1.9 release-gate finally ran with \`iac_ref=release/1.1.x\` (the chart that matches the v1.1.x backend's Meilisearch dependency, unlike \`main\` which dropped Meilisearch in artifact-keeper-iac#67). Run [25190807694](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25190807694).

This is the **first** failure that's actual chart/backend behavior info rather than test scaffolding. Previous failures were all RBAC, naming, or env-var dups.

## Change

Add one line to \`HELM_OVERRIDES\`:

\`\`\`bash
--set 'meilisearch.masterKey=ak-smoke-meilisearch-test-master-key'
\`\`\`

35 chars, well over the 16-byte minimum. Mirrors the pattern of the other test-only secret overrides already in the list (postgres password, JWT secret).

Harmless on the v1.2.x chart (\`iac_ref=main\`) since it has no Meilisearch templates; the \`--set\` is a no-op there.

## Regression test

- [ ] This PR is a \`fix/*\` AND adds/updates a test that would have caught the bug
- [x] N/A — test-script change. Regression test is the next release-gate run reaching past smoke phase.

## Test Checklist

- [x] N/A — bash change, syntax verified with \`bash -n\`.

## Related

- artifact-keeper#886 v1.1.9 stability release tracking
- Sibling test-infra fixes for v1.1.9: #102, #103, #105, #106 (and iac#99)
- artifact-keeper-iac#67 the OpenSearch migration commit (parent SHA \`a9595176\` is the v1.1.x chart's last good state)