### PR TITLE
fix(auth): correct TOTP test assertions surfaced by release-gate

### DIFF
--- a/tests/auth/test-totp-backup-codes.sh
+++ b/tests/auth/test-totp-backup-codes.sh
@@ -102,7 +102,15 @@ fi
 
 # -------------------------------------------------------------------------
 # Helper: log in again to get a fresh totp_token, then verify with code.
-# Returns 0 if verify succeeds, prints HTTP status either way.
+# Always returns 0 and prints the HTTP status (or a sentinel string) on
+# stdout. Callers inspect the printed value directly.
+#
+# NOTE: this MUST always return 0 because the test runs with `set -e` and the
+# helper is called via plain command substitution (`status=$(...)`). If the
+# helper returned non-zero on a 401 response, bash would abort the whole
+# script before the test could assert that 401 was the expected outcome —
+# which is exactly the bug release-gate run 25191428274 surfaced for the
+# "Replay of the same backup code is rejected" case.
 # -------------------------------------------------------------------------
 
 login_and_verify_with_code() {
@@ -116,7 +124,7 @@ login_and_verify_with_code() {
   totp_token=$(echo "$login_resp" | jq -r '.totp_token // empty')
   if [ -z "$totp_token" ] || [ "$totp_token" = "null" ]; then
     echo "no_totp_token"
-    return 1
+    return 0
   fi
   local status
   status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
@@ -126,10 +134,7 @@ login_and_verify_with_code() {
     "${BASE_URL}/api/v1/auth/totp/verify" 2>/dev/null) || true
   status="${status:-000}"
   echo "$status"
-  if [ "$status" -ge 200 ] 2>/dev/null && [ "$status" -lt 300 ] 2>/dev/null; then
-    return 0
-  fi
-  return 1
+  return 0
 }
 
 # -------------------------------------------------------------------------

--- a/tests/auth/test-totp-disable.sh
+++ b/tests/auth/test-totp-disable.sh
@@ -160,7 +160,19 @@ else
   me_resp=$(curl -sf $CURL_TIMEOUT \
     -H "Authorization: Bearer ${USER_TOKEN}" \
     "${BASE_URL}/api/v1/auth/me" 2>/dev/null) || true
-  totp_state=$(echo "$me_resp" | jq -r '.totp_enabled // empty')
+  # NOTE: `jq -r '.totp_enabled // empty'` is buggy here — jq's `//` operator
+  # treats `false` as a missing alternative and returns empty, so a literal
+  # `"totp_enabled":false` would be reported as `''`. Use `if … then … end`
+  # so we distinguish false (the value we want), true, and absent.
+  totp_state=$(echo "$me_resp" | jq -r '
+    if has("totp_enabled") then
+      if .totp_enabled == false then "false"
+      elif .totp_enabled == true then "true"
+      else "non-bool"
+      end
+    else "missing"
+    end
+  ' 2>/dev/null) || totp_state=""
   if [ "$totp_state" = "false" ]; then
     pass
   else


### PR DESCRIPTION
## Summary

Two TOTP tests in the auth suite failed in release-gate run [25191428274](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25191428274) (job `auth-tests`). Both are test bugs, not backend bugs.

### `test-totp-disable.sh` — wrong jq path

The "User profile shows `totp_enabled = false` after disable" assertion used `jq -r '.totp_enabled // empty'`. `jq`'s `//` operator treats `false` as a missing alternative, so a literal `"totp_enabled":false` came out as the empty string. The job log makes this obvious — the response body in the failure message is `{"…","totp_enabled":false}` while the captured value is `''`. Replaced with an explicit `if … then … end` that distinguishes `false`, `true`, non-bool, and absent.

### `test-totp-backup-codes.sh` — `set -e` abort on expected 401

The `login_and_verify_with_code` helper printed the HTTP status on stdout but also returned non-zero whenever the response was not 2xx. The script runs under `set -euo pipefail` and the helper is invoked via plain command substitution (`status=$(login_and_verify_with_code …)`), so on the "Replay of the same backup code is rejected" assertion the 401 we wanted bash to assert against made the helper return 1, and `set -e` aborted the whole script before the `[ "$status" = "401" ]` check ever ran. That matches the log: the test exited with FAIL but no `FAIL: …` line was printed because `fail` never got a chance to run.

Helper now always returns 0 (callers were already branching on the printed status string, never on the exit code).

## Backend status

No backend change is required. The backend already returns the correct response in both flows:
- `/auth/me` includes `"totp_enabled":false` after a successful disable (visible in the failing log).
- `/auth/totp/verify` returns 401 on backup-code replay (consistent with `totp.rs:266-296` where the matched code is replaced with an empty string and skipped on the next match attempt).

## Test plan

- [x] `bash -n tests/auth/test-totp-disable.sh`
- [x] `bash -n tests/auth/test-totp-backup-codes.sh`
- [x] Standalone repro of the jq bug — old `'.totp_enabled // empty'` returns empty for `false`, new logic returns `"false"`.
- [x] Standalone repro of the `set -e` abort — confirmed `status=$(f)` where `f` returns 1 aborts under `set -e` before the next line runs.
- [ ] Re-run release-gate `auth-tests` job after merge.