### PR TITLE
fix(auth): retry 429 in totp-backup-codes login helper

### DIFF
--- a/tests/auth/test-totp-backup-codes.sh
+++ b/tests/auth/test-totp-backup-codes.sh
@@ -111,21 +111,62 @@ fi
 # script before the test could assert that 401 was the expected outcome —
 # which is exactly the bug release-gate run 25191428274 surfaced for the
 # "Replay of the same backup code is rejected" case.
+#
+# Login is retried on transient failures (HTTP 429 / 5xx / curl error). Each
+# call to this helper performs a username+password login, and the loginAuth
+# rate limiter throttles bursts per-user. The "Each remaining backup code is
+# single-use" test makes ~18 logins back-to-back, so retry-on-429 is required
+# to avoid the no_totp_token sentinel surfacing as a flake (release-gate run
+# 25214268566 / job 73931323974 hit this on backup code [4]).
 # -------------------------------------------------------------------------
 
 login_and_verify_with_code() {
   local backup_code="$1"
-  local login_resp
-  login_resp=$(curl -sf $CURL_TIMEOUT -X POST \
-    -H "Content-Type: application/json" \
-    -d "{\"username\":\"${TOTP_USER}\",\"password\":\"${TOTP_PASS}\"}" \
-    "${BASE_URL}/api/v1/auth/login" 2>/dev/null) || true
-  local totp_token
-  totp_token=$(echo "$login_resp" | jq -r '.totp_token // empty')
-  if [ -z "$totp_token" ] || [ "$totp_token" = "null" ]; then
+  local _max="${LOGIN_VERIFY_MAX_ATTEMPTS:-8}"
+  local _delay="${LOGIN_VERIFY_RETRY_DELAY:-3}"
+  local _attempt _http_status _body _tmp totp_token=""
+  for _attempt in $(seq 1 "$_max"); do
+    _tmp=$(mktemp)
+    _http_status=$(curl -s --max-time 10 -o "$_tmp" -w '%{http_code}' \
+      -X POST "${BASE_URL}/api/v1/auth/login" \
+      -H "Content-Type: application/json" \
+      -d "{\"username\":\"${TOTP_USER}\",\"password\":\"${TOTP_PASS}\"}" 2>/dev/null) || _http_status="000"
+    _body=$(cat "$_tmp" 2>/dev/null || true)
+    rm -f "$_tmp"
+
+    if [ "$_http_status" = "200" ]; then
+      totp_token=$(echo "$_body" | jq -r '.totp_token // empty' 2>/dev/null)
+      [ -n "$totp_token" ] && [ "$totp_token" != "null" ] && break
+      totp_token=""
+    fi
+
+    # Only retry on transient failures. A non-200 with a parseable body that
+    # isn't 429/5xx/000 means the backend rejected the credentials for some
+    # other reason and retrying won't help.
+    case "$_http_status" in
+      429|500|502|503|504|000) ;;
+      *)
+        # Non-transient: bail out so the caller sees the sentinel rather than
+        # spinning for ~24s on a permanent error.
+        break
+        ;;
+    esac
+
+    if [ "$_attempt" -lt "$_max" ]; then
+      echo "  login_and_verify retry ${_attempt}/${_max} (HTTP ${_http_status}), sleeping ${_delay}s..." 1>&2
+      if [ "$_http_status" = "429" ]; then
+        sleep "$(( _delay * 2 ))"
+      else
+        sleep "$_delay"
+      fi
+    fi
+  done
+
+  if [ -z "$totp_token" ]; then
     echo "no_totp_token"
     return 0
   fi
+
   local status
   status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
     -X POST \


### PR DESCRIPTION
## Summary

Release-gate run [25214268566](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25214268566) (job 73931323974) failed `auth-tests` on `test-totp-backup-codes.sh` at the "Each remaining backup code is single-use" assertion: backup code [4] replay returned `HTTP no_totp_token` instead of 401.

The sentinel meant the inline login inside `login_and_verify_with_code` got rate-limited (the very next suite in the same job, `test-totp-disable.sh`, immediately reported `auth attempt 1/12 failed (HTTP 429)`), so curl returned no body and the helper bailed out before reaching the verify endpoint that produces the 401.

## Root cause

`login_and_verify_with_code` performs a full username+password login every call so it can pick up a fresh `totp_token`. The single-use loop calls it 18 times back-to-back; once other auth suites are running in parallel that trips the loginAuth rate limiter. The helper used `curl -sf`, which swallowed the 429.

This is a NEW failure mode, distinct from the password-change flake PR #125 fixed (that one passed in run 11). Run 11 progressed further into auth-tests because of #125, exposing this latent issue.

## Fix

Mirror the retry pattern `auth_admin` already uses in `tests/lib/common.sh`:

- Drop `-sf` so the response body and status code are visible.
- Retry only on transient failures (429, 5xx, curl error 000); bail out on 4xx so a real credential failure surfaces immediately.
- Double the sleep on 429 to honor the rate limiter.
- Configurable via `LOGIN_VERIFY_MAX_ATTEMPTS` / `LOGIN_VERIFY_RETRY_DELAY` env vars.

The helper still returns 0 in every path so `set -e` does not abort when callers expect 401 (the path PR #110 fixed for backup-code replay).

## Triage notes

- PR #993 (admin-gating webhook endpoints) is unrelated; auth-tests do not exercise webhook routes.
- Classification: test-side flake from rate limiter, not a backend regression. No artifact-keeper issue filed.

## Test plan

- [x] `bash -n tests/auth/test-totp-backup-codes.sh` clean
- [x] em-dash and emoji rules respected in new code
- [ ] Release-gate run on this PR's branch passes auth-tests