### PR TITLE
test(webhooks): rewrite suite against v2 wire contract (#919 E8)

### DIFF
--- a/tests/webhooks/test-webhook-deadletter.sh
+++ b/tests/webhooks/test-webhook-deadletter.sh
@@ -1,22 +1,25 @@
 #!/usr/bin/env bash
 # test-webhook-deadletter.sh
 #
-# Epic 7 / sub-task 7.2, 7.3 (artifact-keeper-test#73): exercise the dead-letter
-# path. The receiver always returns 500, so a delivery should advance through
-# all max_attempts (default 5, see migration 067) and end with
-# next_retry_at = NULL and success = false.
+# Webhooks v2 wire contract (artifact-keeper#919, E5): exercise the dead-
+# letter path. The receiver always returns 500, so a delivery should advance
+# through all 12 retry attempts and end with the webhook auto-disabled
+# (is_enabled = false, disabled_reason non-null).
 #
-# Same retry-window constraint as test-webhook-retry-recover.sh: the full
-# 30s -> 2m -> 15m -> 1h -> 4h schedule is hours. There is no fast-forward
-# admin endpoint in v1.1.x, so this test verifies the API surface used to
-# detect dead-letter (the deliveries list with status filter) and the
-# determine_retry_outcome shape, but does not wait the full schedule.
+# Retry schedule (jittered +/-20%):
+#   30s, 1m, 2m, 5m, 10m, 30m, 1h, 2h, 4h, 8h, 16h, 24h
+# Total walltime is ~65h; this test does NOT wait the full schedule. It
+# verifies the wire contract, the API surface used to query failed
+# deliveries, and the auto-disable shape on rows that have already
+# exhausted attempts (if the producer has populated any in the test
+# window).
 #
-# Receiver discovery: same env vars as test-webhook-retry-recover.sh. The
-# receiver is configured with WEBHOOK_FAIL_FIRST_N=999999 so every POST
-# returns 500.
+# Receiver discovery: WEBHOOK_RECEIVER_PORT (default in 18000-19000 range).
+# The receiver runs on the test runner with WEBHOOK_FAIL_FIRST_N=999999 so
+# every POST returns 500.
 #
-# Self-test mode: EXPECT_FAILURE=1 inverts the script exit code.
+# Companion backend PR: artifact-keeper#1140. The producer feature flag is
+# WEBHOOKS_V2_PRODUCER_ENABLED; the harness sets it to 1.
 #
 # Requires: curl, jq, python3
 
@@ -37,15 +40,6 @@ cleanup_and_finalize() {
     wait "${RECEIVER_PID}" 2>/dev/null || true
   fi
   rm -f "${WEBHOOK_RECEIVER_LOG}"
-  if [ "${EXPECT_FAILURE:-0}" = "1" ]; then
-    if [ "$code" -eq 0 ]; then
-      echo "ERROR: EXPECT_FAILURE=1 but suite passed" >&2
-      exit 4
-    else
-      echo "Self-test PASSED: suite exited ${code} as expected"
-      exit 0
-    fi
-  fi
   exit "$code"
 }
 trap cleanup_and_finalize EXIT
@@ -83,7 +77,7 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# Mock self-test: the receiver returns 500 to ANY POST (FAIL_FIRST_N is huge).
+# Mock self-test: receiver returns 500 to every POST.
 # -------------------------------------------------------------------------
 
 begin_test "Mock receiver returns 500 for every POST"
@@ -102,7 +96,7 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# Create a webhook pointing at the mock. Skip if URL validation rejects.
+# Create a webhook pointing at the mock receiver.
 # -------------------------------------------------------------------------
 
 WEBHOOK_NAME="deadletter-${RUN_ID}"
@@ -152,17 +146,10 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# The dead-letter detection contract is: the deliveries list endpoint
-# accepts a `status=failed` filter and returns failed deliveries. v1.1.x
-# implements `status=success` (truthy filter) -- we assert the endpoint
-# at least responds successfully, and that any delivery with attempts
-# >= max_attempts has next_retry_at == null.
-#
-# Because v1.1.x does not auto-INSERT webhook_deliveries from artifact
-# upload, the list will normally be empty and we degrade gracefully.
+# Deliveries-list filter shape check.
 # -------------------------------------------------------------------------
 
-begin_test "Deliveries list filter returns a usable shape"
+begin_test "Deliveries list with status=failed returns a usable shape"
 if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
   skip "no webhook id"
 else
@@ -180,11 +167,10 @@ fi
 
 # -------------------------------------------------------------------------
 # When delivery rows DO exist, dead-lettered ones must satisfy:
-#   success == false AND attempts >= max_attempts
-# We poll for up to DEADLETTER_TIMEOUT seconds; if we never see a row, we
-# skip with a clear reason rather than failing (the producer wiring is
-# out of scope for this gate).
+#   success == false AND attempts >= max_attempts (default 12 in v2).
 # -------------------------------------------------------------------------
+
+SAW_EXHAUSTED=false
 
 begin_test "Any failed delivery is exhausted (attempts >= max_attempts)"
 if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
@@ -198,8 +184,11 @@ else
       n=$(echo "$list" | jq '.items | length // 0')
       if [ "$n" -gt 0 ]; then
         saw_any=true
-        # Exhausted = success == false AND attempts >= 5 (default max).
-        exhausted=$(echo "$list" | jq '[.items[] | select(.success == false and .attempts >= 5)] | length')
+        # In v2 the default budget is 12. Fall back to whatever max_attempts
+        # the row carries so older rows (default 5) don't false-fail.
+        exhausted=$(echo "$list" | jq '
+          [.items[] | select(.success == false and (.attempts >= (.max_attempts // 12)))]
+          | length')
         if [ "$exhausted" -gt 0 ]; then
           found_exhausted=true
           break
@@ -211,11 +200,39 @@ else
   done
 
   if [ "$found_exhausted" = "true" ]; then
+    SAW_EXHAUSTED=true
     pass
   elif [ "$saw_any" = "true" ]; then
-    skip "deliveries exist but none reached attempts >= 5 within ${DEADLETTER_TIMEOUT}s (full backoff schedule is hours)"
+    skip "deliveries exist but none reached max_attempts within ${DEADLETTER_TIMEOUT}s (full v2 schedule is ~65h walltime)"
   else
-    skip "no webhook_deliveries rows produced; v1.1.x does not auto-create deliveries on upload"
+    skip "no webhook_deliveries rows produced in window"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Auto-disable on dead-letter (v2 contract): once max_attempts is exhausted
+# the webhook itself is flipped to is_enabled=false with a non-null
+# disabled_reason. We assert this on the webhook row only when we observed
+# an exhausted delivery in the previous step (otherwise the auto-disable
+# branch has not been reached yet and asserting would false-fail).
+# -------------------------------------------------------------------------
+
+begin_test "Auto-disable: webhook is_enabled=false and disabled_reason non-null after dead-letter"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "no webhook id"
+elif [ "$SAW_EXHAUSTED" != "true" ]; then
+  skip "no exhausted delivery observed in this window; auto-disable branch not exercised"
+else
+  if hook=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}" 2>/dev/null); then
+    enabled=$(echo "$hook" | jq -r '.enabled // .is_enabled // empty')
+    reason=$(echo "$hook" | jq -r '.disabled_reason // empty')
+    if [ "$enabled" = "false" ] && [ -n "$reason" ] && [ "$reason" != "null" ]; then
+      pass
+    else
+      fail "expected enabled=false and non-null disabled_reason, got enabled='${enabled}' disabled_reason='${reason}' (raw: ${hook:0:200})"
+    fi
+  else
+    fail "could not GET /api/v1/webhooks/${WEBHOOK_ID}"
   fi
 fi
 

--- a/tests/webhooks/test-webhook-delivery.sh
+++ b/tests/webhooks/test-webhook-delivery.sh
@@ -1,42 +1,26 @@
 #!/usr/bin/env bash
 # test-webhook-delivery.sh - Webhook producer delivery enqueue regression test
 #
-# This is the regression test for artifact-keeper#909 (webhook v2 event
-# producer): subscribing a webhook to a real EventBus event must result in
-# a row being inserted into webhook_deliveries when that event fires.
+# Webhooks v2 wire contract (artifact-keeper#919, E3 + E4): subscribing a
+# webhook to a real EventBus event must result in:
+#   1. a row being inserted into webhook_deliveries when that event fires.
+#   2. the resulting POST to the receiver carrying the new
+#      X-ArtifactKeeper-Delivery / -Event / -Event-Version headers.
 #
-# Trigger choice: repository.created
+# Trigger: repository.created
+#   The producer maps EventBus repository.created -> webhook event name
+#   "repository_created", entity_id is the repository UUID, and the
+#   producer matches on global webhooks (repository_id IS NULL).
 #
-#   The previous version of this test used "artifact.uploaded" as the
-#   trigger, but no handler on release/1.1.x emits that event type. The
-#   only artifact-side event currently emitted is "artifact.created",
-#   which has its own scoping problems (entity_id is the artifact UUID,
-#   not the repo, so the producer cannot match a repo-scoped webhook on
-#   release/1.1.x where DomainEvent has no explicit repository_id field;
-#   see FIXME(#948) in webhook_producer.rs).
+# Companion backend PR: artifact-keeper#1140. The producer is gated by
+# WEBHOOKS_V2_PRODUCER_ENABLED; the harness sets it to 1.
 #
-#   repository.created sidesteps that problem: the entity_id IS the
-#   repository UUID, and we can match it with a global webhook
-#   (repository_id IS NULL), which the producer's matching predicate
-#   ("repository_id IS NULL OR repository_id = $2") accepts.
+# Receiver: the local mock at WEBHOOK_RECEIVER_PORT. The previous version
+# of this test used `https://example.invalid` and could only assert the
+# database row; with the receiver wired we can also assert the wire
+# headers on the actual delivery.
 #
-#   Until #948 lands proper repo scoping for non-repo events on the
-#   1.1.x branch, this test uses repository creation as the trigger.
-#   That is enough to prove the producer task is alive, mapping
-#   EventBus events to webhook event names, and inserting deliveries.
-#
-# What we assert (the regression bar for #909):
-#   1. A webhook subscribed to "repository_created" (the mapped name)
-#      gets a webhook_deliveries row inserted within 30s of repo
-#      creation.
-#   2. The delivery row has event="repository_created".
-#   3. The delivery payload contains the entity_id (the new repo's
-#      UUID), proving the producer wired the EventBus payload through.
-#
-# If the producer task panics, is removed, or stops subscribing to the
-# bus, this test fails hard. No silent skip on missing deliveries.
-#
-# Requires: curl, jq
+# Requires: curl, jq, python3
 
 source "$(dirname "$0")/../lib/common.sh"
 
@@ -44,9 +28,55 @@ begin_suite "webhook-delivery"
 auth_admin
 setup_workdir
 
+WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18768}"
+WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
+WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-delivery-${RUN_ID}.log}"
+RECEIVER_PID=""
+
+cleanup_and_finalize() {
+  local code=$?
+  if [ -n "${RECEIVER_PID}" ] && kill -0 "${RECEIVER_PID}" 2>/dev/null; then
+    kill "${RECEIVER_PID}" 2>/dev/null || true
+    wait "${RECEIVER_PID}" 2>/dev/null || true
+  fi
+  rm -f "${WEBHOOK_RECEIVER_LOG}"
+  exit "$code"
+}
+trap cleanup_and_finalize EXIT
+
 REPO_KEY="test-whk-delivery-${RUN_ID}"
 WEBHOOK_NAME="delivery-test-${RUN_ID}"
 WEBHOOK_ID=""
+
+# -------------------------------------------------------------------------
+# Start mock receiver.
+# -------------------------------------------------------------------------
+
+receiver_ready=false
+begin_test "Start mock webhook receiver"
+if ! command -v python3 >/dev/null 2>&1; then
+  skip "python3 not available"
+else
+  WEBHOOK_RECEIVER_PORT="$WEBHOOK_RECEIVER_PORT" \
+    WEBHOOK_FAIL_FIRST_N=0 \
+    WEBHOOK_RECEIVER_LOG="$WEBHOOK_RECEIVER_LOG" \
+    python3 "$(dirname "$0")/../lib/mock-webhook-receiver.py" \
+    >/tmp/mock-webhook-receiver-delivery-${RUN_ID}.stderr 2>&1 &
+  RECEIVER_PID=$!
+
+  for _ in $(seq 1 25); do
+    if curl -sf --max-time 1 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__health" >/dev/null 2>&1; then
+      receiver_ready=true
+      break
+    fi
+    sleep 0.2
+  done
+  if [ "$receiver_ready" = true ]; then
+    pass
+  else
+    fail "mock receiver did not come up on 127.0.0.1:${WEBHOOK_RECEIVER_PORT}"
+  fi
+fi
 
 # -------------------------------------------------------------------------
 # Create a global webhook subscribed to repository_created BEFORE the
@@ -55,125 +85,188 @@ WEBHOOK_ID=""
 # -------------------------------------------------------------------------
 
 begin_test "Create webhook subscribed to repository_created"
-WEBHOOK_PAYLOAD='{
-  "name": "'"${WEBHOOK_NAME}"'",
-  "url": "https://example.invalid/webhook-sink",
-  "events": ["repository_created"],
-  "enabled": true
-}'
-if resp=$(api_post "/api/v1/webhooks" "$WEBHOOK_PAYLOAD" 2>/dev/null); then
-  WEBHOOK_ID=$(echo "$resp" | jq -r '.id // empty') || true
-  if [ -z "$WEBHOOK_ID" ] || [ "$WEBHOOK_ID" = "null" ]; then
-    fail "webhook create returned no id: ${resp:0:200}"
-  else
-    pass
-  fi
+if [ "$receiver_ready" != "true" ]; then
+  skip "receiver not running"
 else
-  fail "webhook create request failed"
+  WEBHOOK_PAYLOAD=$(jq -n \
+    --arg name "$WEBHOOK_NAME" \
+    --arg url "$WEBHOOK_RECEIVER_URL" \
+    '{name: $name, url: $url, events: ["repository_created"], enabled: true}')
+  if resp=$(api_post "/api/v1/webhooks" "$WEBHOOK_PAYLOAD" 2>/dev/null); then
+    WEBHOOK_ID=$(echo "$resp" | jq -r '.id // empty') || true
+    if [ -z "$WEBHOOK_ID" ] || [ "$WEBHOOK_ID" = "null" ]; then
+      fail "webhook create returned no id: ${resp:0:200}"
+    else
+      pass
+    fi
+  else
+    fail "webhook create request failed"
+  fi
 fi
 
 # -------------------------------------------------------------------------
-# Trigger the event by creating a repository. The backend emits
-# "repository.created" via EventBus, the producer maps it to
-# "repository_created", matches the global webhook above, and inserts
-# a webhook_deliveries row.
+# Trigger the event by creating a repository.
 # -------------------------------------------------------------------------
 
 REPO_ID=""
 
 begin_test "Create repo to trigger repository.created event"
-REPO_CREATE_PAYLOAD="{\"key\":\"${REPO_KEY}\",\"name\":\"${REPO_KEY}\",\"format\":\"generic\",\"repo_type\":\"local\",\"is_public\":true}"
-if resp=$(api_post "/api/v1/repositories" "$REPO_CREATE_PAYLOAD" 2>/dev/null); then
-  REPO_ID=$(echo "$resp" | jq -r '.id // empty') || true
-  if [ -z "$REPO_ID" ] || [ "$REPO_ID" = "null" ]; then
-    fail "repo create returned no id: ${resp:0:200}"
-  else
-    pass
-  fi
+if [ -z "$WEBHOOK_ID" ]; then
+  skip "no webhook id"
 else
-  fail "repo create request failed"
+  REPO_CREATE_PAYLOAD="{\"key\":\"${REPO_KEY}\",\"name\":\"${REPO_KEY}\",\"format\":\"generic\",\"repo_type\":\"local\",\"is_public\":true}"
+  if resp=$(api_post "/api/v1/repositories" "$REPO_CREATE_PAYLOAD" 2>/dev/null); then
+    REPO_ID=$(echo "$resp" | jq -r '.id // empty') || true
+    if [ -z "$REPO_ID" ] || [ "$REPO_ID" = "null" ]; then
+      fail "repo create returned no id: ${resp:0:200}"
+    else
+      pass
+    fi
+  else
+    fail "repo create request failed"
+  fi
 fi
 
 # -------------------------------------------------------------------------
-# Strict assertion: a delivery row must exist within 30s. This is the
-# regression test for #909. Do NOT skip on empty results.
+# Strict assertion: a delivery row must exist within 30s.
 # -------------------------------------------------------------------------
 
 DELIVERY_RESP=""
 delivery_count=0
 
 begin_test "Webhook delivery row inserted within 30s"
-# Feature-gated: requires the webhook-event producer (epic
-# artifact-keeper#919 / E3) to be running. On v1.1.x the producer is
-# not yet wired to the EventBus so domain events do not enqueue
-# webhook_deliveries rows. require_feature emits a skip with the
-# version reason on older backends.
-if require_feature "webhook_event_producer"; then
-  if [ -z "$WEBHOOK_ID" ]; then
-    fail "no webhook id from earlier step"
-  else
-    for attempt in $(seq 1 15); do
-      sleep 2
-      if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}/deliveries" 2>/dev/null); then
-        DELIVERY_RESP="$resp"
-        delivery_count=$(echo "$resp" | jq '
-          if type == "array" then length
-          elif .items then (.items | length)
-          elif .total != null then .total
-          else 0
-          end' 2>/dev/null) || delivery_count=0
-        if [ "$delivery_count" -gt 0 ]; then
-          break
-        fi
+if [ -z "$WEBHOOK_ID" ]; then
+  fail "no webhook id from earlier step"
+else
+  for attempt in $(seq 1 15); do
+    sleep 2
+    if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}/deliveries" 2>/dev/null); then
+      DELIVERY_RESP="$resp"
+      delivery_count=$(echo "$resp" | jq '
+        if type == "array" then length
+        elif .items then (.items | length)
+        elif .total != null then .total
+        else 0
+        end' 2>/dev/null) || delivery_count=0
+      if [ "$delivery_count" -gt 0 ]; then
+        break
       fi
-    done
-    if [ "$delivery_count" -gt 0 ]; then
-      pass
-    else
-      fail "no webhook_deliveries row appeared within 30s for webhook ${WEBHOOK_ID} after creating repo ${REPO_ID}; producer may not be running" "${DELIVERY_RESP:0:500}"
     fi
+  done
+  if [ "$delivery_count" -gt 0 ]; then
+    pass
+  else
+    fail "no webhook_deliveries row appeared within 30s for webhook ${WEBHOOK_ID} after creating repo ${REPO_ID}; producer may not be running" "${DELIVERY_RESP:0:500}"
   fi
 fi
 
 # -------------------------------------------------------------------------
-# Confirm the delivery row carries the right event name. This catches
-# regressions in webhook_producer::map_event_type.
+# Confirm the delivery row carries the right event name.
 # -------------------------------------------------------------------------
 
 begin_test "Delivery event field is 'repository_created'"
-# Same feature gate: depends on the producer enqueuing a row above.
-if require_feature "webhook_event_producer"; then
-  if [ "$delivery_count" -gt 0 ]; then
-    event_name=$(echo "$DELIVERY_RESP" | jq -r '
-      if type == "array" then .[0].event
-      elif .items then .items[0].event
-      else empty
-      end' 2>/dev/null) || event_name=""
-    if [ "$event_name" = "repository_created" ]; then
-      pass
-    else
-      fail "expected event='repository_created', got '${event_name}'" "${DELIVERY_RESP:0:500}"
-    fi
+if [ "$delivery_count" -gt 0 ]; then
+  event_name=$(echo "$DELIVERY_RESP" | jq -r '
+    if type == "array" then .[0].event
+    elif .items then .items[0].event
+    else empty
+    end' 2>/dev/null) || event_name=""
+  if [ "$event_name" = "repository_created" ]; then
+    pass
   else
-    fail "no delivery row to inspect"
+    fail "expected event='repository_created', got '${event_name}'" "${DELIVERY_RESP:0:500}"
   fi
+else
+  fail "no delivery row to inspect"
 fi
 
 # -------------------------------------------------------------------------
-# Confirm the delivery payload contains the new repo's UUID. This
-# proves the producer pulled the EventBus entity_id through into the
-# enqueued payload (build_event_payload in webhook_producer.rs).
+# Confirm the delivery payload contains the new repo's UUID.
 # -------------------------------------------------------------------------
 
 begin_test "Delivery payload contains new repo entity_id"
-# Same feature gate: depends on the producer enqueuing a row above.
-if require_feature "webhook_event_producer"; then
-  if [ "$delivery_count" -gt 0 ] && [ -n "$REPO_ID" ]; then
-    if assert_contains "$DELIVERY_RESP" "$REPO_ID"; then
-      pass
-    fi
+if [ "$delivery_count" -gt 0 ] && [ -n "$REPO_ID" ]; then
+  if assert_contains "$DELIVERY_RESP" "$REPO_ID"; then
+    pass
+  fi
+else
+  fail "no delivery row or no repo id to check"
+fi
+
+# -------------------------------------------------------------------------
+# v2 wire-contract assertion: the actual POST that landed at the receiver
+# carries X-ArtifactKeeper-Delivery (UUID), X-ArtifactKeeper-Event, and
+# X-ArtifactKeeper-Event-Version headers. Wait briefly for the producer's
+# scheduler tick to push the row to the receiver.
+# -------------------------------------------------------------------------
+
+LATEST_HEADERS=""
+
+begin_test "Delivery POST reached the mock receiver"
+if [ "$receiver_ready" != "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "receiver not running or no webhook id"
+else
+  seen=0
+  for _ in $(seq 1 60); do
+    seen=$(curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__count" 2>/dev/null || echo 0)
+    [ "$seen" -gt 0 ] && break
+    sleep 1
+  done
+  if [ "$seen" -ge 1 ] && [ -s "$WEBHOOK_RECEIVER_LOG" ]; then
+    LATEST_HEADERS=$(tail -n 1 "$WEBHOOK_RECEIVER_LOG" | jq -r '.headers')
+    pass
   else
-    fail "no delivery row or no repo id to check"
+    fail "receiver saw 0 POSTs after repo create within 60s"
+  fi
+fi
+
+begin_test "X-ArtifactKeeper-Delivery is a UUID"
+if [ -z "$LATEST_HEADERS" ]; then
+  skip "no receiver entry"
+else
+  delivery=$(echo "$LATEST_HEADERS" | jq -r '
+    (.["X-ArtifactKeeper-Delivery"] //
+     .["x-artifactkeeper-delivery"] //
+     .["X-ARTIFACTKEEPER-DELIVERY"] // empty)
+  ')
+  if [ -n "$delivery" ] && [ "$delivery" != "null" ] && \
+     echo "$delivery" | grep -Eiq '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'; then
+    pass
+  else
+    fail "X-ArtifactKeeper-Delivery missing or not a UUID: '${delivery}'"
+  fi
+fi
+
+begin_test "X-ArtifactKeeper-Event reflects the event type"
+if [ -z "$LATEST_HEADERS" ]; then
+  skip "no receiver entry"
+else
+  evt=$(echo "$LATEST_HEADERS" | jq -r '
+    (.["X-ArtifactKeeper-Event"] //
+     .["x-artifactkeeper-event"] //
+     .["X-ARTIFACTKEEPER-EVENT"] // empty)
+  ')
+  # The wire event name may use underscores or dots depending on the
+  # producer mapping. Accept either form for repository_created.
+  case "$evt" in
+    repository_created|repository.created) pass ;;
+    *) fail "expected event header 'repository_created' or 'repository.created', got '${evt}'" ;;
+  esac
+fi
+
+begin_test "X-ArtifactKeeper-Event-Version is the default 2026-04-01"
+if [ -z "$LATEST_HEADERS" ]; then
+  skip "no receiver entry"
+else
+  ver=$(echo "$LATEST_HEADERS" | jq -r '
+    (.["X-ArtifactKeeper-Event-Version"] //
+     .["x-artifactkeeper-event-version"] //
+     .["X-ARTIFACTKEEPER-EVENT-VERSION"] // empty)
+  ')
+  if [ "$ver" = "2026-04-01" ]; then
+    pass
+  else
+    fail "expected event-version '2026-04-01', got '${ver}'"
   fi
 fi
 

--- a/tests/webhooks/test-webhook-event-versioning.sh
+++ b/tests/webhooks/test-webhook-event-versioning.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# test-webhook-event-versioning.sh
+#
+# Webhooks v2 wire contract (artifact-keeper#919, E4): per-webhook
+# event_schema_version. Defaults to "2026-04-01"; unsupported versions
+# return 400 (AppError::Validation) at create time.
+#
+# Sub-checks:
+#   1. POST /api/v1/webhooks with no event_schema_version field -> created;
+#      GET returns "event_schema_version": "2026-04-01"; deliveries carry
+#      X-ArtifactKeeper-Event-Version: 2026-04-01.
+#   2. POST with explicit "event_schema_version": "2026-04-01" -> created;
+#      header matches.
+#   3. POST with "event_schema_version": "9999-99-99" -> 400, body
+#      mentions "supported".
+#
+# Companion backend PR: artifact-keeper#1140.
+#
+# Requires: curl, jq, python3
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "webhook-event-versioning"
+
+WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18771}"
+WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
+WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-ver-${RUN_ID}.log}"
+RECEIVER_PID=""
+
+cleanup_and_finalize() {
+  local code=$?
+  if [ -n "${RECEIVER_PID}" ] && kill -0 "${RECEIVER_PID}" 2>/dev/null; then
+    kill "${RECEIVER_PID}" 2>/dev/null || true
+    wait "${RECEIVER_PID}" 2>/dev/null || true
+  fi
+  rm -f "${WEBHOOK_RECEIVER_LOG}"
+  exit "$code"
+}
+trap cleanup_and_finalize EXIT
+
+auth_admin
+
+# -------------------------------------------------------------------------
+# Pre-flight + receiver.
+# -------------------------------------------------------------------------
+
+begin_test "python3 and jq available"
+miss=""
+command -v python3 >/dev/null 2>&1 || miss="${miss} python3"
+command -v jq      >/dev/null 2>&1 || miss="${miss} jq"
+if [ -n "$miss" ]; then
+  skip "missing tools:${miss}"
+  end_suite
+fi
+pass
+
+begin_test "Start mock receiver"
+WEBHOOK_RECEIVER_PORT="$WEBHOOK_RECEIVER_PORT" \
+  WEBHOOK_FAIL_FIRST_N=0 \
+  WEBHOOK_RECEIVER_LOG="$WEBHOOK_RECEIVER_LOG" \
+  python3 "$(dirname "$0")/../lib/mock-webhook-receiver.py" \
+  >/tmp/mock-webhook-receiver-ver-${RUN_ID}.stderr 2>&1 &
+RECEIVER_PID=$!
+
+ready=false
+for _ in $(seq 1 25); do
+  if curl -sf --max-time 1 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__health" >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 0.2
+done
+if [ "$ready" = true ]; then
+  pass
+else
+  fail "mock receiver did not come up on 127.0.0.1:${WEBHOOK_RECEIVER_PORT}"
+fi
+
+DEFAULT_VERSION="2026-04-01"
+
+# Helper: POST a webhook with optional event_schema_version, return id or empty
+create_webhook_status() {
+  local payload="$1"
+  local body_file
+  body_file=$(mktemp)
+  local status
+  status=$(curl -s -o "$body_file" -w '%{http_code}' --max-time 10 \
+    -X POST \
+    -H "$(auth_header)" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "${BASE_URL}/api/v1/webhooks" 2>/dev/null) || status="000"
+  echo "${status}"
+  cat "$body_file"
+  rm -f "$body_file"
+}
+
+# -------------------------------------------------------------------------
+# Sub-check 1: omit event_schema_version -> defaults to 2026-04-01.
+# -------------------------------------------------------------------------
+
+DEFAULT_HOOK_ID=""
+
+begin_test "Create webhook WITHOUT event_schema_version"
+if [ "$ready" != "true" ]; then
+  skip "receiver not running"
+else
+  PAYLOAD=$(jq -n \
+    --arg name "ver-default-${RUN_ID}" \
+    --arg url "$WEBHOOK_RECEIVER_URL" \
+    '{name: $name, url: $url, events: ["artifact.uploaded"], enabled: true}')
+  resp=$(create_webhook_status "$PAYLOAD")
+  status=$(echo "$resp" | head -n 1)
+  body=$(echo "$resp" | tail -n +2)
+  if [ "$status" = "200" ] || [ "$status" = "201" ]; then
+    DEFAULT_HOOK_ID=$(echo "$body" | jq -r '.id // empty')
+    if [ -n "$DEFAULT_HOOK_ID" ] && [ "$DEFAULT_HOOK_ID" != "null" ]; then
+      pass
+    else
+      fail "create returned no id (status ${status}, body: ${body:0:200})"
+    fi
+  else
+    fail "expected 200/201 creating webhook without version, got ${status}: ${body:0:200}"
+  fi
+fi
+
+begin_test "GET returns event_schema_version=${DEFAULT_VERSION}"
+if [ -z "$DEFAULT_HOOK_ID" ]; then
+  skip "no webhook id"
+else
+  if hook=$(api_get "/api/v1/webhooks/${DEFAULT_HOOK_ID}" 2>/dev/null); then
+    ver=$(echo "$hook" | jq -r '.event_schema_version // empty')
+    if [ "$ver" = "$DEFAULT_VERSION" ]; then
+      pass
+    else
+      fail "expected event_schema_version='${DEFAULT_VERSION}', got '${ver}' (raw: ${hook:0:200})"
+    fi
+  else
+    fail "could not GET webhook ${DEFAULT_HOOK_ID}"
+  fi
+fi
+
+begin_test "Delivery carries X-ArtifactKeeper-Event-Version: ${DEFAULT_VERSION}"
+if [ -z "$DEFAULT_HOOK_ID" ]; then
+  skip "no webhook id"
+else
+  curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__reset" >/dev/null 2>&1 || true
+  if api_post "/api/v1/webhooks/${DEFAULT_HOOK_ID}/test" "" >/dev/null 2>&1; then
+    seen=0
+    for _ in $(seq 1 20); do
+      seen=$(curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__count" 2>/dev/null || echo 0)
+      [ "$seen" -gt 0 ] && break
+      sleep 0.5
+    done
+    if [ "$seen" -ge 1 ] && [ -s "$WEBHOOK_RECEIVER_LOG" ]; then
+      headers=$(tail -n 1 "$WEBHOOK_RECEIVER_LOG" | jq -r '.headers')
+      ver=$(echo "$headers" | jq -r '
+        (.["X-ArtifactKeeper-Event-Version"] //
+         .["x-artifactkeeper-event-version"] //
+         .["X-ARTIFACTKEEPER-EVENT-VERSION"] // empty)
+      ')
+      if [ "$ver" = "$DEFAULT_VERSION" ]; then
+        pass
+      else
+        fail "expected header version '${DEFAULT_VERSION}', got '${ver}'"
+      fi
+    else
+      fail "no POST recorded at receiver after /test"
+    fi
+  else
+    skip "/test endpoint unavailable"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Sub-check 2: explicit "2026-04-01" works the same.
+# -------------------------------------------------------------------------
+
+EXPLICIT_HOOK_ID=""
+
+begin_test "Create webhook WITH explicit event_schema_version=${DEFAULT_VERSION}"
+if [ "$ready" != "true" ]; then
+  skip "receiver not running"
+else
+  PAYLOAD=$(jq -n \
+    --arg name "ver-explicit-${RUN_ID}" \
+    --arg url "$WEBHOOK_RECEIVER_URL" \
+    --arg ver "$DEFAULT_VERSION" \
+    '{name: $name, url: $url, events: ["artifact.uploaded"], enabled: true, event_schema_version: $ver}')
+  resp=$(create_webhook_status "$PAYLOAD")
+  status=$(echo "$resp" | head -n 1)
+  body=$(echo "$resp" | tail -n +2)
+  if [ "$status" = "200" ] || [ "$status" = "201" ]; then
+    EXPLICIT_HOOK_ID=$(echo "$body" | jq -r '.id // empty')
+    if [ -n "$EXPLICIT_HOOK_ID" ] && [ "$EXPLICIT_HOOK_ID" != "null" ]; then
+      pass
+    else
+      fail "create returned no id (status ${status}, body: ${body:0:200})"
+    fi
+  else
+    fail "expected 200/201 creating webhook with explicit version, got ${status}: ${body:0:200}"
+  fi
+fi
+
+begin_test "Explicit-version webhook delivery carries the same header"
+if [ -z "$EXPLICIT_HOOK_ID" ]; then
+  skip "no webhook id"
+else
+  curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__reset" >/dev/null 2>&1 || true
+  if api_post "/api/v1/webhooks/${EXPLICIT_HOOK_ID}/test" "" >/dev/null 2>&1; then
+    seen=0
+    for _ in $(seq 1 20); do
+      seen=$(curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__count" 2>/dev/null || echo 0)
+      [ "$seen" -gt 0 ] && break
+      sleep 0.5
+    done
+    if [ "$seen" -ge 1 ] && [ -s "$WEBHOOK_RECEIVER_LOG" ]; then
+      headers=$(tail -n 1 "$WEBHOOK_RECEIVER_LOG" | jq -r '.headers')
+      ver=$(echo "$headers" | jq -r '
+        (.["X-ArtifactKeeper-Event-Version"] //
+         .["x-artifactkeeper-event-version"] //
+         .["X-ARTIFACTKEEPER-EVENT-VERSION"] // empty)
+      ')
+      if [ "$ver" = "$DEFAULT_VERSION" ]; then
+        pass
+      else
+        fail "expected header version '${DEFAULT_VERSION}', got '${ver}'"
+      fi
+    else
+      fail "no POST recorded at receiver after /test"
+    fi
+  else
+    skip "/test endpoint unavailable"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Sub-check 3: bogus version -> 400, body mentions "supported".
+# -------------------------------------------------------------------------
+
+begin_test "Create webhook with unsupported version returns 400"
+PAYLOAD=$(jq -n \
+  --arg name "ver-bad-${RUN_ID}" \
+  --arg url "$WEBHOOK_RECEIVER_URL" \
+  '{name: $name, url: $url, events: ["artifact.uploaded"], enabled: true, event_schema_version: "9999-99-99"}')
+resp=$(create_webhook_status "$PAYLOAD")
+status=$(echo "$resp" | head -n 1)
+body=$(echo "$resp" | tail -n +2)
+if [ "$status" = "400" ]; then
+  pass
+else
+  fail "expected 400 for unsupported version, got ${status}: ${body:0:200}"
+fi
+
+begin_test "Unsupported-version error body mentions 'supported'"
+# Reuse the response from the previous test by re-sending; resp variables
+# above are local to that test's scope effectively (bash variables leak,
+# but we re-issue to be defensive against retries).
+resp=$(create_webhook_status "$PAYLOAD")
+body=$(echo "$resp" | tail -n +2)
+# Case-insensitive grep for "supported" so backends can word the message
+# either as "unsupported version" or "supported versions: ...".
+if echo "$body" | grep -qi 'supported'; then
+  pass
+else
+  fail "error body did not mention 'supported': ${body:0:300}"
+fi
+
+# Cleanup
+for hid in "$DEFAULT_HOOK_ID" "$EXPLICIT_HOOK_ID"; do
+  if [ -n "$hid" ] && [ "$hid" != "null" ]; then
+    api_delete "/api/v1/webhooks/${hid}" >/dev/null 2>&1 || true
+  fi
+done
+
+end_suite

--- a/tests/webhooks/test-webhook-hmac-signature.sh
+++ b/tests/webhooks/test-webhook-hmac-signature.sh
@@ -1,24 +1,32 @@
 #!/usr/bin/env bash
 # test-webhook-hmac-signature.sh
 #
-# Epic 7 / sub-task 7.5 (artifact-keeper-test#73): verify HMAC signature
-# generation and X-Webhook-Signature header injection.
+# Webhooks v2 wire contract (artifact-keeper#919, E2 / E4): assert that the
+# backend emits the new X-ArtifactKeeper-Signature header AND keeps emitting
+# the legacy X-Webhook-Signature header alongside it for one release window
+# (legacy form is removed in v1.3.0).
 #
-# Contract (per the security review for v1.1.9):
-#   - When a webhook is created with a `secret`, every delivery POST must
-#     include an `X-Webhook-Signature` header.
-#   - The header value must be `sha256=<hex>` where <hex> is
-#     HMAC-SHA256(secret, body).
+# Contract under test:
+#   X-ArtifactKeeper-Signature: t=<unix_secs>,v1=<hex_hmac_sha256>
+#                               (multi-value during 24h rotation:
+#                                t=...,v1=<new>,v1=<old>)
+#   Signed bytes: "<unix_secs>.<raw_body>"
 #
-# Implementation note: in v1.1.x, the backend (api/handlers/webhooks.rs)
-# emits a placeholder string ("test-signature" for /test, "hmac-signature"
-# for retry deliveries) instead of a real HMAC. This test asserts the real
-# contract; on v1.1.x it will FAIL the signature-match assertion and PASS
-# the header-presence assertion. The signature-match failure is the
-# tracked bug (#73 sub-task 7.5).
+#   X-Webhook-Signature (legacy): sha256=<hex_hmac_sha256>
+#                                 Signed bytes: <raw_body> (no timestamp)
 #
-# Receiver discovery: WEBHOOK_RECEIVER_URL / WEBHOOK_RECEIVER_PORT, same as
-# the sibling tests. EXPECT_FAILURE=1 inverts the script exit code.
+# Plus the supporting headers:
+#   X-ArtifactKeeper-Delivery       UUID
+#   X-ArtifactKeeper-Event          event type
+#   X-ArtifactKeeper-Event-Version  schema version (default 2026-04-01)
+#
+# The companion backend PR (artifact-keeper#1140) finalizes this contract.
+# This test is meant to land AFTER that backend change. Do not enable in
+# release-gate until #1140 is merged.
+#
+# Receiver discovery: WEBHOOK_RECEIVER_PORT (default in the 18000-19000
+# range, matches the sibling tests). The mock receiver runs locally on the
+# test runner and the backend POSTs to it directly.
 #
 # Requires: curl, jq, python3, openssl
 
@@ -39,15 +47,6 @@ cleanup_and_finalize() {
     wait "${RECEIVER_PID}" 2>/dev/null || true
   fi
   rm -f "${WEBHOOK_RECEIVER_LOG}"
-  if [ "${EXPECT_FAILURE:-0}" = "1" ]; then
-    if [ "$code" -eq 0 ]; then
-      echo "ERROR: EXPECT_FAILURE=1 but suite passed" >&2
-      exit 4
-    else
-      echo "Self-test PASSED: suite exited ${code} as expected"
-      exit 0
-    fi
-  fi
   exit "$code"
 }
 trap cleanup_and_finalize EXIT
@@ -58,10 +57,11 @@ auth_admin
 # Pre-flight: required tools.
 # -------------------------------------------------------------------------
 
-begin_test "openssl and python3 available"
+begin_test "openssl, python3, and jq available"
 miss=""
 command -v openssl >/dev/null 2>&1 || miss="${miss} openssl"
 command -v python3  >/dev/null 2>&1 || miss="${miss} python3"
+command -v jq       >/dev/null 2>&1 || miss="${miss} jq"
 if [ -n "$miss" ]; then
   skip "missing tools:${miss}"
   end_suite
@@ -69,8 +69,7 @@ fi
 pass
 
 # -------------------------------------------------------------------------
-# Start the mock receiver in always-200 mode (no failure simulation; we
-# care about the request, not the response).
+# Start the mock receiver in always-200 mode.
 # -------------------------------------------------------------------------
 
 begin_test "Start mock receiver"
@@ -96,10 +95,9 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# Create a webhook WITH a secret. The backend hashes the secret on create
-# (Argon2 -- see auth_service::hash_password), so we cannot extract it
-# back. We use the plaintext secret we sent on the way in to compute the
-# expected HMAC locally.
+# Create a webhook WITH a secret. We use the plaintext secret we sent on
+# the way in to compute the expected HMAC locally; the backend hashes the
+# secret on storage, so we cannot read it back.
 # -------------------------------------------------------------------------
 
 WEBHOOK_NAME="hmac-${RUN_ID}"
@@ -160,53 +158,155 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# Header presence: X-Webhook-Signature must be set.
+# X-ArtifactKeeper-Signature: presence + shape (t=<int>,v1=<hex64>).
 # -------------------------------------------------------------------------
 
-SIGNATURE_HEADER=""
+NEW_SIG_HEADER=""
+NEW_SIG_TS=""
+NEW_SIG_V1=""
 
-begin_test "X-Webhook-Signature header is present on the delivery"
+begin_test "X-ArtifactKeeper-Signature is present and well-formed"
 if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$LATEST_HEADERS" ]; then
   skip "no receiver entry"
 else
-  # Header lookup is case-insensitive: try common spellings.
-  SIGNATURE_HEADER=$(echo "$LATEST_HEADERS" | jq -r '
-    (.["X-Webhook-Signature"] // .["x-webhook-signature"] // .["X-WEBHOOK-SIGNATURE"] // empty)
+  NEW_SIG_HEADER=$(echo "$LATEST_HEADERS" | jq -r '
+    (.["X-ArtifactKeeper-Signature"] //
+     .["x-artifactkeeper-signature"] //
+     .["X-ARTIFACTKEEPER-SIGNATURE"] // empty)
   ')
-  if [ -n "$SIGNATURE_HEADER" ] && [ "$SIGNATURE_HEADER" != "null" ]; then
-    pass
+  if [ -z "$NEW_SIG_HEADER" ] || [ "$NEW_SIG_HEADER" = "null" ]; then
+    fail "X-ArtifactKeeper-Signature header missing (headers: ${LATEST_HEADERS:0:300})"
   else
-    fail "X-Webhook-Signature header missing (headers: ${LATEST_HEADERS:0:300})"
-  fi
-fi
-
-# -------------------------------------------------------------------------
-# Signature value: must equal sha256=<hex> where hex = HMAC-SHA256(secret, body).
-# -------------------------------------------------------------------------
-
-begin_test "X-Webhook-Signature equals HMAC-SHA256(secret, body)"
-if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$SIGNATURE_HEADER" ] || [ -z "$LATEST_BODY" ]; then
-  skip "no signature or body"
-else
-  expected_hex=$(printf '%s' "$LATEST_BODY" \
-    | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" 2>/dev/null \
-    | awk '{print $NF}')
-
-  if [ -z "$expected_hex" ]; then
-    fail "openssl produced empty HMAC"
-  else
-    expected="sha256=${expected_hex}"
-    # Some implementations emit the raw hex without the "sha256=" prefix.
-    if [ "$SIGNATURE_HEADER" = "$expected" ] || [ "$SIGNATURE_HEADER" = "$expected_hex" ]; then
+    # Shape: t=<digits>(,v1=<64-hex>)+
+    if echo "$NEW_SIG_HEADER" | grep -Eq '^t=[0-9]+(,v1=[0-9a-f]{64})+$'; then
+      NEW_SIG_TS=$(echo "$NEW_SIG_HEADER" | sed -nE 's/^t=([0-9]+).*/\1/p')
+      # Take the FIRST v1 token (current secret, per render_header order).
+      NEW_SIG_V1=$(echo "$NEW_SIG_HEADER" | sed -nE 's/.*,v1=([0-9a-f]{64}).*/\1/p' | head -n 1)
       pass
     else
-      fail "signature mismatch: header='${SIGNATURE_HEADER}' expected='${expected}' (or '${expected_hex}'). v1.1.x is known to emit a placeholder; this assertion tracks the real-HMAC contract for v1.1.9."
+      fail "header value '${NEW_SIG_HEADER}' does not match t=<int>,v1=<64-hex>[,v1=<64-hex>]"
     fi
   fi
 fi
 
 # -------------------------------------------------------------------------
-# Sanity: the body should be valid JSON that includes the event field.
+# X-ArtifactKeeper-Signature: HMAC equality. Recompute over
+# "<t>.<raw_body>" with the known plaintext secret.
+# -------------------------------------------------------------------------
+
+begin_test "X-ArtifactKeeper-Signature v1 token equals HMAC-SHA256(secret, <t>.<body>)"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$NEW_SIG_V1" ] || [ -z "$NEW_SIG_TS" ] || [ -z "$LATEST_BODY" ]; then
+  skip "no signature components captured"
+else
+  expected=$(printf '%s.%s' "$NEW_SIG_TS" "$LATEST_BODY" \
+    | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" 2>/dev/null \
+    | awk '{print $NF}')
+  if [ -z "$expected" ]; then
+    fail "openssl produced empty HMAC"
+  elif [ "$NEW_SIG_V1" = "$expected" ]; then
+    pass
+  else
+    fail "HMAC mismatch: header v1='${NEW_SIG_V1}' expected='${expected}' (signed bytes: '${NEW_SIG_TS}.<body>')"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Legacy X-Webhook-Signature header presence + value. The legacy form is
+# `sha256=<hex>` over the raw body (no timestamp, secret-only). Removed in
+# v1.3.0 per the deprecation plan; still emitted in v1.2.0.
+# -------------------------------------------------------------------------
+
+LEGACY_SIG_HEADER=""
+
+begin_test "Legacy X-Webhook-Signature header is still emitted"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$LATEST_HEADERS" ]; then
+  skip "no receiver entry"
+else
+  LEGACY_SIG_HEADER=$(echo "$LATEST_HEADERS" | jq -r '
+    (.["X-Webhook-Signature"] //
+     .["x-webhook-signature"] //
+     .["X-WEBHOOK-SIGNATURE"] // empty)
+  ')
+  if [ -n "$LEGACY_SIG_HEADER" ] && [ "$LEGACY_SIG_HEADER" != "null" ]; then
+    pass
+  else
+    fail "X-Webhook-Signature legacy header missing (still required in v1.2.0; removed in v1.3.0)"
+  fi
+fi
+
+begin_test "Legacy X-Webhook-Signature equals sha256=HMAC(secret, body)"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$LEGACY_SIG_HEADER" ] || [ -z "$LATEST_BODY" ]; then
+  skip "no legacy signature or body"
+else
+  expected_hex=$(printf '%s' "$LATEST_BODY" \
+    | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" 2>/dev/null \
+    | awk '{print $NF}')
+  expected="sha256=${expected_hex}"
+  if [ -z "$expected_hex" ]; then
+    fail "openssl produced empty legacy HMAC"
+  elif [ "$LEGACY_SIG_HEADER" = "$expected" ]; then
+    pass
+  else
+    fail "legacy signature mismatch: header='${LEGACY_SIG_HEADER}' expected='${expected}'"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Supporting headers: delivery UUID, event type, event version.
+# -------------------------------------------------------------------------
+
+begin_test "X-ArtifactKeeper-Delivery is a UUID"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$LATEST_HEADERS" ]; then
+  skip "no receiver entry"
+else
+  delivery=$(echo "$LATEST_HEADERS" | jq -r '
+    (.["X-ArtifactKeeper-Delivery"] //
+     .["x-artifactkeeper-delivery"] //
+     .["X-ARTIFACTKEEPER-DELIVERY"] // empty)
+  ')
+  if [ -z "$delivery" ] || [ "$delivery" = "null" ]; then
+    fail "X-ArtifactKeeper-Delivery header missing"
+  elif echo "$delivery" | grep -Eiq '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'; then
+    pass
+  else
+    fail "delivery '${delivery}' is not a UUID"
+  fi
+fi
+
+begin_test "X-ArtifactKeeper-Event is non-empty"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$LATEST_HEADERS" ]; then
+  skip "no receiver entry"
+else
+  evt=$(echo "$LATEST_HEADERS" | jq -r '
+    (.["X-ArtifactKeeper-Event"] //
+     .["x-artifactkeeper-event"] //
+     .["X-ARTIFACTKEEPER-EVENT"] // empty)
+  ')
+  if [ -n "$evt" ] && [ "$evt" != "null" ]; then
+    pass
+  else
+    fail "X-ArtifactKeeper-Event header missing"
+  fi
+fi
+
+begin_test "X-ArtifactKeeper-Event-Version defaults to 2026-04-01"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$LATEST_HEADERS" ]; then
+  skip "no receiver entry"
+else
+  ver=$(echo "$LATEST_HEADERS" | jq -r '
+    (.["X-ArtifactKeeper-Event-Version"] //
+     .["x-artifactkeeper-event-version"] //
+     .["X-ARTIFACTKEEPER-EVENT-VERSION"] // empty)
+  ')
+  if [ "$ver" = "2026-04-01" ]; then
+    pass
+  else
+    fail "expected event-version '2026-04-01', got '${ver}'"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Sanity: body is JSON with an event field.
 # -------------------------------------------------------------------------
 
 begin_test "Delivery body is JSON with an event field"

--- a/tests/webhooks/test-webhook-replay-window.sh
+++ b/tests/webhooks/test-webhook-replay-window.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# test-webhook-replay-window.sh
+#
+# Webhooks v2 wire contract (artifact-keeper#919, E2): receivers MUST reject
+# deliveries whose timestamp falls outside the replay window (default 300s).
+#
+# Why this is structured as an offline-verifier test:
+#   The backend always signs `t=now` at delivery time; we cannot push a
+#   stale timestamp through the live producer path without backdating the
+#   server clock, which is not a thing the harness can do safely. Instead
+#   we capture a real signed delivery (header + body) into a file and then
+#   run a small inline python3 verifier that mirrors the contract's sample
+#   verification logic. The verifier returns 401 when |t - now| > window
+#   even though the HMAC itself is valid.
+#
+# Receiver discovery: WEBHOOK_RECEIVER_PORT (default in 18000-19000 range).
+#
+# Companion backend PR: artifact-keeper#1140.
+#
+# Requires: curl, jq, python3, openssl
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "webhook-replay-window"
+
+WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18769}"
+WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
+WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-replay-${RUN_ID}.log}"
+WEBHOOK_SECRET="${WEBHOOK_SECRET:-replay-${RUN_ID}}"
+REPLAY_WINDOW_SECS="${REPLAY_WINDOW_SECS:-300}"
+RECEIVER_PID=""
+
+cleanup_and_finalize() {
+  local code=$?
+  if [ -n "${RECEIVER_PID}" ] && kill -0 "${RECEIVER_PID}" 2>/dev/null; then
+    kill "${RECEIVER_PID}" 2>/dev/null || true
+    wait "${RECEIVER_PID}" 2>/dev/null || true
+  fi
+  rm -f "${WEBHOOK_RECEIVER_LOG}"
+  exit "$code"
+}
+trap cleanup_and_finalize EXIT
+
+auth_admin
+
+# -------------------------------------------------------------------------
+# Pre-flight: required tools.
+# -------------------------------------------------------------------------
+
+begin_test "openssl, python3, and jq available"
+miss=""
+command -v openssl >/dev/null 2>&1 || miss="${miss} openssl"
+command -v python3  >/dev/null 2>&1 || miss="${miss} python3"
+command -v jq       >/dev/null 2>&1 || miss="${miss} jq"
+if [ -n "$miss" ]; then
+  skip "missing tools:${miss}"
+  end_suite
+fi
+pass
+
+# -------------------------------------------------------------------------
+# Capture a real delivery: spin up the mock receiver, create a webhook
+# with a known plaintext secret, fire /test, and snapshot the request.
+# -------------------------------------------------------------------------
+
+begin_test "Start mock receiver"
+WEBHOOK_RECEIVER_PORT="$WEBHOOK_RECEIVER_PORT" \
+  WEBHOOK_FAIL_FIRST_N=0 \
+  WEBHOOK_RECEIVER_LOG="$WEBHOOK_RECEIVER_LOG" \
+  python3 "$(dirname "$0")/../lib/mock-webhook-receiver.py" \
+  >/tmp/mock-webhook-receiver-replay-${RUN_ID}.stderr 2>&1 &
+RECEIVER_PID=$!
+
+ready=false
+for _ in $(seq 1 25); do
+  if curl -sf --max-time 1 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__health" >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 0.2
+done
+if [ "$ready" = true ]; then
+  pass
+else
+  fail "mock receiver did not come up on 127.0.0.1:${WEBHOOK_RECEIVER_PORT}"
+fi
+
+WEBHOOK_NAME="replay-${RUN_ID}"
+WEBHOOK_ID=""
+SUITE_BLOCKED=false
+
+begin_test "Create webhook with shared secret"
+if [ "$ready" != "true" ]; then
+  skip "receiver not running"
+else
+  PAYLOAD=$(jq -n \
+    --arg name "$WEBHOOK_NAME" \
+    --arg url "$WEBHOOK_RECEIVER_URL" \
+    --arg secret "$WEBHOOK_SECRET" \
+    '{name: $name, url: $url, secret: $secret, events: ["artifact.uploaded"], enabled: true}')
+  if resp=$(api_post "/api/v1/webhooks" "$PAYLOAD" 2>/dev/null); then
+    WEBHOOK_ID=$(echo "$resp" | jq -r '.id // empty')
+    if [ -z "$WEBHOOK_ID" ] || [ "$WEBHOOK_ID" = "null" ]; then
+      fail "create returned no id"
+    else
+      pass
+    fi
+  else
+    SUITE_BLOCKED=true
+    skip "webhook create rejected (URL '${WEBHOOK_RECEIVER_URL}' likely blocked by SSRF allow-list)"
+  fi
+fi
+
+LATEST_HEADERS=""
+LATEST_BODY=""
+SIG_HEADER=""
+
+begin_test "Capture a real signed delivery"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "no webhook id"
+else
+  if api_post "/api/v1/webhooks/${WEBHOOK_ID}/test" "" >/dev/null 2>&1; then
+    seen=0
+    for _ in $(seq 1 20); do
+      seen=$(curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__count" 2>/dev/null || echo 0)
+      [ "$seen" -gt 0 ] && break
+      sleep 0.5
+    done
+    if [ "$seen" -ge 1 ] && [ -s "$WEBHOOK_RECEIVER_LOG" ]; then
+      LATEST=$(tail -n 1 "$WEBHOOK_RECEIVER_LOG")
+      LATEST_HEADERS=$(echo "$LATEST" | jq -r '.headers')
+      LATEST_BODY=$(echo "$LATEST" | jq -r '.body')
+      SIG_HEADER=$(echo "$LATEST_HEADERS" | jq -r '
+        (.["X-ArtifactKeeper-Signature"] //
+         .["x-artifactkeeper-signature"] //
+         .["X-ARTIFACTKEEPER-SIGNATURE"] // empty)
+      ')
+      if [ -n "$SIG_HEADER" ] && [ "$SIG_HEADER" != "null" ]; then
+        pass
+      else
+        fail "no X-ArtifactKeeper-Signature header on captured delivery"
+      fi
+    else
+      fail "no POST recorded at receiver after /test"
+    fi
+  else
+    skip "/test endpoint unavailable"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Verifier sub-tests. The python3 helper below mirrors the docs sample:
+# parse the header, check |t - now| <= window, recompute HMAC, accept or
+# reject.
+# -------------------------------------------------------------------------
+
+VERIFIER_PY=$(cat <<'PYEOF'
+import hashlib
+import hmac
+import os
+import sys
+import time
+
+secret = os.environ["VERIFY_SECRET"].encode()
+window = int(os.environ.get("VERIFY_WINDOW", "300"))
+now = int(os.environ.get("VERIFY_NOW", str(int(time.time()))))
+sig_header = os.environ["VERIFY_SIG"]
+body = os.environ["VERIFY_BODY"].encode()
+
+ts = None
+v1_tokens = []
+for part in sig_header.split(","):
+    part = part.strip()
+    if part.startswith("t="):
+        try:
+            ts = int(part[2:])
+        except ValueError:
+            print("malformed t=", file=sys.stderr)
+            sys.exit(1)
+    elif part.startswith("v1="):
+        v1_tokens.append(part[3:])
+
+if ts is None or not v1_tokens:
+    print("missing t= or v1=", file=sys.stderr)
+    sys.exit(1)
+
+if abs(now - ts) > window:
+    print(f"replay rejected: |now-t|={abs(now-ts)} > window={window}", file=sys.stderr)
+    sys.exit(2)
+
+signed = f"{ts}.".encode() + body
+expected = hmac.new(secret, signed, hashlib.sha256).hexdigest()
+if any(hmac.compare_digest(expected, tok) for tok in v1_tokens):
+    print("ok")
+    sys.exit(0)
+
+print("hmac mismatch", file=sys.stderr)
+sys.exit(3)
+PYEOF
+)
+
+# -------------------------------------------------------------------------
+# Sub-test 1: replay the captured delivery as-is (now ~= t). Verifier must
+# accept (exit 0). This proves the verifier itself works.
+# -------------------------------------------------------------------------
+
+begin_test "Verifier ACCEPTS a fresh delivery (within replay window)"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$SIG_HEADER" ]; then
+  skip "no captured signature"
+else
+  if VERIFY_SECRET="$WEBHOOK_SECRET" \
+     VERIFY_WINDOW="$REPLAY_WINDOW_SECS" \
+     VERIFY_SIG="$SIG_HEADER" \
+     VERIFY_BODY="$LATEST_BODY" \
+     python3 -c "$VERIFIER_PY" >/dev/null 2>/tmp/replay-verify-fresh-${RUN_ID}.err; then
+    pass
+  else
+    err=$(cat /tmp/replay-verify-fresh-${RUN_ID}.err 2>/dev/null || true)
+    fail "fresh delivery should verify but verifier rejected: ${err}"
+  fi
+  rm -f /tmp/replay-verify-fresh-${RUN_ID}.err
+fi
+
+# -------------------------------------------------------------------------
+# Sub-test 2: simulate a stale delivery by passing VERIFY_NOW pushed ahead
+# of the embedded t= by (window + 60) seconds. The HMAC remains valid for
+# the original t but the timestamp window check must reject. Verifier exit
+# code 2 = replay rejected.
+# -------------------------------------------------------------------------
+
+begin_test "Verifier REJECTS a delivery outside the replay window (exit 2)"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$SIG_HEADER" ]; then
+  skip "no captured signature"
+else
+  ts=$(echo "$SIG_HEADER" | sed -nE 's/^t=([0-9]+).*/\1/p')
+  if [ -z "$ts" ]; then
+    fail "could not parse t= from signature header '${SIG_HEADER}'"
+  else
+    fake_now=$(( ts + REPLAY_WINDOW_SECS + 60 ))
+    set +e
+    VERIFY_SECRET="$WEBHOOK_SECRET" \
+      VERIFY_WINDOW="$REPLAY_WINDOW_SECS" \
+      VERIFY_NOW="$fake_now" \
+      VERIFY_SIG="$SIG_HEADER" \
+      VERIFY_BODY="$LATEST_BODY" \
+      python3 -c "$VERIFIER_PY" >/dev/null 2>/tmp/replay-verify-stale-${RUN_ID}.err
+    rc=$?
+    set -e
+    if [ "$rc" = "2" ]; then
+      pass
+    else
+      err=$(cat /tmp/replay-verify-stale-${RUN_ID}.err 2>/dev/null || true)
+      fail "expected verifier exit 2 (replay rejected), got ${rc}: ${err}"
+    fi
+    rm -f /tmp/replay-verify-stale-${RUN_ID}.err
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Sub-test 3: tampered body must fail HMAC even within the window
+# (verifier exit 3 = hmac mismatch). Sanity check that the verifier is
+# not just rubber-stamping anything.
+# -------------------------------------------------------------------------
+
+begin_test "Verifier REJECTS a tampered body within the replay window (exit 3)"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$SIG_HEADER" ]; then
+  skip "no captured signature"
+else
+  tampered_body="${LATEST_BODY}<tampered>"
+  set +e
+  VERIFY_SECRET="$WEBHOOK_SECRET" \
+    VERIFY_WINDOW="$REPLAY_WINDOW_SECS" \
+    VERIFY_SIG="$SIG_HEADER" \
+    VERIFY_BODY="$tampered_body" \
+    python3 -c "$VERIFIER_PY" >/dev/null 2>/tmp/replay-verify-tamper-${RUN_ID}.err
+  rc=$?
+  set -e
+  if [ "$rc" = "3" ]; then
+    pass
+  else
+    err=$(cat /tmp/replay-verify-tamper-${RUN_ID}.err 2>/dev/null || true)
+    fail "expected verifier exit 3 (hmac mismatch), got ${rc}: ${err}"
+  fi
+  rm -f /tmp/replay-verify-tamper-${RUN_ID}.err
+fi
+
+if [ -n "$WEBHOOK_ID" ] && [ "$WEBHOOK_ID" != "null" ]; then
+  api_delete "/api/v1/webhooks/${WEBHOOK_ID}" >/dev/null 2>&1 || true
+fi
+
+end_suite

--- a/tests/webhooks/test-webhook-retry-recover.sh
+++ b/tests/webhooks/test-webhook-retry-recover.sh
@@ -1,37 +1,36 @@
 #!/usr/bin/env bash
 # test-webhook-retry-recover.sh
 #
-# Epic 7 / sub-task 7.1, 7.4 (artifact-keeper-test#73): exercise the webhook
-# delivery retry engine end-to-end. The receiver returns 500 for the first N
-# requests then 200, so a delivery should be retried and eventually succeed.
+# Webhooks v2 wire contract (artifact-keeper#919, E5): exercise the webhook
+# delivery retry engine end-to-end.
 #
-# Backoff schedule (from backend webhooks::webhook_retry_delay_secs):
-#   attempt 1 -> 30s,  2 -> 2m,  3 -> 15m,  4 -> 1h,  5+ -> 4h (cap)
+# Full v2 retry schedule (jittered +/-20%):
+#   30s, 1m, 2m, 5m, 10m, 30m, 1h, 2h, 4h, 8h, 16h, 24h
+#   = 12 attempts; total walltime ~65h.
 #
-# Hard constraint noted in the issue: full retry schedule is hours long. There
-# is no admin "fast-forward" endpoint and no SHORT_BACKOFF env in v1.1.x. The
-# scheduler ticks every 30s (services::scheduler_service::start_all line 244)
-# so the FIRST retry will fire within ~60s. This test asserts only the first
-# retry round-trip and is bounded at WEBHOOK_RETRY_TIMEOUT seconds (default
-# 180). Longer-attempt verification is out of scope for the gate.
+# Smoke profile: this test caps observation at the first 3 attempts so the
+# release-gate stays under WEBHOOK_RETRY_TIMEOUT (default 360s). The first
+# three intervals (30s, 60s, 120s base) plus +/-20% jitter give acceptable
+# windows of:
+#   attempt 1 ->  24-36s
+#   attempt 2 ->  48-72s   (cumulative 72-108s)
+#   attempt 3 ->  96-144s  (cumulative 168-252s)
+# The full 12-attempt schedule is exercised in the dead-letter test.
 #
 # Receiver discovery:
-#   WEBHOOK_RECEIVER_URL  - full URL the backend will POST to (default
-#                           http://127.0.0.1:18765/hook). MUST be reachable
-#                           from the backend AND must pass the SSRF allow-list
-#                           (see backend api::validation). 127.0.0.1 is
-#                           blocked, so on CI you must override this with a
-#                           publicly routable URL. Local-dev only works when
-#                           the backend runs out-of-container and can hit
-#                           loopback (skip otherwise).
-#   WEBHOOK_RECEIVER_PORT - port the local mock listens on (default 18765).
-#   WEBHOOK_FAIL_FIRST_N  - how many POSTs the mock should reject with 500
-#                           before flipping to 200 (default 1).
-#   WEBHOOK_RETRY_TIMEOUT - seconds to wait for the recover round-trip
-#                           (default 180; first retry fires at ~30-60s).
+#   WEBHOOK_RECEIVER_PORT  - port the local mock listens on (default 18765).
+#   WEBHOOK_RECEIVER_URL   - URL the backend POSTs to. Defaults to the
+#                            local mock; override in environments where
+#                            the backend cannot reach loopback.
+#   WEBHOOK_FAIL_FIRST_N   - how many POSTs the mock should reject with
+#                            500 before flipping to 200 (default 1, so we
+#                            observe the recover path on the first retry).
+#   WEBHOOK_RETRY_TIMEOUT  - seconds to wait for the recover round-trip
+#                            (default 360 to cover up to attempt 3 with
+#                            jitter headroom).
 #
-# Self-test mode: set EXPECT_FAILURE=1 to invert the script exit code (used
-# by clean-install-smoke.sh-style gate self-tests).
+# Companion backend PR: artifact-keeper#1140. Producer feature flag is
+# WEBHOOKS_V2_PRODUCER_ENABLED; harness sets it to 1.
 #
 # Requires: curl, jq, python3
 
@@ -42,7 +41,7 @@ begin_suite "webhook-retry-recover"
 WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18765}"
 WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
 WEBHOOK_FAIL_FIRST_N="${WEBHOOK_FAIL_FIRST_N:-1}"
-WEBHOOK_RETRY_TIMEOUT="${WEBHOOK_RETRY_TIMEOUT:-180}"
+WEBHOOK_RETRY_TIMEOUT="${WEBHOOK_RETRY_TIMEOUT:-360}"
 WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-${RUN_ID}.log}"
 RECEIVER_PID=""
 
@@ -53,15 +52,6 @@ cleanup_and_finalize() {
     wait "${RECEIVER_PID}" 2>/dev/null || true
   fi
   rm -f "${WEBHOOK_RECEIVER_LOG}"
-  if [ "${EXPECT_FAILURE:-0}" = "1" ]; then
-    if [ "$code" -eq 0 ]; then
-      echo "ERROR: EXPECT_FAILURE=1 but suite passed" >&2
-      exit 4
-    else
-      echo "Self-test PASSED: suite exited ${code} as expected"
-      exit 0
-    fi
-  fi
   exit "$code"
 }
 trap cleanup_and_finalize EXIT
@@ -69,7 +59,7 @@ trap cleanup_and_finalize EXIT
 auth_admin
 
 # -------------------------------------------------------------------------
-# Start mock receiver
+# Start mock receiver.
 # -------------------------------------------------------------------------
 
 begin_test "Start mock webhook receiver"
@@ -83,7 +73,6 @@ else
     >/tmp/mock-webhook-receiver-${RUN_ID}.stderr 2>&1 &
   RECEIVER_PID=$!
 
-  # Poll the health endpoint for up to 5 seconds.
   ready=false
   for _ in $(seq 1 25); do
     if curl -sf --max-time 1 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__health" >/dev/null 2>&1; then
@@ -100,10 +89,7 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# Create a webhook pointing at the mock receiver. If the URL is loopback /
-# RFC1918, the backend's SSRF allow-list will reject the POST with a 422; we
-# treat that as a skip (the gate operator must supply a publicly-routable
-# WEBHOOK_RECEIVER_URL in CI).
+# Create a webhook pointing at the mock receiver.
 # -------------------------------------------------------------------------
 
 WEBHOOK_NAME="retry-recover-${RUN_ID}"
@@ -127,18 +113,12 @@ else
     fi
   else
     SUITE_BLOCKED=true
-    skip "webhook create rejected (URL '${WEBHOOK_RECEIVER_URL}' likely blocked by SSRF allow-list; set WEBHOOK_RECEIVER_URL to a publicly-routable address)"
+    skip "webhook create rejected (URL '${WEBHOOK_RECEIVER_URL}' likely blocked by SSRF allow-list)"
   fi
 fi
 
 # -------------------------------------------------------------------------
-# Trigger the webhook. The /test endpoint POSTs to the configured URL once,
-# without writing a webhook_deliveries row -- so the retry engine itself
-# cannot be exercised through this path. We use it here to confirm the mock
-# receiver wiring works (request reaches the receiver, fail-then-succeed
-# logic is observable at the receiver level). Full retry-engine coverage
-# requires a producer that INSERTs into webhook_deliveries with
-# next_retry_at set, which v1.1.x does not yet wire from artifact upload.
+# Trigger the initial delivery.
 # -------------------------------------------------------------------------
 
 begin_test "Trigger /test delivery and observe initial POST at receiver"
@@ -146,7 +126,6 @@ if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
   skip "no webhook id"
 else
   if api_post "/api/v1/webhooks/${WEBHOOK_ID}/test" "" >/dev/null 2>&1; then
-    # Wait a moment for the async POST to arrive at the receiver.
     seen=0
     for _ in $(seq 1 10); do
       seen=$(curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__count" 2>/dev/null || echo 0)
@@ -164,68 +143,106 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# Drive the retry pipeline via redeliver. /redeliver re-POSTs an existing
-# webhook_deliveries row but, like /test, does not by itself schedule a
-# follow-up retry. We use it here to confirm the end-to-end shape (the
-# delivery list is queryable, attempt count increments, headers reach the
-# receiver) within the bounded WEBHOOK_RETRY_TIMEOUT window.
+# Retry windows for v2 schedule (with +/-20% jitter applied):
+#   attempt 1: 24..36s   after the failed try
+#   attempt 2: 48..72s   after attempt 1
+#   attempt 3: 96..144s  after attempt 2
+# We observe the timestamps of consecutive POSTs at the receiver and
+# assert each gap is within window. For the smoke profile we cap at 3
+# attempts (covers attempt 1, 2, 3 deltas).
 # -------------------------------------------------------------------------
 
-begin_test "Verify deliveries-list endpoint is reachable for this webhook"
+EXPECT_ATTEMPTS=3
+RETRY_MIN=(24 48 96)
+RETRY_MAX=(36 72 144)
+
+# Mark the receiver log so we can read deltas freshly.
+LOG_BASELINE_LINES=0
+if [ -f "$WEBHOOK_RECEIVER_LOG" ]; then
+  LOG_BASELINE_LINES=$(wc -l < "$WEBHOOK_RECEIVER_LOG" | tr -d ' ')
+fi
+
+begin_test "Retry intervals for attempts 1..3 fall within v2 schedule (+/-20% jitter)"
 if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
   skip "no webhook id"
 else
-  if list=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}/deliveries" 2>/dev/null); then
-    # Shape check: must have an .items array (possibly empty) and a .total.
-    items_type=$(echo "$list" | jq -r 'try (.items | type) catch "missing"')
-    if [ "$items_type" = "array" ]; then
+  # Wait for at least EXPECT_ATTEMPTS + 1 entries (the initial delivery
+  # plus the retry attempts). Bail at WEBHOOK_RETRY_TIMEOUT.
+  expected_entries=$(( EXPECT_ATTEMPTS + 1 ))
+  elapsed=0
+  poll=5
+  while [ "$elapsed" -lt "$WEBHOOK_RETRY_TIMEOUT" ]; do
+    seen=$(curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__count" 2>/dev/null || echo 0)
+    if [ "$seen" -ge "$expected_entries" ]; then
+      break
+    fi
+    sleep "$poll"
+    elapsed=$(( elapsed + poll ))
+  done
+
+  total_lines=$(wc -l < "$WEBHOOK_RECEIVER_LOG" 2>/dev/null | tr -d ' ' || echo 0)
+  new_lines=$(( total_lines - LOG_BASELINE_LINES ))
+  if [ "$new_lines" -lt "$expected_entries" ]; then
+    skip "only ${new_lines} delivery entries observed within ${WEBHOOK_RETRY_TIMEOUT}s; producer may not be running, or jitter pushed timing out of window"
+  else
+    # Pull the last `expected_entries` timestamps (in seconds, float).
+    mapfile -t ts_lines < <(tail -n "$expected_entries" "$WEBHOOK_RECEIVER_LOG" \
+      | jq -r '.ts' 2>/dev/null)
+    if [ "${#ts_lines[@]}" -lt "$expected_entries" ]; then
+      fail "could not parse ${expected_entries} timestamps from receiver log"
+    else
+      bad=""
+      for i in $(seq 1 "$EXPECT_ATTEMPTS"); do
+        prev="${ts_lines[$((i-1))]}"
+        curr="${ts_lines[$i]}"
+        # Integer delta (sec). awk handles the float subtraction.
+        delta=$(awk -v a="$curr" -v b="$prev" 'BEGIN { printf "%d", (a - b) }')
+        min="${RETRY_MIN[$((i-1))]}"
+        max="${RETRY_MAX[$((i-1))]}"
+        if [ "$delta" -lt "$min" ] || [ "$delta" -gt "$max" ]; then
+          bad="${bad} attempt${i}_delta=${delta}s(expected_${min}-${max})"
+        fi
+      done
+      if [ -z "$bad" ]; then
+        pass
+      else
+        fail "retry interval(s) outside v2 +/-20% window:${bad}"
+      fi
+    fi
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# X-ArtifactKeeper-Retry-Attempt is emitted ONLY on retry deliveries
+# (per the v2 wire contract). The first delivery has no retry header;
+# subsequent deliveries carry attempt counters >= 1.
+# -------------------------------------------------------------------------
+
+begin_test "X-ArtifactKeeper-Retry-Attempt header present on retry deliveries"
+if [ "$SUITE_BLOCKED" = "true" ] || [ ! -s "$WEBHOOK_RECEIVER_LOG" ]; then
+  skip "no receiver log"
+else
+  total_lines=$(wc -l < "$WEBHOOK_RECEIVER_LOG" 2>/dev/null | tr -d ' ' || echo 0)
+  if [ "$total_lines" -lt 2 ]; then
+    skip "only ${total_lines} delivery entry/entries; cannot check retry header"
+  else
+    second_headers=$(sed -n '2p' "$WEBHOOK_RECEIVER_LOG" | jq -r '.headers')
+    retry_attempt=$(echo "$second_headers" | jq -r '
+      (.["X-ArtifactKeeper-Retry-Attempt"] //
+       .["x-artifactkeeper-retry-attempt"] //
+       .["X-ARTIFACTKEEPER-RETRY-ATTEMPT"] // empty)
+    ')
+    if [ -n "$retry_attempt" ] && [ "$retry_attempt" != "null" ] && \
+       [[ "$retry_attempt" =~ ^[0-9]+$ ]] && [ "$retry_attempt" -ge 1 ]; then
       pass
     else
-      fail "deliveries response shape unexpected: ${list:0:200}"
+      fail "expected retry-attempt header >= 1 on second delivery, got '${retry_attempt}'"
     fi
-  else
-    fail "deliveries endpoint unreachable"
   fi
 fi
 
 # -------------------------------------------------------------------------
-# Inspect the receiver log for the recover semantics: the FIRST POSTs return
-# 500 (mock-receiver failure simulation) and a later POST returns 200. If
-# the backend producer wires retries through, the receiver log will show
-# >= WEBHOOK_FAIL_FIRST_N + 1 entries. v1.1.x: only the /test single shot
-# is observable, so we assert the recover boundary at the receiver layer
-# (the mock itself flipped from 500 -> 200).
-# -------------------------------------------------------------------------
-
-begin_test "Receiver flipped from failure to success after WEBHOOK_FAIL_FIRST_N"
-if [ "$SUITE_BLOCKED" = "true" ]; then
-  skip "suite blocked"
-elif [ ! -f "$WEBHOOK_RECEIVER_LOG" ]; then
-  skip "receiver log missing"
-else
-  # Send WEBHOOK_FAIL_FIRST_N + 1 direct POSTs to the receiver to verify
-  # its flip behaviour. This is a self-check on the mock, independent of
-  # the backend retry engine.
-  total=$(( WEBHOOK_FAIL_FIRST_N + 1 ))
-  for i in $(seq 1 "$total"); do
-    curl -s -o /dev/null --max-time 5 -X POST \
-      -H "Content-Type: application/json" \
-      -d "{\"probe\":${i}}" \
-      "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/probe" || true
-  done
-  # Pull the last entry's effective status. The mock returns 500 to the
-  # first N then 200; we use jq to grep the log for one entry whose
-  # path is /probe and which arrived after our fail-cutoff.
-  log_count=$(wc -l < "$WEBHOOK_RECEIVER_LOG" | tr -d ' ')
-  if [ "$log_count" -ge "$total" ]; then
-    pass
-  else
-    fail "receiver log has ${log_count} entries, expected >= ${total}"
-  fi
-fi
-
-# -------------------------------------------------------------------------
-# Cleanup the webhook so re-runs of the suite don't accumulate fixtures.
+# Cleanup.
 # -------------------------------------------------------------------------
 
 if [ -n "$WEBHOOK_ID" ] && [ "$WEBHOOK_ID" != "null" ]; then

--- a/tests/webhooks/test-webhook-rotation-overlap.sh
+++ b/tests/webhooks/test-webhook-rotation-overlap.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# test-webhook-rotation-overlap.sh
+#
+# Webhooks v2 wire contract (artifact-keeper#919, E2): during the 24h secret
+# rotation overlap window the X-ArtifactKeeper-Signature header carries TWO
+# v1= tokens (current, previous) so receivers that have not yet rotated keys
+# can still validate.
+#
+# Test plan:
+#   1. Create webhook with secret S0.
+#   2. POST /api/v1/webhooks/<id>/rotate-secret. The response carries the
+#      new plaintext secret S1 and the previous_secret_expires_at window.
+#   3. Fire /test (or wait for a producer-driven delivery) and capture the
+#      receiver entry.
+#   4. Assert the X-ArtifactKeeper-Signature header has exactly two v1=
+#      tokens.
+#   5. Recompute HMAC(S1, t.body) and HMAC(S0, t.body); both must appear in
+#      the header (in either order; the contract pins current-first but
+#      receivers MUST tolerate either).
+#
+# Companion backend PR: artifact-keeper#1140.
+#
+# Requires: curl, jq, python3, openssl
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "webhook-rotation-overlap"
+
+WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18770}"
+WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
+WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-rot-${RUN_ID}.log}"
+INITIAL_SECRET="${WEBHOOK_SECRET:-rot-initial-${RUN_ID}}"
+RECEIVER_PID=""
+
+cleanup_and_finalize() {
+  local code=$?
+  if [ -n "${RECEIVER_PID}" ] && kill -0 "${RECEIVER_PID}" 2>/dev/null; then
+    kill "${RECEIVER_PID}" 2>/dev/null || true
+    wait "${RECEIVER_PID}" 2>/dev/null || true
+  fi
+  rm -f "${WEBHOOK_RECEIVER_LOG}"
+  exit "$code"
+}
+trap cleanup_and_finalize EXIT
+
+auth_admin
+
+# -------------------------------------------------------------------------
+# Pre-flight.
+# -------------------------------------------------------------------------
+
+begin_test "openssl, python3, and jq available"
+miss=""
+command -v openssl >/dev/null 2>&1 || miss="${miss} openssl"
+command -v python3  >/dev/null 2>&1 || miss="${miss} python3"
+command -v jq       >/dev/null 2>&1 || miss="${miss} jq"
+if [ -n "$miss" ]; then
+  skip "missing tools:${miss}"
+  end_suite
+fi
+pass
+
+# -------------------------------------------------------------------------
+# Start mock receiver.
+# -------------------------------------------------------------------------
+
+begin_test "Start mock receiver"
+WEBHOOK_RECEIVER_PORT="$WEBHOOK_RECEIVER_PORT" \
+  WEBHOOK_FAIL_FIRST_N=0 \
+  WEBHOOK_RECEIVER_LOG="$WEBHOOK_RECEIVER_LOG" \
+  python3 "$(dirname "$0")/../lib/mock-webhook-receiver.py" \
+  >/tmp/mock-webhook-receiver-rot-${RUN_ID}.stderr 2>&1 &
+RECEIVER_PID=$!
+
+ready=false
+for _ in $(seq 1 25); do
+  if curl -sf --max-time 1 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__health" >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 0.2
+done
+if [ "$ready" = true ]; then
+  pass
+else
+  fail "mock receiver did not come up on 127.0.0.1:${WEBHOOK_RECEIVER_PORT}"
+fi
+
+# -------------------------------------------------------------------------
+# Create webhook with initial secret S0.
+# -------------------------------------------------------------------------
+
+WEBHOOK_NAME="rotation-${RUN_ID}"
+WEBHOOK_ID=""
+SUITE_BLOCKED=false
+
+begin_test "Create webhook with initial secret"
+if [ "$ready" != "true" ]; then
+  skip "receiver not running"
+else
+  PAYLOAD=$(jq -n \
+    --arg name "$WEBHOOK_NAME" \
+    --arg url "$WEBHOOK_RECEIVER_URL" \
+    --arg secret "$INITIAL_SECRET" \
+    '{name: $name, url: $url, secret: $secret, events: ["artifact.uploaded"], enabled: true}')
+  if resp=$(api_post "/api/v1/webhooks" "$PAYLOAD" 2>/dev/null); then
+    WEBHOOK_ID=$(echo "$resp" | jq -r '.id // empty')
+    if [ -z "$WEBHOOK_ID" ] || [ "$WEBHOOK_ID" = "null" ]; then
+      fail "create returned no id"
+    else
+      pass
+    fi
+  else
+    SUITE_BLOCKED=true
+    skip "webhook create rejected (URL '${WEBHOOK_RECEIVER_URL}' likely blocked by SSRF allow-list)"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Rotate the secret. The response carries:
+#   { secret: "<new plaintext>", secret_digest: "<hex>",
+#     previous_secret_expires_at: "<rfc3339>" }
+# -------------------------------------------------------------------------
+
+NEW_SECRET=""
+PREV_EXPIRES_AT=""
+
+begin_test "POST /rotate-secret returns new secret + previous_secret_expires_at"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "no webhook id"
+else
+  if rot_resp=$(api_post "/api/v1/webhooks/${WEBHOOK_ID}/rotate-secret" "" 2>/dev/null); then
+    NEW_SECRET=$(echo "$rot_resp" | jq -r '.secret // empty')
+    PREV_EXPIRES_AT=$(echo "$rot_resp" | jq -r '.previous_secret_expires_at // empty')
+    if [ -z "$NEW_SECRET" ] || [ "$NEW_SECRET" = "null" ]; then
+      fail "rotate-secret response missing .secret: ${rot_resp:0:200}"
+    elif [ -z "$PREV_EXPIRES_AT" ] || [ "$PREV_EXPIRES_AT" = "null" ]; then
+      fail "rotate-secret response missing .previous_secret_expires_at: ${rot_resp:0:200}"
+    else
+      pass
+    fi
+  else
+    SUITE_BLOCKED=true
+    skip "/rotate-secret endpoint unavailable"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Capture a delivery during the overlap window. Truncate the receiver log
+# first so we read the post-rotation entry.
+# -------------------------------------------------------------------------
+
+LATEST_HEADERS=""
+LATEST_BODY=""
+SIG_HEADER=""
+
+begin_test "Capture a delivery during the overlap window"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$NEW_SECRET" ]; then
+  skip "rotation not performed"
+else
+  # Reset the receiver counter + log so we read fresh entries.
+  curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__reset" >/dev/null 2>&1 || true
+
+  if api_post "/api/v1/webhooks/${WEBHOOK_ID}/test" "" >/dev/null 2>&1; then
+    seen=0
+    for _ in $(seq 1 20); do
+      seen=$(curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__count" 2>/dev/null || echo 0)
+      [ "$seen" -gt 0 ] && break
+      sleep 0.5
+    done
+    if [ "$seen" -ge 1 ] && [ -s "$WEBHOOK_RECEIVER_LOG" ]; then
+      LATEST=$(tail -n 1 "$WEBHOOK_RECEIVER_LOG")
+      LATEST_HEADERS=$(echo "$LATEST" | jq -r '.headers')
+      LATEST_BODY=$(echo "$LATEST" | jq -r '.body')
+      SIG_HEADER=$(echo "$LATEST_HEADERS" | jq -r '
+        (.["X-ArtifactKeeper-Signature"] //
+         .["x-artifactkeeper-signature"] //
+         .["X-ARTIFACTKEEPER-SIGNATURE"] // empty)
+      ')
+      if [ -n "$SIG_HEADER" ] && [ "$SIG_HEADER" != "null" ]; then
+        pass
+      else
+        fail "captured delivery has no X-ArtifactKeeper-Signature header"
+      fi
+    else
+      fail "no POST recorded after /test during overlap"
+    fi
+  else
+    skip "/test endpoint unavailable"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Assert TWO v1= tokens.
+# -------------------------------------------------------------------------
+
+V1_TOKENS=()
+SIG_TS=""
+
+begin_test "X-ArtifactKeeper-Signature carries exactly two v1= tokens"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$SIG_HEADER" ]; then
+  skip "no captured signature"
+else
+  SIG_TS=$(echo "$SIG_HEADER" | sed -nE 's/^t=([0-9]+).*/\1/p')
+  # Extract every v1=<64-hex> token.
+  mapfile -t V1_TOKENS < <(echo "$SIG_HEADER" | grep -Eo 'v1=[0-9a-f]{64}' | sed 's/^v1=//')
+  count="${#V1_TOKENS[@]}"
+  if [ -z "$SIG_TS" ]; then
+    fail "could not parse t= from header '${SIG_HEADER}'"
+  elif [ "$count" -eq 2 ]; then
+    pass
+  else
+    fail "expected 2 v1= tokens during overlap, got ${count} (header: ${SIG_HEADER})"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Both tokens must validate: one against the new secret, one against the
+# previous (initial) secret. The contract pins current-first, but tests
+# accept either order.
+# -------------------------------------------------------------------------
+
+begin_test "Both v1= tokens validate (one matches new secret, one matches previous)"
+if [ "$SUITE_BLOCKED" = "true" ] || [ "${#V1_TOKENS[@]}" -ne 2 ] || [ -z "$SIG_TS" ]; then
+  skip "no token pair to validate"
+else
+  hmac_with() {
+    printf '%s.%s' "$SIG_TS" "$LATEST_BODY" \
+      | openssl dgst -sha256 -hmac "$1" 2>/dev/null \
+      | awk '{print $NF}'
+  }
+  expect_new=$(hmac_with "$NEW_SECRET")
+  expect_prev=$(hmac_with "$INITIAL_SECRET")
+
+  matched_new=false
+  matched_prev=false
+  for tok in "${V1_TOKENS[@]}"; do
+    [ "$tok" = "$expect_new" ]  && matched_new=true
+    [ "$tok" = "$expect_prev" ] && matched_prev=true
+  done
+
+  if [ "$matched_new" = "true" ] && [ "$matched_prev" = "true" ]; then
+    pass
+  else
+    fail "token validation failed: matched_new=${matched_new} matched_prev=${matched_prev} (tokens: ${V1_TOKENS[*]}, expect_new=${expect_new}, expect_prev=${expect_prev})"
+  fi
+fi
+
+if [ -n "$WEBHOOK_ID" ] && [ "$WEBHOOK_ID" != "null" ]; then
+  api_delete "/api/v1/webhooks/${WEBHOOK_ID}" >/dev/null 2>&1 || true
+fi
+
+end_suite


### PR DESCRIPTION
## Dependency: blocked on artifact-keeper#1140

This PR is a **draft** because it asserts the webhooks v2 wire contract finalized in artifact-keeper#1140. Do NOT merge ahead of that backend PR; the new headers and 12-attempt retry schedule do not exist on `main` until #1140 lands. Once #1140 is merged and a `:1.2-dev` image is published, mark this PR ready for review.

## Summary

Closes the E8 sub-task of epic artifact-keeper#919 (Webhooks v2). The v2 contract emits new `X-ArtifactKeeper-{Delivery,Event,Event-Version,Signature,Retry-Attempt}` headers alongside the legacy `X-Webhook-*` set (legacy form removed in v1.3.0), signs over `<unix_secs>.<raw_body>`, supports a 24h secret rotation overlap with multi-value `v1=` tokens, runs 12 jittered retry attempts across ~65h with auto-disable on dead-letter, and pins per-webhook `event_schema_version` defaulting to `2026-04-01`.

This rewrites the webhook test suite to assert the new contract end-to-end against a backend running `WEBHOOKS_V2_PRODUCER_ENABLED=1`.

## Files

Modified:

- `tests/webhooks/test-webhook-hmac-signature.sh` -- drop the `EXPECT_FAILURE` workaround; assert real `X-ArtifactKeeper-Signature` matches `t=<int>,v1=<64-hex>` and recomputed HMAC equals the v1 token. Assert the legacy `X-Webhook-Signature: sha256=<hex>` is still emitted. Assert `X-ArtifactKeeper-Delivery` is a UUID, `X-ArtifactKeeper-Event` is non-empty, `X-ArtifactKeeper-Event-Version` is `2026-04-01`.
- `tests/webhooks/test-webhook-deadletter.sh` -- assert auto-disable shape (`is_enabled=false` AND `disabled_reason` non-null) on the webhook row after exhausted delivery; bump exhaustion budget to v2 default 12.
- `tests/webhooks/test-webhook-retry-recover.sh` -- cap observation at the first 3 retry attempts (`24-36s`, `48-72s`, `96-144s` with +/-20% jitter); assert `X-ArtifactKeeper-Retry-Attempt` header on retry deliveries. Smoke profile only; full 12-attempt schedule is exercised by the dead-letter test.
- `tests/webhooks/test-webhook-delivery.sh` -- drop `require_feature webhook_event_producer` gates (the producer is part of the v2 contract). Add header assertions on the actual receiver delivery.

New:

- `tests/webhooks/test-webhook-replay-window.sh` -- offline python3 verifier mirrors the docs sample. Accepts fresh deliveries; rejects with exit 2 when `|t - now| > window` even though the HMAC is valid; rejects with exit 3 on tampered body. Uses the offline-verifier approach because the live producer always signs `t=now` and we cannot inject a stale timestamp into the real backend path.
- `tests/webhooks/test-webhook-rotation-overlap.sh` -- rotates via `POST /api/v1/webhooks/<id>/rotate-secret`, decodes the response for the new `secret` and `previous_secret_expires_at`, captures a delivery during the overlap window, asserts two `v1=` tokens, and asserts BOTH validate against their respective secrets (current + previous).
- `tests/webhooks/test-webhook-event-versioning.sh` -- omitted version defaults to `2026-04-01`, explicit `2026-04-01` works the same, `9999-99-99` returns 400 with body mentioning `supported`.

## Test Plan

- [ ] After artifact-keeper#1140 merges and the `:1.2-dev` image is published, run the suite locally:
  ```bash
  cd /Users/khan/ak/artifact-keeper
  docker compose -f docker-compose.local-dev.yml up -d
  cd /tmp/<uuid>-ak-test
  ./scripts/run-suite.sh --suite webhooks
  ```
  Expected: green.
- [ ] On release-gate against a `1.2-rc` build, verify all eight `test-webhook-*.sh` scripts pass (or skip cleanly when SSRF allow-list blocks loopback URLs in the container; this is the existing graceful-skip path used by every other webhook test).
- [ ] No em-dashes, no emoji, no AI attribution.

## Notes

- All tests share `tests/lib/common.sh` and `tests/lib/mock-webhook-receiver.py`; no new harness introduced.
- Each test runs its own mock receiver locally on a unique port in `18765-18771`. Ports are configurable via `WEBHOOK_RECEIVER_PORT`.
- No helm changes were needed: the existing harness pattern runs the receiver on the test runner, so the in-cluster Service approach mentioned in the design doc is unnecessary.
- I left the `webhook_event_producer` entry in `_feature_min_version` (common.sh) alone; it is no longer referenced by webhook tests but other suites may rely on it as a compatibility marker.