### PR TITLE
fix(rbac): retry login_as on HTTP 429 so test-idor doesn't flake

### DIFF
--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -289,24 +289,52 @@ create_test_user() {
 # Log in as the named user and echo the access_token on stdout.
 # On failure, echoes empty string and the response body to stderr.
 #
+# Retries on HTTP 429 (auth rate-limit) because non-admin users are not in
+# RATE_LIMIT_EXEMPT_USERNAMES. When parallel suites burst-call /auth/login
+# (e.g. test-idor creates two users + logs one in, all in <1s), the bucket
+# can momentarily refuse the login that immediately follows. Same retry
+# budget as auth_admin: 5x3s = 15s. 429s honor a doubled delay.
+#
 # Usage:
 #   USER_TOKEN=$(login_as "$USERNAME" "$PASSWORD")
 login_as() {
   local username="$1"
   local password="$2"
-  local resp
-  resp=$(curl -sf $CURL_TIMEOUT -X POST \
-    -H "Content-Type: application/json" \
-    -d "{\"username\":\"${username}\",\"password\":\"${password}\"}" \
-    "${BASE_URL}/api/v1/auth/login" 2>/dev/null) || true
-  local tok
-  tok=$(echo "$resp" | jq -r '.access_token // .token // empty')
-  if [ -z "$tok" ] || [ "$tok" = "null" ]; then
-    echo "login_as failed for ${username}: ${resp:0:200}" >&2
-    echo ""
-    return 1
-  fi
-  echo "$tok"
+  local _max="${LOGIN_AS_MAX_ATTEMPTS:-5}"
+  local _delay="${LOGIN_AS_RETRY_DELAY:-3}"
+  local _attempt _http_status _body _tmp tok=""
+  for _attempt in $(seq 1 "$_max"); do
+    _tmp=$(mktemp)
+    _http_status=$(curl -s $CURL_TIMEOUT -o "$_tmp" -w '%{http_code}' \
+      -X POST -H "Content-Type: application/json" \
+      -d "{\"username\":\"${username}\",\"password\":\"${password}\"}" \
+      "${BASE_URL}/api/v1/auth/login" 2>/dev/null) || _http_status="000"
+    _body=$(cat "$_tmp" 2>/dev/null || true)
+    rm -f "$_tmp"
+
+    if [ "$_http_status" = "200" ] && [ -n "$_body" ]; then
+      tok=$(echo "$_body" | jq -r '.access_token // .token // empty')
+      if [ -n "$tok" ] && [ "$tok" != "null" ]; then
+        echo "$tok"
+        return 0
+      fi
+    fi
+
+    # Only retry on transient 429 / 503 / network. 401/400 are real failures.
+    if [ "$_http_status" != "429" ] && [ "$_http_status" != "503" ] && [ "$_http_status" != "000" ]; then
+      break
+    fi
+    if [ "$_attempt" -lt "$_max" ]; then
+      if [ "$_http_status" = "429" ]; then
+        sleep "$(( _delay * 2 ))"
+      else
+        sleep "$_delay"
+      fi
+    fi
+  done
+  echo "login_as failed for ${username} after ${_max} attempts (last HTTP ${_http_status}): ${_body:0:200}" >&2
+  echo ""
+  return 1
 }
 
 api_post() {

--- a/tests/rbac/test-idor.sh
+++ b/tests/rbac/test-idor.sh
@@ -56,16 +56,13 @@ fi
 # -------------------------------------------------------------------------
 
 begin_test "Login as User A"
-USER_A_TOKEN=""
-if resp=$(curl -sf $CURL_TIMEOUT -X POST "${BASE_URL}/api/v1/auth/login" \
-    -H "Content-Type: application/json" \
-    -d "{\"username\":\"${USER_A}\",\"password\":\"${USER_PASS}\"}" 2>/dev/null); then
-  USER_A_TOKEN=$(echo "$resp" | jq -r '.token // .access_token // empty') || true
-  if [ -n "$USER_A_TOKEN" ]; then
-    pass
-  else
-    fail "no token in login response"
-  fi
+# Use login_as helper so we get 429 retry behaviour. Non-admin users are not
+# in RATE_LIMIT_EXEMPT_USERNAMES, so a fresh login right after two POST
+# /api/v1/users calls (admin-token auth) can collide with the auth bucket
+# when many suites bootstrap in parallel (release-gate run 25192394163).
+USER_A_TOKEN=$(login_as "${USER_A}" "${USER_PASS}" || true)
+if [ -n "$USER_A_TOKEN" ]; then
+  pass
 else
   fail "login as User A failed"
 fi


### PR DESCRIPTION
## Summary

In release-gate run [25192394163](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25192394163), `rbac-tests` failed at `test-idor.sh > Login as User A`. The same test passed in run [25191428274](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25191428274). Cause: HTTP 429 from the backend's auth rate-limit bucket because non-admin users are not in `RATE_LIMIT_EXEMPT_USERNAMES` and the parallel-suite burst exhausted the window.

## Diagnosis

- Run 9 logs show `auth attempt 1/12 failed (HTTP 429, body: Rate limit exceeded...)` from the *next* test's `auth_admin` call (which has retry). The login in `test-idor.sh` itself used a single-shot `curl -sf` and saw the same 429 with no retry, so it failed immediately.
- `RATE_LIMIT_EXEMPT_USERNAMES: "admin"` only exempts the bootstrap user; freshly-created `e2e-idor-a-${RUN_ID}` is normally rate-limited (correct production behaviour).
- This is a flake (not a real bug): identical test code, identical backend, just window-timing dependent.

## Fix

- Centralise 429 / 503 / transient retry in `login_as` (5x3s budget, doubled wait on 429). 401/400 still fail-fast so real auth bugs are not masked.
- Update `test-idor.sh > Login as User A` to use `login_as` instead of inline curl.

## Test plan

- [x] `bash -n tests/lib/common.sh` and `bash -n tests/rbac/test-idor.sh` clean
- [ ] Release-gate run on this branch passes the `rbac-tests` job (CI)
- [ ] No regression in other rbac/security suites that already use `login_as` (helper is backwards-compatible: success path unchanged)

## Out of scope

- `security-tests` failed in this run too, but it was already failing in run 8 with the same 3 RESULT: FAIL signatures (cache-poisoning, cache-stampede, scan-completes lite-provenance + silent-success). That is a pre-existing condition, tracked separately. The user prompt incorrectly framed `security-tests` as a new failure.