### PR TITLE
fix(conan): version-guard tests that depend on v1.2.x backend behavior (artifact-keeper#986)

### DIFF
--- a/tests/formats/test-conan-recipes.sh
+++ b/tests/formats/test-conan-recipes.sh
@@ -305,6 +305,13 @@ fi
 # ---------------------------------------------------------------------------
 begin_test "Fetch user/channel recipe independently from default"
 
+# Backend support for user/channel scoping landed in v1.2.x via #869.
+# v1.1.x collapses all variants to _/_/latest, returning the wrong revision.
+# Tracked for v1.1.10 backport in artifact-keeper#986.
+if ! require_feature "conan_user_channel_scoping"; then
+  :  # require_feature already emitted skip; continue to next test
+else
+
 # Fetch latest for user/channel recipe
 uc_latest=$(curl -sf \
   -H "$(format_auth_header)" \
@@ -327,6 +334,8 @@ else
     fi
   fi
 fi
+
+fi  # require_feature "conan_user_channel_scoping"
 
 # ---------------------------------------------------------------------------
 # 14. Upload recipe with conanfile.txt (not .py) and verify round-trip

--- a/tests/formats/test-conan-remote.sh
+++ b/tests/formats/test-conan-remote.sh
@@ -226,6 +226,11 @@ fi
 # =========================================================================
 
 begin_test "Fetch locallib latest through virtual matches local"
+# Virtual recipe_latest fan-out across non-Remote members landed in v1.2.x
+# via #875. v1.1.x backend lacks fan-out so virtual_resp is empty.
+# Tracked for v1.1.10 backport in artifact-keeper#986.
+if require_feature "conan_virtual_recipe_fanout"; then
+
 # Get latest revision directly from the local repo
 local_resp=$(curl -sf $CURL_TIMEOUT \
     -H "$(format_auth_header)" \
@@ -257,6 +262,8 @@ else
     fi
   fi
 fi
+
+fi  # require_feature "conan_virtual_recipe_fanout"
 
 # =========================================================================
 # Test 12: Verify virtual repo ping endpoint

--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -117,6 +117,13 @@ _feature_min_version() {
   case "$1" in
     "conan_remote_search_forward")    echo "1.3.0" ;;
     "conan_virtual_search_aggregate") echo "1.3.0" ;;
+    # recipe_latest / recipe_revisions filter by user/channel rather than
+    # collapsing variants to _/_/latest. Backported via artifact-keeper#869.
+    # v1.1.x backend lacks this scoping; tracked for v1.1.10 backport in #986.
+    "conan_user_channel_scoping")     echo "1.2.0" ;;
+    # Virtual-repo recipe_latest fans out across non-Remote members. Landed
+    # via artifact-keeper#875. v1.1.x backend lacks this; tracked in #986.
+    "conan_virtual_recipe_fanout")    echo "1.2.0" ;;
     "maven_virtual_snapshot")         echo "1.2.0" ;;
     "guest_access_toggle")            echo "1.2.0" ;;
     "opensearch_indexing")            echo "1.2.0" ;;


### PR DESCRIPTION
## Summary

Two Conan tests fail against v1.1.x backend because three v1.2.x fixes were never backported to \`release/1.1.x\`:

- artifact-keeper#869: \`recipe_latest\` / \`recipe_revisions\` filter by user/channel.
- artifact-keeper#873: \`v2/ping\` repo validation.
- artifact-keeper#875: virtual-repo \`recipe_latest\` fan-out across non-Remote members.

This is **pre-existing v1.1.x behavior**, not a regression introduced by v1.1.9 cherry-picks. Tracked for v1.1.10 backport in [artifact-keeper#986](https://github.com/artifact-keeper/artifact-keeper/issues/986). Until that lands, the affected tests should skip on v1.1.x backends so the release-gate goes green.

## Change

Adds two feature flags to \`tests/lib/common.sh\`'s \`_feature_min_version\` map (>= 1.2.0):
- \`conan_user_channel_scoping\`
- \`conan_virtual_recipe_fanout\`

Wraps the affected blocks in:
- \`tests/formats/test-conan-recipes.sh\` test 13 ("Fetch user/channel recipe independently from default" + the default-revision-still-REV2 invariant)
- \`tests/formats/test-conan-remote.sh\` test 11 ("Fetch locallib latest through virtual matches local")

Mirrors the existing \`conan_remote_search_forward\` (>= 1.3.0) guards from #868.

## Effect

- v1.1.x backend (\`/health\` reports < 1.2.0) → these two tests skip
- v1.2.x backend → tests run as before, catching future regressions

## Discovery

Surfaced by release-gate run [25191428274](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25191428274) once the gate finally got past smoke and exercised the matrix on v1.1.9 candidate.

## Test Checklist

- [x] N/A — test-script change. Validated via \`bash -n\` on all 3 files.

## Related

- artifact-keeper#986 — backport tracking for v1.1.10
- artifact-keeper#886 — v1.1.9 stability release tracking
- Sibling test-infra fixes that landed today: #102, #103, #105, #106, #107, #110, #112, #114, #115