### PR TITLE
fix(maven): allow HTTP cluster-internal repo via mirror override

### DIFF
--- a/tests/formats/test-maven-native-client.sh
+++ b/tests/formats/test-maven-native-client.sh
@@ -107,12 +107,40 @@ SETTINGS_FILE="${WORK_DIR}/settings.xml"
 LOCAL_REPO="${WORK_DIR}/.m2-local"
 mkdir -p "$LOCAL_REPO"
 
+# Maven 3.8.1+ ships a default mirror called `maven-default-http-blocker`
+# that refuses any plain-HTTP repository (mirrorOf = `external:http:*`).
+# In release-gate runs the backend lives at the cluster-internal HTTP URL
+# `http://artifact-keeper-backend.test-${RUN_ID}.svc.cluster.local:8080/maven/...`,
+# which the blocker rejects with:
+#   "Blocked mirror for repositories: [ak-test (...)] from the specified
+#    remote repositories: [central, maven-default-http-blocker]".
+#
+# We override the blocker by declaring our own mirror that captures the
+# `ak-test` repo id with `<blocked>false</blocked>`. Maven evaluates
+# user-defined mirrors before the built-in blocker, so this lets the
+# request through. The mirror url is the same as the upstream repo,
+# making the redirect a no-op. The mirror id needs matching credentials
+# in <servers> because Maven looks up auth by the resolved mirror id.
 cat > "$SETTINGS_FILE" <<EOF
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
   <localRepository>${LOCAL_REPO}</localRepository>
+  <mirrors>
+    <mirror>
+      <id>ak-test-allow-http</id>
+      <name>Allow plain-HTTP for ak-test cluster-internal repo</name>
+      <url>${MAVEN_URL}</url>
+      <mirrorOf>ak-test</mirrorOf>
+      <blocked>false</blocked>
+    </mirror>
+  </mirrors>
   <servers>
     <server>
       <id>ak-test</id>
+      <username>${ADMIN_USER}</username>
+      <password>${ADMIN_PASS}</password>
+    </server>
+    <server>
+      <id>ak-test-allow-http</id>
       <username>${ADMIN_USER}</username>
       <password>${ADMIN_PASS}</password>
     </server>
@@ -153,12 +181,27 @@ PULL_REPO="${WORK_DIR}/.m2-pull"
 mkdir -p "$PULL_REPO"
 
 PULL_SETTINGS="${WORK_DIR}/settings-pull.xml"
+# Same http-blocker override as above, but for the pull-side settings.
 cat > "$PULL_SETTINGS" <<EOF
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
   <localRepository>${PULL_REPO}</localRepository>
+  <mirrors>
+    <mirror>
+      <id>ak-test-allow-http</id>
+      <name>Allow plain-HTTP for ak-test cluster-internal repo</name>
+      <url>${MAVEN_URL}</url>
+      <mirrorOf>ak-test</mirrorOf>
+      <blocked>false</blocked>
+    </mirror>
+  </mirrors>
   <servers>
     <server>
       <id>ak-test</id>
+      <username>${ADMIN_USER}</username>
+      <password>${ADMIN_PASS}</password>
+    </server>
+    <server>
+      <id>ak-test-allow-http</id>
       <username>${ADMIN_USER}</username>
       <password>${ADMIN_PASS}</password>
     </server>


### PR DESCRIPTION
## Problem

The format-tests jvm job in release-gate run [25191428274](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25191428274) fails with:

```
FAIL: mvn dependency:get failed; ... Blocked mirror for repositories: [ak-test
(http://artifact-keeper-backend...:8080/maven/...)] from the specified remote repositories:
[central, maven-default-http-blocker (http://0.0.0.0/, releases=true, snapshots=true)]
```

Maven 3.8.1+ ships a default mirror called `maven-default-http-blocker` (mirrorOf = `external:http:*`) that refuses any plain-HTTP repository. The test backend is at a cluster-internal HTTP URL, which the blocker rejects.

## Fix

Add a user-defined mirror in the generated `settings.xml` that captures the `ak-test` repo id with `<blocked>false</blocked>`. Maven evaluates user-defined mirrors before the built-in blocker, so this lets the request through. The mirror url points back at the same upstream repo (no-op redirect).

Applied to both the deploy-side and pull-side settings files.

## Why this is a one-file test fix and not a server-side change

The cluster-internal URL is the correct deploy target for these tests. Switching to HTTPS would require provisioning per-namespace certs into dockerd / mvn / every other client at deploy time, and the existing infra deliberately uses plain HTTP behind the cluster network boundary. Other formats with stricter clients (npm, cargo) already work because they don't have a default HTTP-blocker; this is a Maven-specific override.

## Verification

- `bash -n tests/formats/test-maven-native-client.sh` clean.
- The override pattern matches Apache's documented workaround for 3.8.1's blocker (https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291).

## Refs

- Release-gate run: https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25191428274
- Companion PR for the docker pre-flight: same run's containers job, separate PR.