### PR TITLE
fix(security): retry positive admin login on 429 in test-default-credentials

### DIFF
--- a/tests/security/test-default-credentials.sh
+++ b/tests/security/test-default-credentials.sh
@@ -109,14 +109,46 @@ fi
 
 # ---------------------------------------------------------------------------
 # Verify that the actual test credentials still work
+#
+# Six wrong-credential attempts above can trip the per-IP auth rate limiter
+# (429). admin is in RATE_LIMIT_EXEMPT_USERNAMES for username-bucket checks,
+# but the IP bucket counts every failed login regardless of username. So the
+# positive assertion below has to tolerate a transient 429 by waiting for
+# the bucket to refill. Same retry budget pattern as auth_admin / login_as
+# (PR #118): 5 attempts with 3s base delay, doubled on 429.
 # ---------------------------------------------------------------------------
 
 begin_test "Actual admin credentials are accepted"
-status=$(try_login "$ADMIN_USER" "$ADMIN_PASS")
+_max_attempts="${ADMIN_LOGIN_MAX_ATTEMPTS:-5}"
+_base_delay="${ADMIN_LOGIN_RETRY_DELAY:-3}"
+status="000"
+for _attempt in $(seq 1 "$_max_attempts"); do
+  status=$(try_login "$ADMIN_USER" "$ADMIN_PASS")
+  if [ "$status" = "200" ]; then
+    break
+  fi
+  # Only retry on transient throttling / readiness signals. 401 / 403 mean
+  # the creds genuinely don't work and retrying would just mask a real bug.
+  case "$status" in
+    429|503|000)
+      if [ "$_attempt" -lt "$_max_attempts" ]; then
+        if [ "$status" = "429" ]; then
+          sleep "$(( _base_delay * 2 ))"
+        else
+          sleep "$_base_delay"
+        fi
+        continue
+      fi
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 if [ "$status" = "200" ]; then
   pass
 else
-  fail "expected admin credentials to be accepted, got HTTP ${status}"
+  fail "expected admin credentials to be accepted, got HTTP ${status} after ${_max_attempts} attempts"
 fi
 
 end_suite


### PR DESCRIPTION
## Summary

In release-gate run [25214268566](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25214268566), `security-tests` failed at `test-default-credentials.sh > Actual admin credentials are accepted`:

```
--- Actual admin credentials are accepted ---
  FAIL: expected admin credentials to be accepted, got HTTP 429 (0s)
```

The six preceding wrong-credential `try_login` calls (admin:admin, admin:password, root:root, admin:changeme, admin:12345, root:admin) trip the per-IP auth rate limiter. `admin` is in `RATE_LIMIT_EXEMPT_USERNAMES` for the username bucket, but the IP bucket counts every failed login regardless of which username was tried. The positive assertion that runs immediately after races the bucket-refill window.

## Diagnosis

- Six failed-login attempts from the same source IP, then a positive assertion in the same wall-clock second.
- `RATE_LIMIT_EXEMPT_USERNAMES` only covers the username bucket. The IP bucket has no exemption, by design.
- Identical flake class to the one PR #118 fixed for `login_as` in test-idor: real cluster-timing variance, no underlying backend bug.

## Fix

Wrap the final positive assertion in the same retry policy used by `auth_admin` and `login_as`:

- 5 attempts, 3s base delay, doubled to 6s on 429.
- Only retry on transient signals (429, 503, 000). 401 / 403 still fail-fast so a genuine auth regression is not masked.
- Configurable via `ADMIN_LOGIN_MAX_ATTEMPTS` and `ADMIN_LOGIN_RETRY_DELAY` env vars for local debugging.

## Test plan

- [x] `bash -n tests/security/test-default-credentials.sh` clean
- [ ] Release-gate run on this branch passes the `security-tests` job (CI)
- [ ] Wrong-credential rejection assertions are unchanged so the security property is still exercised

## Related

- Sibling fix: PR #118 (same retry pattern for `login_as`)
- Other security-tests failures in run 11 are pre-existing and tracked separately (cache-poisoning + cache-stampede in PR #126; scan-completes silent-success backend issue filed against artifact-keeper)
- Milestone: v1.1.9