### PR TITLE
fix(pypi): build wheel and install --only-binary in native-client test

### DIFF
--- a/tests/formats/test-pypi-native-client.sh
+++ b/tests/formats/test-pypi-native-client.sh
@@ -71,10 +71,19 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# Build a real sdist
+# Build a real sdist + wheel
+#
+# We build both and upload both. The wheel is what `pip install` resolves
+# to in the next step: an sdist would force pip to bootstrap its build
+# backend (setuptools>=61) from the same private index, which doesn't
+# proxy public PyPI in this test, so that resolution would always fail.
+# The sdist is still uploaded so the index-listing assertions stay
+# meaningful and so the upload path itself is exercised against both
+# distribution types (twine treats them differently in its multipart
+# encoding).
 # -------------------------------------------------------------------------
 
-begin_test "Build sdist tarball"
+begin_test "Build sdist tarball and wheel"
 SRC_DIR="${WORK_DIR}/src"
 mkdir -p "$SRC_DIR"
 cd "$SRC_DIR"
@@ -98,27 +107,31 @@ def hello():
 EOF
 
 # Pin the build backend version so this test does not break when
-# setuptools or pyproject-build changes their CLI.
-if ! pip install --quiet --disable-pip-version-check "build==1.2.2" "setuptools==75.6.0" 2>"${WORK_DIR}/pip-build.log"; then
-  skip "could not install build/setuptools: $(tail -n 5 "${WORK_DIR}/pip-build.log" | tr '\n' ' ')"
+# setuptools or pyproject-build changes their CLI. wheel is required
+# for `python -m build --wheel` to succeed without network calls.
+if ! pip install --quiet --disable-pip-version-check "build==1.2.2" "setuptools==75.6.0" "wheel==0.45.1" 2>"${WORK_DIR}/pip-build.log"; then
+  skip "could not install build/setuptools/wheel: $(tail -n 5 "${WORK_DIR}/pip-build.log" | tr '\n' ' ')"
   end_suite
 fi
 
-if python -m build --sdist --outdir "${WORK_DIR}/dist" "${SRC_DIR}" > "${WORK_DIR}/build.log" 2>&1; then
+if python -m build --sdist --wheel --outdir "${WORK_DIR}/dist" "${SRC_DIR}" > "${WORK_DIR}/build.log" 2>&1; then
   pass
 else
   fail "python -m build failed; tail: $(tail -n 10 "${WORK_DIR}/build.log" | tr '\n' ' ')"
 fi
 
 SDIST_FILE=$(ls "${WORK_DIR}/dist/"*.tar.gz 2>/dev/null | head -n1)
+WHEEL_FILE=$(ls "${WORK_DIR}/dist/"*.whl 2>/dev/null | head -n1)
 
 # -------------------------------------------------------------------------
 # twine upload
 # -------------------------------------------------------------------------
 
-begin_test "twine upload pushes sdist"
+begin_test "twine upload pushes sdist and wheel"
 if [ -z "$SDIST_FILE" ] || [ ! -s "$SDIST_FILE" ]; then
   fail "no sdist file to upload"
+elif [ -z "$WHEEL_FILE" ] || [ ! -s "$WHEEL_FILE" ]; then
+  fail "no wheel file to upload"
 else
   upload_log="${WORK_DIR}/twine-upload.log"
   if TWINE_USERNAME="$ADMIN_USER" \
@@ -127,7 +140,7 @@ else
        --repository-url "${PYPI_URL}/" \
        --non-interactive \
        --disable-progress-bar \
-       "$SDIST_FILE" \
+       "$SDIST_FILE" "$WHEEL_FILE" \
        > "$upload_log" 2>&1; then
     pass
   else
@@ -157,11 +170,19 @@ fi
 INDEX_URL="${AUTHED_BASE}/pypi/${REPO_KEY}/simple/"
 
 install_log="${WORK_DIR}/pip-install.log"
