### PR TITLE
fix(scan-gate): sleep past +2s recency threshold before scan trigger

### DIFF
--- a/tests/security/test-scan-completes.sh
+++ b/tests/security/test-scan-completes.sh
@@ -251,9 +251,22 @@ fi
 # `date +%s` 1-second granularity and any clock-skew between the runner
 # and the backend pod (usually co-located on the same node, so skew is
 # bounded).
+#
+# We also sleep 2s+1 here so that any scan triggered after this point
+# has a `created_at` whose second-truncated value strictly exceeds
+# (TEST_START_EPOCH + 2). Without this sleep, a backend that scans
+# fast enough to complete in <1s relative to wall-clock will produce
+# a created_at truncated to the SAME second as TEST_START_EPOCH, which
+# fails `>= TEST_START_EPOCH + 2`. That is a false-positive: the scan
+# is in fact fresh, but the second-precision truncation hides it.
+# Observed against trivy in a co-located ARC runner / backend pod:
+# scan started_at and TEST_START_EPOCH both fell in the same wall
+# second. Sleeping past the +2 threshold makes the assertion robust
+# regardless of how fast the backend completes the scan.
 # ---------------------------------------------------------------------------
 
 TEST_START_EPOCH=$(date -u +%s)
+sleep 3
 
 # ---------------------------------------------------------------------------
 # Resolve the artifact_id. The metadata endpoint is GET /:key/artifacts/*path


### PR DESCRIPTION
## Summary

Fixes #123. Release-gate Run 10 [25194405511] caught a false-positive failure in test-scan-completes.sh:

```
FAIL: scan 87b3b58e... fails lite provenance: completed_at=1, error_message_clean=1, scan_is_recent=0
(TEST_START_EPOCH=1777592110)
scan response started_at=2026-04-30T23:35:10.977938Z, created_at=2026-04-30T23:35:10.977938Z
```

Both `TEST_START_EPOCH` and the scan's `created_at` fell in the same wall-clock second. The recency assertion truncates `created_at` to second precision (since `date -u +%s` is also second-precision) and checks `>= TEST_START_EPOCH + 2`. With both values truncated to the same second, `1777592110 >= 1777592112` evaluates false even though the scan IS legitimately fresh.

## Root cause

The `+2s` buffer was introduced to defeat the auto-scan-on-upload race -- ensuring the scan we trigger has `created_at` strictly greater than any auto-triggered scan from the upload. The intent is correct, but the implementation only enforces the threshold in the assertion, not as a precondition. A co-located ARC runner / backend pod (the common case) routinely turns a scan around in less than 1s, violating the precondition and false-positiving the assertion.

## Fix

Sleep 3s after capturing `TEST_START_EPOCH` and before triggering the scan. This guarantees any subsequent scan's `created_at` second-truncated value strictly exceeds `TEST_START_EPOCH + 2`, regardless of how fast the backend processes the trigger. 3 (not 2) gives a 1s safety margin for sub-second clock skew between the runner and the backend pod.

## Cost

~3s added to one test path. The rest of the suite is dominated by `SCAN_TIMEOUT` (60s default) polling, and the per-test wrapper in `run-suite.sh` is 120s. 3s does not push the test budget anywhere near limits.

## Test plan

- [ ] Re-run release-gate against the rc with this PR; lite provenance asserts deterministically
- [ ] Verify `bash -n tests/security/test-scan-completes.sh` clean (done locally)
- [ ] Confirm no new shellcheck warnings introduced (done locally; only pre-existing SC1091/SC2034)