### PR TITLE
fix(release-gate): exclude soft-failing stress-tests from gate-check rollup

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -997,13 +997,37 @@ jobs:
           path: /tmp/all-results/
           if-no-files-found: ignore
 
-      - name: Gate check - fail if any suite failed
+      - name: Gate check - fail if any required suite failed
+        # stress-tests is intentionally excluded from this rollup. The job
+        # has continue-on-error: true (see comment above the stress-tests
+        # job) so its outcome can be 'failure' on a flaky bcrypt-saturated
+        # run without blocking the release gate. The wildcard form
+        # contains(needs.*.result, 'failure') still observes that failure
+        # because needs.<job>.result reflects the job's outcome, not its
+        # continue-on-error-adjusted conclusion. So we list the required
+        # suites explicitly here. If you add a new required suite, add it
+        # to this list. Soft-failing suites (currently just stress-tests)
+        # stay off the list.
         if: >-
-          contains(needs.*.result, 'failure') ||
-          contains(needs.*.result, 'cancelled')
+          needs.clean-install-smoke.result == 'failure' || needs.clean-install-smoke.result == 'cancelled' ||
+          needs.deploy.result == 'failure' || needs.deploy.result == 'cancelled' ||
+          needs.format-tests.result == 'failure' || needs.format-tests.result == 'cancelled' ||
+          needs.security-tests.result == 'failure' || needs.security-tests.result == 'cancelled' ||
+          needs.compatibility-tests.result == 'failure' || needs.compatibility-tests.result == 'cancelled' ||
+          needs.repo-tests.result == 'failure' || needs.repo-tests.result == 'cancelled' ||
+          needs.promotion-tests.result == 'failure' || needs.promotion-tests.result == 'cancelled' ||
+          needs.rbac-tests.result == 'failure' || needs.rbac-tests.result == 'cancelled' ||
+          needs.lifecycle-tests.result == 'failure' || needs.lifecycle-tests.result == 'cancelled' ||
+          needs.webhook-tests.result == 'failure' || needs.webhook-tests.result == 'cancelled' ||
+          needs.search-tests.result == 'failure' || needs.search-tests.result == 'cancelled' ||
+          needs.platform-tests.result == 'failure' || needs.platform-tests.result == 'cancelled' ||
+          needs.auth-tests.result == 'failure' || needs.auth-tests.result == 'cancelled' ||
+          needs.resilience-tests.result == 'failure' || needs.resilience-tests.result == 'cancelled' ||
+          needs.mesh-tests.result == 'failure' || needs.mesh-tests.result == 'cancelled'
         run: |
-          echo "::error::Release gate FAILED - one or more test suites did not pass"
+          echo "::error::Release gate FAILED - one or more required test suites did not pass"
           echo "Review the workflow summary above for details"
+          echo "Note: stress-tests is non-blocking; its outcome is shown in the summary but does not gate the release"
           exit 1
 
   # -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Run 10 of the release gate (25194405511) still rolled stress-tests up as \`failure\` even though PR #120 added \`continue-on-error: true\` to that job. The collect-results gate-check exits 1 because the wildcard \`contains(needs.*.result, 'failure')\` catches stress-tests' failure outcome.

GitHub Actions semantics: \`continue-on-error: true\` at the job level allows the workflow to continue past the failure and changes the workflow run conclusion, but \`needs.<job>.result\` still reflects the job's outcome (\`failure\`), not the adjusted conclusion. The wildcard rollup observes that.

## Fix

Replace the \`contains(needs.*.result, 'failure')\` wildcard in the gate-check step with an explicit list of required suites that omits stress-tests. The job still runs, still publishes JUnit, and still appears in the per-suite status table in the workflow summary. It just no longer gates the release.

The job-level \`continue-on-error: true\` from #120 stays in place. The stress job's \`if:\` condition is unchanged. Resilience-tests no longer depending on stress-tests is preserved from #120.

## How this fixes run 10

Before:

\`\`\`
needs.stress-tests.result == 'failure'
contains(needs.*.result, 'failure') -> true
Gate check -> exit 1 -> collect-results failure
\`\`\`

After:

\`\`\`
needs.stress-tests.result == 'failure'   (still)
gate-check predicate omits stress-tests
Gate check -> if condition false, step skipped
collect-results -> success
\`\`\`

## Test plan

- [ ] Trigger \`release-gate.yml\` against a v1.1-dev backend tag where stress-tests is expected to fail
- [ ] Verify stress-tests reports \`failure\` in the summary table
- [ ] Verify collect-results completes \`success\`
- [ ] Verify teardown still runs

## Notes

- If a future suite is added that should be required, append it to the explicit \`if\` list in collect-results
- Non-blocking suites stay off the list. Currently only stress-tests
- Real perf regressions are still caught by dedicated benchmark workflows on Rocky, not by this CI smoke gate