### PR TITLE
fix(conan): retry transient 401 on format-native PUTs to absorb 1.1.x bcrypt flakes

### DIFF
--- a/tests/formats/test-conan-packages.sh
+++ b/tests/formats/test-conan-packages.sh
@@ -242,11 +242,13 @@ EOF
 
 PKG2_FILE_BASE="${RECIPE_BASE}/revisions/${RECIPE_REV}/packages/${PKG_ID_2}/revisions/${PKG_REV_2}/files"
 
-status=$(curl -s -o /dev/null -w '%{http_code}' -X PUT \
-  -H "$(format_auth_header)" \
-  -H "Content-Type: application/octet-stream" \
-  --data-binary "@${WORK_DIR}/conaninfo-arm.txt" \
-  "${BASE_URL}${PKG2_FILE_BASE}/conaninfo.txt") || true
+# Use retry helper: 1.1.x backend bcrypt-verifies Basic creds on every
+# format-native call, and the spawn_blocking pool can transiently drop a
+# verify task under back-to-back PUTs, surfacing as 401. See common.sh for
+# the rationale (RATE_LIMIT_EXEMPT_USERNAMES wasn't backported to 1.1.x).
+status=$(format_put_with_retry \
+  "${BASE_URL}${PKG2_FILE_BASE}/conaninfo.txt" \
+  "${WORK_DIR}/conaninfo-arm.txt") || true
 
 if [ "$status" -ge 200 ] 2>/dev/null && [ "$status" -lt 300 ] 2>/dev/null; then
   pass
@@ -259,13 +261,18 @@ fi
 # -----------------------------------------------------------------------
 begin_test "Verify both package binaries exist"
 
-resp1=$(curl -sf \
-  -H "$(format_auth_header)" \
-  "${BASE_URL}${RECIPE_BASE}/revisions/${RECIPE_REV}/packages/${PKG_ID_1}/latest" 2>/dev/null) || true
-
-resp2=$(curl -sf \
-  -H "$(format_auth_header)" \
-  "${BASE_URL}${RECIPE_BASE}/revisions/${RECIPE_REV}/packages/${PKG_ID_2}/latest" 2>/dev/null) || true
+# Retry both reads; same transient-401 risk as the PUTs above.
+resp1_file=$(mktemp)
+resp2_file=$(mktemp)
+status1=$(format_get_with_retry \
+  "${BASE_URL}${RECIPE_BASE}/revisions/${RECIPE_REV}/packages/${PKG_ID_1}/latest" \
+  "$resp1_file") || true
+status2=$(format_get_with_retry \
+  "${BASE_URL}${RECIPE_BASE}/revisions/${RECIPE_REV}/packages/${PKG_ID_2}/latest" \
+  "$resp2_file") || true
+resp1=$(cat "$resp1_file" 2>/dev/null || echo "")
+resp2=$(cat "$resp2_file" 2>/dev/null || echo "")
+rm -f "$resp1_file" "$resp2_file"
 
 ok=true
 rev1=$(echo "$resp1" | jq -r '.revision // empty' 2>/dev/null)

--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -256,6 +256,93 @@ format_auth_header() {
   echo "Authorization: Basic $(printf '%s:%s' "$ADMIN_USER" "$ADMIN_PASS" | base64)"
 }
 
