### PR TITLE
fix(auth): retry password change flakes and capture diagnostics

### DIFF
--- a/tests/auth/test-session-invalidation.sh
+++ b/tests/auth/test-session-invalidation.sh
@@ -83,16 +83,43 @@ fi
 begin_test "Change user password"
 PASSWORD_CHANGED=false
 if [ -n "${TOKEN_T1:-}" ]; then
-  # POST /api/v1/users/{id}/password requires admin_middleware, so use admin token.
-  # Admins can change any user's password without current_password.
-  if curl -sf $CURL_TIMEOUT -X POST \
-      -H "$(auth_header)" -H "Content-Type: application/json" \
-      -d "{\"new_password\":\"${NEW_PASS}\"}" \
-      "${BASE_URL}/api/v1/users/${USER_ID}/password" > /dev/null 2>&1; then
+  # POST /api/v1/users/{id}/password requires admin auth; auth_header() carries
+  # the admin token captured at suite start. Admins can change any user's
+  # password without supplying current_password.
+  #
+  # Retry transient failures (5xx, 429, network 000) up to 3 times to absorb
+  # the occasional in-cluster blip. Capture status + body so any future failure
+  # surfaces the actual response instead of an opaque "could not change".
+  pwc_tmp=$(mktemp)
+  pwc_status="000"
+  pwc_body=""
+  for pwc_attempt in 1 2 3; do
+    pwc_status=$(curl -s $CURL_TIMEOUT -o "$pwc_tmp" -w '%{http_code}' -X POST \
+        -H "$(auth_header)" -H "Content-Type: application/json" \
+        -d "{\"new_password\":\"${NEW_PASS}\"}" \
+        "${BASE_URL}/api/v1/users/${USER_ID}/password" 2>/dev/null) || pwc_status="000"
+    pwc_body=$(cat "$pwc_tmp" 2>/dev/null || true)
+    if [ "$pwc_status" -ge 200 ] 2>/dev/null && [ "$pwc_status" -lt 300 ] 2>/dev/null; then
+      break
+    fi
+    # Only retry transient classes; deterministic 4xx (except 429) won't recover.
+    case "$pwc_status" in
+      000|429|5*)
+        echo "  attempt ${pwc_attempt}/3: password change returned HTTP ${pwc_status}, retrying..."
+        sleep 2
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  rm -f "$pwc_tmp"
+  if [ "$pwc_status" -ge 200 ] 2>/dev/null && [ "$pwc_status" -lt 300 ] 2>/dev/null; then
     PASSWORD_CHANGED=true
     pass
   else
-    fail "could not change password via POST /users/{id}/password"
+    pwc_snip="${pwc_body:0:200}"
+    fail "could not change password via POST /users/{id}/password (HTTP ${pwc_status}, body: ${pwc_snip:-<empty>})"
   fi
 else
   skip "no user token"


### PR DESCRIPTION
## Summary

Run [25194405511](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25194405511) failed at "Change user password" in `test-session-invalidation.sh`. The immediately prior run [25192394163](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25192394163) passed all 8 steps in this suite on the same backend image (v1.1.6) and same test commit. No relevant code changes between the two runs; the failure is a transient cluster blip during the POST.

The bigger problem: the original `curl -sf ... > /dev/null 2>&1` discarded both the HTTP status and the response body, so the only signal on failure was `FAIL: could not change password via POST /users/{id}/password`. There was no way to tell whether the backend returned 401, 429, 500, or refused the connection.

This PR:
- Captures `%{http_code}` and the response body, surfaces both in the FAIL message so the next failure is diagnosable.
- Retries up to 3 times on transient classes (5xx, 429, network 000) with a 2s backoff. 4xx (other than 429) fails immediately, matching the retry policy already in `auth_admin()` (`tests/lib/common.sh`).
- No backend change required. The handler at `backend/src/api/handlers/users.rs:816` is correct.

## Investigation

- Run 10 sha `578cb97`, run 9 sha `f66e758` — only `release-gate` workflow + conan/pypi/rbac fixes between them, none touch this test.
- Both runs ran on backend v1.1.6, both in isolated namespaces (`e2e-1777591733-89` vs `e2e-1777588060-88`).
- Looked back 10 release-gate runs: this exact failure mode appears once. Earlier auth-tests failures were either unrelated steps or the suite skipped.
- Failure took ~420ms, similar to the success path (~440ms), so this was not an instant 401 or rate-limit reject. Most likely a transient blip during the in-cluster HTTP call.

## Test Plan

- [x] `bash -n tests/auth/test-session-invalidation.sh`
- [x] shellcheck: no new issues introduced (existing SC2086 notices are pre-existing on `$CURL_TIMEOUT` and consistent with the rest of the file)
- [ ] Release-gate `auth-tests` job passes on this branch's CI run