### PR TITLE
fix(webhooks): use repository.created as test trigger event (#909 regression test)

### DIFF
--- a/tests/webhooks/test-webhook-delivery.sh
+++ b/tests/webhooks/test-webhook-delivery.sh
@@ -1,9 +1,43 @@
 #!/usr/bin/env bash
-# test-webhook-delivery.sh - Webhook delivery on artifact upload E2E test
+# test-webhook-delivery.sh - Webhook producer delivery enqueue regression test
 #
-# Creates a webhook, uploads an artifact, verifies the delivery was logged.
+# This is the regression test for artifact-keeper#909 (webhook v2 event
+# producer): subscribing a webhook to a real EventBus event must result in
+# a row being inserted into webhook_deliveries when that event fires.
+#
+# Trigger choice: repository.created
+#
+#   The previous version of this test used "artifact.uploaded" as the
+#   trigger, but no handler on release/1.1.x emits that event type. The
+#   only artifact-side event currently emitted is "artifact.created",
+#   which has its own scoping problems (entity_id is the artifact UUID,
+#   not the repo, so the producer cannot match a repo-scoped webhook on
+#   release/1.1.x where DomainEvent has no explicit repository_id field;
+#   see FIXME(#948) in webhook_producer.rs).
+#
+#   repository.created sidesteps that problem: the entity_id IS the
+#   repository UUID, and we can match it with a global webhook
+#   (repository_id IS NULL), which the producer's matching predicate
+#   ("repository_id IS NULL OR repository_id = $2") accepts.
+#
+#   Until #948 lands proper repo scoping for non-repo events on the
+#   1.1.x branch, this test uses repository creation as the trigger.
+#   That is enough to prove the producer task is alive, mapping
+#   EventBus events to webhook event names, and inserting deliveries.
+#
+# What we assert (the regression bar for #909):
+#   1. A webhook subscribed to "repository_created" (the mapped name)
+#      gets a webhook_deliveries row inserted within 30s of repo
+#      creation.
+#   2. The delivery row has event="repository_created".
+#   3. The delivery payload contains the entity_id (the new repo's
+#      UUID), proving the producer wired the EventBus payload through.
+#
+# If the producer task panics, is removed, or stops subscribing to the
+# bus, this test fails hard. No silent skip on missing deliveries.
 #
 # Requires: curl, jq
+
 source "$(dirname "$0")/../lib/common.sh"
 
 begin_suite "webhook-delivery"
@@ -12,93 +46,126 @@ setup_workdir
 
 REPO_KEY="test-whk-delivery-${RUN_ID}"
 WEBHOOK_NAME="delivery-test-${RUN_ID}"
-
-begin_test "Create repo"
-if create_local_repo "$REPO_KEY" "generic"; then
-  pass
-else
-  fail "could not create repo"
-fi
+WEBHOOK_ID=""
 
 # -------------------------------------------------------------------------
-# Create webhook targeting the repo
+# Create a global webhook subscribed to repository_created BEFORE the
+# repo exists. Ordering matters: the event is fanned out to webhooks
+# matching at emit time, so the subscription must be in place first.
 # -------------------------------------------------------------------------
 
-begin_test "Create webhook for artifact.uploaded events"
+begin_test "Create webhook subscribed to repository_created"
 WEBHOOK_PAYLOAD='{
   "name": "'"${WEBHOOK_NAME}"'",
-  "url": "https://httpbin.org/post",
-  "events": ["artifact.uploaded"],
-  "repository_key": "'"${REPO_KEY}"'",
+  "url": "https://example.invalid/webhook-sink",
+  "events": ["repository_created"],
   "enabled": true
 }'
 if resp=$(api_post "/api/v1/webhooks" "$WEBHOOK_PAYLOAD" 2>/dev/null); then
   WEBHOOK_ID=$(echo "$resp" | jq -r '.id // empty') || true
-  pass
+  if [ -z "$WEBHOOK_ID" ] || [ "$WEBHOOK_ID" = "null" ]; then
+    fail "webhook create returned no id: ${resp:0:200}"
+  else
+    pass
+  fi
 else
-  skip "webhooks not available"
+  fail "webhook create request failed"
 fi
 
 # -------------------------------------------------------------------------
-# Upload artifact to trigger webhook
+# Trigger the event by creating a repository. The backend emits
+# "repository.created" via EventBus, the producer maps it to
+# "repository_created", matches the global webhook above, and inserts
+# a webhook_deliveries row.
 # -------------------------------------------------------------------------
 
