### PR TITLE
fix(webhook-tests): gate producer assertions behind feature flag

### DIFF
--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -150,6 +150,16 @@ _feature_min_version() {
     # regressions, so they're slated for v1.1.10 / v1.2.0. Tracked in
     # artifact-keeper#990.
     "conan_error_correctness")        echo "1.1.10" ;;
+    # webhook_event_producer: the in-process EventBus -> webhook_deliveries
+    # producer task. Subscribes to domain events and enqueues delivery rows
+    # for the existing retry scheduler. v1.1.x ships the wire contract
+    # (webhook CRUD, /test, signing, retry scheduler) but not the producer:
+    # rows only appear in webhook_deliveries when /test is hit synchronously.
+    # Real EventBus events do not produce rows on 1.1.x. Producer wire-up is
+    # epic artifact-keeper#919 (E3) for v1.2.0. Until then, tests that assert
+    # "delivery row appears after a domain event" must skip on 1.1.x backends
+    # to avoid hard-failing on the absence of an unshipped feature.
+    "webhook_event_producer")         echo "1.2.0" ;;
     *) return 1 ;;
   esac
 }

--- a/tests/webhooks/test-webhook-delivery.sh
+++ b/tests/webhooks/test-webhook-delivery.sh
@@ -103,28 +103,35 @@ DELIVERY_RESP=""
 delivery_count=0
 
 begin_test "Webhook delivery row inserted within 30s"