+# --only-binary=:all: forces pip to resolve the wheel and never fall back
+# to the sdist. Falling back would require pip to bootstrap setuptools>=61
+# from this same private index, which doesn't proxy public PyPI, so an
+# sdist resolution would always fail with "No matching distribution
+# found for setuptools>=61". Keeping the install wheel-only also matches
+# how the upload step above publishes both sdist + wheel: this asserts
+# the wheel survived the round trip.
 if pip install \
     --quiet \
     --disable-pip-version-check \
     --index-url "$INDEX_URL" \
     --trusted-host "$TRUSTED_HOST" \
+    --only-binary=:all: \
     --target "$INSTALL_TARGET" \
     "${PKG_NAME}==${PKG_VERSION}" \
     > "$install_log" 2>&1; then


### PR DESCRIPTION
## Summary

Release-gate run [25192394163](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25192394163) showed `format-tests (python)` still failing despite #112's twine bump. The new failure is one step further along: upload now succeeds, but `pip install` fails to resolve build dependencies.

## Failure mode

Run #25192394163, job `format-tests (python)`, sub-test `test-pypi-native-client.sh`, step *pip install pulls package from simple index*:

```
ERROR: Could not find a version that satisfies the requirement setuptools>=61 (from versions: none)
ERROR: No matching distribution found for setuptools>=61
```

The package being installed is an **sdist** (`.tar.gz`). When pip resolves an sdist it has to bootstrap the declared `[build-system].requires` (here, `setuptools>=61`) before it can build the wheel. The test invokes `pip install --index-url $INDEX_URL` pointing at the private PyPI repo on the backend, which does not proxy public PyPI, so `setuptools>=61` is never reachable.

PR #112 was correct on the upload side: twine 5.1.1's bundled `pkginfo` cannot parse the `Metadata-Version: 2.4` that setuptools 75 writes, so the upload was failing client-side before bytes left the runner. twine 6.1.0 fixes that, and the upload step now passes (visible in the same log: `twine upload pushes sdist (1s) PASS`). The install bug is downstream of that fix.

## Fix

Build a wheel alongside the sdist and upload both. `pip install --only-binary=:all:` then resolves the wheel directly and never invokes the build backend, so the `setuptools>=61` bootstrap problem is gone.

- `python -m build --sdist --wheel` (was `--sdist`)
- Pin `wheel==0.45.1` in the build-deps install
- twine uploads both `$SDIST_FILE` and `$WHEEL_FILE`
- Add `--only-binary=:all:` to the pip install

Choosing `--only-binary` over `--extra-index-url https://pypi.org/simple/`: the latter would introduce a hard dependency on public-PyPI reachability from cluster runners, which is exactly the kind of external-network coupling release-gate is supposed to avoid. The wheel-only path keeps the test hermetic and exercises the same code path real users hit when they publish wheels (the common case for pure-Python).

The sdist is still uploaded and indexed, so:
- twine's multipart encoding for sdist is still exercised on the upload
- the existing `simple/` listing assertions remain meaningful
- a future sub-test that wants to assert sdist resolution can opt in by dropping `--only-binary`

## Verification

Reproduced the build path locally with the same pinned versions in this PR (`build==1.2.2`, `setuptools==75.6.0`, `wheel==0.45.1`, `twine==6.1.0`):

- `python -m build --sdist --wheel` produces both `.tar.gz` and `.whl`
- `pip install --only-binary=:all: --no-index --find-links dist/ ...` installs the wheel cleanly
- `python -c "import ak_smoke; print(ak_smoke.hello())"` round-trips

CI on this PR will run the actual format-tests (python) job against a live backend, which is the only way to confirm end-to-end.

## Test plan

- [ ] release-gate `format-tests (python)` job passes on this PR
- [ ] `test-pypi-native-client.sh` reports 6/6 PASS (was 5/6)
- [ ] `test-pypi.sh`, `test-pypi-remote.sh`, `test-conda.sh`, `test-huggingface.sh`, `test-mlmodel.sh` remain green (no regressions)