-begin_test "Upload artifact to trigger webhook"
-echo "webhook-trigger-${RUN_ID}" > "${WORK_DIR}/trigger.bin"
-if api_upload "/api/v1/repositories/${REPO_KEY}/artifacts/trigger.bin" \
-    "${WORK_DIR}/trigger.bin"; then
-  pass
+REPO_ID=""
+
+begin_test "Create repo to trigger repository.created event"
+REPO_CREATE_PAYLOAD="{\"key\":\"${REPO_KEY}\",\"name\":\"${REPO_KEY}\",\"format\":\"generic\",\"repo_type\":\"local\",\"is_public\":true}"
+if resp=$(api_post "/api/v1/repositories" "$REPO_CREATE_PAYLOAD" 2>/dev/null); then
+  REPO_ID=$(echo "$resp" | jq -r '.id // empty') || true
+  if [ -z "$REPO_ID" ] || [ "$REPO_ID" = "null" ]; then
+    fail "repo create returned no id: ${resp:0:200}"
+  else
+    pass
+  fi
 else
-  fail "upload failed"
+  fail "repo create request failed"
 fi
 
 # -------------------------------------------------------------------------
-# Verify delivery was logged
+# Strict assertion: a delivery row must exist within 30s. This is the
+# regression test for #909. Do NOT skip on empty results.
 # -------------------------------------------------------------------------
 
 DELIVERY_RESP=""
-delivery_found=false
+delivery_count=0
 
-begin_test "Verify webhook delivery logged"
-if [ -n "${WEBHOOK_ID:-}" ] && [ "$WEBHOOK_ID" != "null" ]; then
-  for attempt in 1 2 3; do
-    sleep 5
+begin_test "Webhook delivery row inserted within 30s"
+if [ -z "$WEBHOOK_ID" ]; then
+  fail "no webhook id from earlier step"
+else
+  for attempt in $(seq 1 15); do
+    sleep 2
     if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}/deliveries" 2>/dev/null); then
       DELIVERY_RESP="$resp"
