### PR TITLE
fix(maven): retry transient mvn deploy:deploy-file failures

### DIFF
--- a/tests/formats/test-maven-native-client.sh
+++ b/tests/formats/test-maven-native-client.sh
@@ -158,17 +158,39 @@ fi
 # -------------------------------------------------------------------------
 
 begin_test "mvn deploy:deploy-file pushes JAR + POM"
+# The maven-deploy-plugin (default v2.7) uses the legacy Wagon HTTP transport,
+# which has no built-in retry. A transient 401/5xx from the backend during the
+# initial PUT (POM upload) tanks the whole deploy. Run 25214268566 hit this on
+# v1.1.6 with no test/backend changes vs the run that passed (25194405511);
+# the deploy reported "401 Unauthorized" while curl-based maven, mvn
+# dependency:get, and other format tests in the same namespace worked fine.
+#
+# Retry up to 3 times on any failure with a 2s backoff, mirroring the policy
+# already used by auth_admin() in tests/lib/common.sh and the password-change
+# retry added in PR #125.
 deploy_log="${WORK_DIR}/mvn-deploy.log"
-if mvn -B -q --settings "$SETTINGS_FILE" \
-    deploy:deploy-file \
-    -Dfile="$JAR_FILE" \
-    -DpomFile="$POM_FILE" \
-    -DrepositoryId="ak-test" \
-    -Durl="$MAVEN_URL" \
-    > "$deploy_log" 2>&1; then
+deploy_attempts=3
+deploy_ok=false
+for deploy_attempt in $(seq 1 "$deploy_attempts"); do
+  if mvn -B -q --settings "$SETTINGS_FILE" \
+      deploy:deploy-file \
+      -Dfile="$JAR_FILE" \
+      -DpomFile="$POM_FILE" \
+      -DrepositoryId="ak-test" \
+      -Durl="$MAVEN_URL" \
+      > "$deploy_log" 2>&1; then
+    deploy_ok=true
+    break
+  fi
+  if [ "$deploy_attempt" -lt "$deploy_attempts" ]; then
+    echo "  mvn deploy:deploy-file attempt ${deploy_attempt}/${deploy_attempts} failed, retrying in 2s..."
+    sleep 2
+  fi
+done
+if $deploy_ok; then
   pass
 else
-  fail "mvn deploy:deploy-file failed; tail of log: $(tail -n 20 "$deploy_log" | tr '\n' ' ')"
+  fail "mvn deploy:deploy-file failed after ${deploy_attempts} attempts; tail of log: $(tail -n 20 "$deploy_log" | tr '\n' ' ')"
 fi
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`format-tests (jvm)` flaked on Release Gate run [25214268566](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25214268566) (run 11): `test-maven-native-client.sh` failed at the `mvn deploy:deploy-file` step with `401 Unauthorized` on the POM upload, while every other Maven test in the same job (test-maven.sh, test-maven-remote.sh, test-maven-virtual-snapshot.sh) passed using curl with preemptive Basic auth. Run [25194405511](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25194405511) (run 10) passed the same test on the same backend image (v1.1.6) with no test/backend changes between runs.

The failure path:

```
Failed to deploy artifacts: ... authentication failed for
http://artifact-keeper-backend.test-e2e-1777638612-90.svc.cluster.local:8080/maven/test-mvn-nc-e2e-1777638612-90/com/example/native/native-smoke/1.0.0/native-smoke-1.0.0.pom,
status: 401 Unauthorized
```

18 seconds later in the same script, `mvn dependency:get` against the same URL with the same settings.xml returned 200. The backend's auth path was healthy.

## Root cause

The `maven-deploy-plugin` defaults to v2.7 (released ~2012), which uses the legacy Wagon HTTP transport with reactive Basic auth and no built-in retry. A single transient backend hiccup during the initial PUT aborts the whole deploy. Curl-based tests in the same job avoid this because they send credentials preemptively in one shot.

## Fix

Retry `mvn deploy:deploy-file` up to 3 times with a 2s backoff, matching the retry policy already used by `auth_admin()` in `tests/lib/common.sh` and the password-change retry added in #125.

## Test plan

- [x] `bash -n tests/formats/test-maven-native-client.sh` (syntax check)
- [ ] Re-run Release Gate workflow_dispatch and confirm `format-tests (jvm)` passes
- [ ] Confirm `mvn deploy:deploy-file` still passes on the first attempt in the steady-state case (no regression in pass timing)

## Out of scope

No backend change. The backend's Maven format handler and auth middleware are correct; this fix only hardens the test against transient cluster blips, mirroring the v1.1.9 hardening pattern established by #125.