+# PUT a file to a format-native endpoint with retry on transient auth/rate-limit
+# failures. Echoes the final HTTP status on stdout.
+#
+# The 1.1.x backend reauthenticates Basic credentials on every format-native
+# request via bcrypt(cost=12) inside spawn_blocking. Under back-to-back PUT
+# bursts within the same suite (and parallel suites sharing the same admin
+# user), the spawn_blocking pool can transiently drop a verify task, surfacing
+# as HTTP 401 even though credentials are valid. The 1.2.x backend grew
+# RATE_LIMIT_EXEMPT_USERNAMES (#697) to take the admin user off the auth
+# bucket, but that exemption was never backported to release/1.1.x, so the
+# release-gate (which targets 1.1.6) needs test-side resilience.
+#
+# Retries on HTTP 401, 429, 503, and network errors. Returns the final status
+# so callers can assert success.
+#
+# Usage:
+#   status=$(format_put_with_retry "$URL" "$DATA_FILE" [extra_curl_args...])
+format_put_with_retry() {
+  local url="$1"
+  local data_file="$2"
+  shift 2
+  local _max="${FORMAT_PUT_MAX_ATTEMPTS:-4}"
+  local _delay="${FORMAT_PUT_RETRY_DELAY:-2}"
+  local _attempt _status="000"
+  for _attempt in $(seq 1 "$_max"); do
+    _status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X PUT \
+      -H "$(format_auth_header)" \
+      -H "Content-Type: application/octet-stream" \
+      --data-binary "@${data_file}" \
+      "$@" \
+      "$url" 2>/dev/null) || _status="000"
+
+    # Success
+    if [ "$_status" -ge 200 ] 2>/dev/null && [ "$_status" -lt 300 ] 2>/dev/null; then
+      echo "$_status"
+      return 0
+    fi
+
+    # Non-transient failure: stop retrying
+    if [ "$_status" != "401" ] && [ "$_status" != "429" ] && \
+       [ "$_status" != "503" ] && [ "$_status" != "000" ]; then
+      break
+    fi
+
+    if [ "$_attempt" -lt "$_max" ]; then
+      sleep "$_delay"
+    fi
+  done
+  echo "$_status"
+  return 1
+}
+
+# GET from a format-native endpoint with retry on transient auth/rate-limit
+# failures. Writes body to OUT_FILE (-) and echoes the final HTTP status.
+# Same retry rationale as format_put_with_retry.
+#
+# Usage:
+#   status=$(format_get_with_retry "$URL" "$OUT_FILE")
+format_get_with_retry() {
+  local url="$1"
+  local out_file="${2:-/dev/null}"
+  local _max="${FORMAT_PUT_MAX_ATTEMPTS:-4}"
+  local _delay="${FORMAT_PUT_RETRY_DELAY:-2}"
+  local _attempt _status="000"
+  for _attempt in $(seq 1 "$_max"); do
+    _status=$(curl -s -o "$out_file" -w '%{http_code}' $CURL_TIMEOUT \
+      -H "$(format_auth_header)" \
+      "$url" 2>/dev/null) || _status="000"
+
+    if [ "$_status" -ge 200 ] 2>/dev/null && [ "$_status" -lt 300 ] 2>/dev/null; then
+      echo "$_status"
+      return 0
+    fi
+
+    if [ "$_status" != "401" ] && [ "$_status" != "429" ] && \
+       [ "$_status" != "503" ] && [ "$_status" != "000" ]; then
+      break
+    fi
+
+    if [ "$_attempt" -lt "$_max" ]; then
+      sleep "$_delay"
+    fi
+  done
+  echo "$_status"
+  return 1
+}
+
 # ---------------------------------------------------------------------------
 # HTTP helpers
 #


### PR DESCRIPTION
## Summary

Release-gate run [25214268566](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25214268566) (r11) failed format-tests `generic-protocol` with two cascading failures in `test-conan-packages.sh`:

```
FAIL: second package conaninfo.txt upload returned HTTP 401 (1s)
FAIL: package e3b0c44298fc1c149afbf4c8996fb92427ae41e4 latest revision not found (2s)
```

The same suite passed in r10 ([25194405511](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25194405511)) with identical credentials and identical code path, confirming this is a flake rather than a deterministic regression. Tests 1-8 (7 prior PUTs with the same Basic auth header) all succeeded, and test 11 (a third PUT immediately after) also succeeded.

## Root cause

The release-gate targets backend `1.1.6`. On 1.1.x, the format-native auth middleware reauthenticates Basic credentials on **every request** via `bcrypt(cost=12)` inside `tokio::task::spawn_blocking`. Under back-to-back PUT bursts (8 sequential PUTs in this suite for two package_ids), the spawn_blocking pool can transiently drop a verify task. The surface symptom is an isolated HTTP 401 on one call while the calls before and after succeed.

PR #697 (`feat: rate limit exemptions and config-driven limits`) added `RATE_LIMIT_EXEMPT_USERNAMES` on main in v1.2.x, and PR #102 set `RATE_LIMIT_EXEMPT_USERNAMES: admin` in `helm/values-test.yaml`. However, #697 was **never backported to `release/1.1.x`**, so the env var is silently ignored against 1.1.6. Until 1.1.10 / 1.2.0 ships, the test suite needs its own resilience.

This is the same kind of fix as #118 (retry `login_as` on 429) and the `auth_admin` retry budget already in `common.sh`.

## Changes

- `tests/lib/common.sh`: add `format_put_with_retry` and `format_get_with_retry` helpers. Both retry on HTTP 401, 429, 503, and network errors with a 2s backoff and 4 attempts. Non-transient failures (4xx other than 401, 5xx other than 503) are returned on the first attempt.
- `tests/formats/test-conan-packages.sh`: tests 9 and 10 now use the new helpers.

## Test plan

- [x] `bash -n` syntax check on both edited files
- [x] `shellcheck -S error` clean
- [ ] Re-run release-gate (`gh workflow run release-gate.yml`) and confirm `format-tests (generic-protocol)` passes test-conan-packages.sh
- [ ] No regression in other format-tests jobs

## Follow-up

Consider opening a backport issue against `artifact-keeper#697` for `release/1.1.x` so the admin user can be exempted from auth rate-limit / bcrypt verify pressure on the 1.1.x line. Track separately from this test-side fix.