-      count=$(echo "$resp" | jq '
+      delivery_count=$(echo "$resp" | jq '
         if type == "array" then length
         elif .items then (.items | length)
         elif .total != null then .total
         else 0
-        end' 2>/dev/null) || count=0
-      if [ "$count" -gt 0 ]; then
-        delivery_found=true
+        end' 2>/dev/null) || delivery_count=0
+      if [ "$delivery_count" -gt 0 ]; then
         break
       fi
-      echo "  Attempt ${attempt}/3: zero deliveries, retrying..."
-    else
-      echo "  Attempt ${attempt}/3: delivery listing request failed, retrying..."
     fi
   done
-  if [ "$delivery_found" = true ]; then
+  if [ "$delivery_count" -gt 0 ]; then
     pass
   else
-    skip "webhook delivery may be async or endpoint unreachable in CI"
+    fail "no webhook_deliveries row appeared within 30s for webhook ${WEBHOOK_ID} after creating repo ${REPO_ID}; producer may not be running" "${DELIVERY_RESP:0:500}"
   fi
-else
-  skip "no webhook ID"
 fi
 
-begin_test "Delivery payload contains event type"
-if [ "$delivery_found" = true ]; then
-  if assert_contains "$DELIVERY_RESP" "event"; then
+# -------------------------------------------------------------------------
+# Confirm the delivery row carries the right event name. This catches
+# regressions in webhook_producer::map_event_type.
+# -------------------------------------------------------------------------
+
+begin_test "Delivery event field is 'repository_created'"
+if [ "$delivery_count" -gt 0 ]; then
+  event_name=$(echo "$DELIVERY_RESP" | jq -r '
+    if type == "array" then .[0].event
+    elif .items then .items[0].event
+    else empty
+    end' 2>/dev/null) || event_name=""
+  if [ "$event_name" = "repository_created" ]; then
+    pass
+  else
+    fail "expected event='repository_created', got '${event_name}'" "${DELIVERY_RESP:0:500}"
+  fi
+else
+  fail "no delivery row to inspect"
+fi
+
+# -------------------------------------------------------------------------
+# Confirm the delivery payload contains the new repo's UUID. This
+# proves the producer pulled the EventBus entity_id through into the
+# enqueued payload (build_event_payload in webhook_producer.rs).
+# -------------------------------------------------------------------------
+
+begin_test "Delivery payload contains new repo entity_id"
+if [ "$delivery_count" -gt 0 ] && [ -n "$REPO_ID" ]; then
+  if assert_contains "$DELIVERY_RESP" "$REPO_ID"; then
     pass
   fi
 else
-  skip "no deliveries to check"
+  fail "no delivery row or no repo id to check"
 fi
 
 # Cleanup
 api_delete "/api/v1/webhooks/${WEBHOOK_ID}" > /dev/null 2>&1 || true
+api_delete "/api/v1/repositories/${REPO_KEY}" > /dev/null 2>&1 || true
 
 end_suite


### PR DESCRIPTION
## Summary

The webhook delivery E2E test (`tests/webhooks/test-webhook-delivery.sh`)
was a false positive. It subscribed a webhook to `artifact.uploaded` and
uploaded a file, but **no handler on `release/1.1.x` emits an
`artifact.uploaded` event**. When no delivery row appeared, the test fell
through to:

```bash
skip "webhook delivery may be async or endpoint unreachable in CI"
```

That made it useless as the regression test for #909 (webhook v2 event
producer). A producer regression -- subscription removed, producer task
panicking, `map_event_type` breaking -- would not be caught.

## What changed

Refactor the test to fire a real event and hard-assert on the delivery
row.

- Subscribe a **global** webhook (no `repository_id`) to
  `repository_created` -- the mapped event name produced by
  `webhook_producer::map_event_type` from the EventBus
  `repository.created` event emitted by the repositories handler
  (`backend/src/api/handlers/repositories.rs:678` on `release/1.1.x`).
- Trigger the event by creating a repository as admin.
- Poll `GET /api/v1/webhooks/{id}/deliveries` for up to 30s. **Hard
  fail** if no row appears -- no silent skip.
- Assert the delivery's `event` field equals `repository_created`
  (catches `map_event_type` regressions).
- Assert the response body contains the new repo's UUID (proves the
  producer wired the EventBus payload through into
  `build_event_payload`).

## Why `repository.created` and not `artifact.created`

`artifact.created` IS emitted on `release/1.1.x`, but the
producer's matching SQL is:

```
WHERE is_enabled = true
  AND $1 = ANY(events)
  AND (repository_id IS NULL OR repository_id = $2)
```

with `$2 = uuid::parse(event.entity_id).ok()`. For
`artifact.created`, `entity_id` is the artifact UUID, not the repo
UUID, so a repo-scoped webhook cannot match it on `release/1.1.x`
where `DomainEvent` has no explicit `repository_id` field
(see `FIXME(#948)` in `webhook_producer.rs`).

`repository.created` sidesteps this: `entity_id` IS the new repo's
UUID, and a global webhook (`repository_id IS NULL`) matches cleanly.
Until #948 lands proper repo scoping for non-repo events on the
`1.1.x` branch, repository creation is the cleanest trigger to
validate the producer end-to-end.

A header comment in the test documents this trade-off so it doesn't
get re-litigated next time.

## Verification of the assumption

Grepped emit sites on `origin/release/1.1.x`:

```
$ git grep -nE "event_bus.emit|\.emit\(" origin/release/1.1.x -- backend/src/
groups.rs        group.created, group.updated, group.deleted, group.member_added, group.member_removed
permissions.rs   permission.created, permission.updated, permission.deleted
quality_gates.rs quality_gate.created, quality_gate.updated, quality_gate.deleted
repositories.rs  repository.created, repository.updated, repository.deleted
service_accounts service_account.{created,updated,deleted}
users.rs         user.created, user.updated, user.deleted
```

No `artifact.uploaded` emit anywhere. Confirmed.

`map_event_type` on `feat/webhooks-producer-909` includes
`"repository.created" => Some("repository_created")`, so the chosen
event is mapped and will match a webhook subscribed to
`repository_created`.

## Test plan

- [x] `bash -n tests/webhooks/test-webhook-delivery.sh` (clean)
- [ ] release-gate run against a backend with the #909 producer landed:
      this suite is now strict and will fail if the producer is missing
- [ ] release-gate run against a backend WITHOUT #909: this test should
      fail (`no webhook_deliveries row appeared within 30s ... producer
      may not be running`) -- this is the desired negative-control
      behaviour