-if [ -z "$WEBHOOK_ID" ]; then
-  fail "no webhook id from earlier step"
-else
-  for attempt in $(seq 1 15); do
-    sleep 2
-    if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}/deliveries" 2>/dev/null); then
-      DELIVERY_RESP="$resp"
-      delivery_count=$(echo "$resp" | jq '
-        if type == "array" then length
-        elif .items then (.items | length)
-        elif .total != null then .total
-        else 0
-        end' 2>/dev/null) || delivery_count=0
-      if [ "$delivery_count" -gt 0 ]; then
-        break
-      fi
-    fi
-  done
-  if [ "$delivery_count" -gt 0 ]; then
-    pass
+# Feature-gated: requires the webhook-event producer (epic
+# artifact-keeper#919 / E3) to be running. On v1.1.x the producer is
+# not yet wired to the EventBus so domain events do not enqueue
+# webhook_deliveries rows. require_feature emits a skip with the
+# version reason on older backends.
+if require_feature "webhook_event_producer"; then
+  if [ -z "$WEBHOOK_ID" ]; then
+    fail "no webhook id from earlier step"
   else
-    fail "no webhook_deliveries row appeared within 30s for webhook ${WEBHOOK_ID} after creating repo ${REPO_ID}; producer may not be running" "${DELIVERY_RESP:0:500}"
+    for attempt in $(seq 1 15); do
+      sleep 2
+      if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}/deliveries" 2>/dev/null); then
+        DELIVERY_RESP="$resp"
+        delivery_count=$(echo "$resp" | jq '
+          if type == "array" then length
+          elif .items then (.items | length)
+          elif .total != null then .total
+          else 0
+          end' 2>/dev/null) || delivery_count=0
+        if [ "$delivery_count" -gt 0 ]; then
+          break
+        fi
+      fi
+    done
+    if [ "$delivery_count" -gt 0 ]; then
+      pass
+    else
+      fail "no webhook_deliveries row appeared within 30s for webhook ${WEBHOOK_ID} after creating repo ${REPO_ID}; producer may not be running" "${DELIVERY_RESP:0:500}"
+    fi
   fi
 fi
 
@@ -134,19 +141,22 @@ fi
 # -------------------------------------------------------------------------
 
 begin_test "Delivery event field is 'repository_created'"
-if [ "$delivery_count" -gt 0 ]; then
-  event_name=$(echo "$DELIVERY_RESP" | jq -r '
-    if type == "array" then .[0].event
-    elif .items then .items[0].event
-    else empty
-    end' 2>/dev/null) || event_name=""
-  if [ "$event_name" = "repository_created" ]; then
-    pass
+# Same feature gate: depends on the producer enqueuing a row above.
+if require_feature "webhook_event_producer"; then
+  if [ "$delivery_count" -gt 0 ]; then
+    event_name=$(echo "$DELIVERY_RESP" | jq -r '
+      if type == "array" then .[0].event
+      elif .items then .items[0].event
+      else empty
+      end' 2>/dev/null) || event_name=""
+    if [ "$event_name" = "repository_created" ]; then
+      pass
+    else
+      fail "expected event='repository_created', got '${event_name}'" "${DELIVERY_RESP:0:500}"
+    fi
   else
-    fail "expected event='repository_created', got '${event_name}'" "${DELIVERY_RESP:0:500}"
+    fail "no delivery row to inspect"
   fi
-else
-  fail "no delivery row to inspect"
 fi
 
 # -------------------------------------------------------------------------
@@ -156,12 +166,15 @@ fi
 # -------------------------------------------------------------------------
 
 begin_test "Delivery payload contains new repo entity_id"
-if [ "$delivery_count" -gt 0 ] && [ -n "$REPO_ID" ]; then
-  if assert_contains "$DELIVERY_RESP" "$REPO_ID"; then
-    pass
+# Same feature gate: depends on the producer enqueuing a row above.
+if require_feature "webhook_event_producer"; then
+  if [ "$delivery_count" -gt 0 ] && [ -n "$REPO_ID" ]; then
+    if assert_contains "$DELIVERY_RESP" "$REPO_ID"; then
+      pass
+    fi
+  else
+    fail "no delivery row or no repo id to check"
   fi
-else
-  fail "no delivery row or no repo id to check"
 fi
 
 # Cleanup


### PR DESCRIPTION
## Summary

`test-webhook-delivery.sh` asserts that creating a repo causes a row to appear in `webhook_deliveries` within 30s. That requires the webhook-event producer (epic [artifact-keeper#919](https://github.com/artifact-keeper/artifact-keeper/issues/919) / E3) to be running and wired to the EventBus. The producer is **v1.2.0 scope**, not on `release/1.1.x`.

On 1.1.x the v1.1.9-rc.2 release-gate run failed three assertions in this suite (rows never appear because the producer task does not exist), which in turn skipped Publish Docker Images for the entire release.

## Change

- Add a `webhook_event_producer` feature flag gated at backend >= `1.2.0` in `tests/lib/common.sh`.
- Wrap the three producer-dependent assertions in `test-webhook-delivery.sh` with `if require_feature "webhook_event_producer"; then ... fi`. Tests 1-2 (webhook CRUD, repo create) are producer-independent and stay running on every backend version.
- Skip behavior on backends < 1.2.0: tests 3-5 emit `skip` with the version reason. Suite stays valid in release-gate context (no `skip_suite` invocation).

## Why this is the right fix (vs. removing the test)

The test is a real regression test for [artifact-keeper#909](https://github.com/artifact-keeper/artifact-keeper/issues/909) and must run against v1.2.0+ backends where the producer ships. Feature-gating preserves coverage for v1.2.0 while unblocking 1.1.x release validation.

## Verification

- `bash -n tests/webhooks/test-webhook-delivery.sh` clean
- `bash -n tests/lib/common.sh` clean
- Pattern matches existing usages (`tests/formats/test-conan-remote.sh`, `tests/auth/test-refresh-token-rotation.sh`)
- v1.1.9-rc.2 had 2 passed / 3 failed in this suite; with this PR a 1.1.x backend should report 2 passed / 3 skipped.

## Related

- v1.1.9-rc.2 release run: artifact-keeper/artifact-keeper#25348233406 (skipped Publish Docker Images)
- Webhook v2 producer epic: artifact-keeper#919 (E3)
- FIXME in `webhook_producer.rs` referenced by the test header (artifact-keeper#948)