### PR TITLE
test(security): document backend SSRF allowlist dependency for cache-poisoning + cache-stampede

### DIFF
--- a/tests/security/test-cache-poisoning.sh
+++ b/tests/security/test-cache-poisoning.sh
@@ -1,25 +1,52 @@
 #!/usr/bin/env bash
 # test-cache-poisoning.sh - T2-11: Proxy/remote repo cache poisoning prevention
 #
-# STUBBED: Mock-upstream fixture is incompatible with the backend's SSRF guard.
-# The current `start_mock_upstream` helper deploys mock-upstream.py inside the
-# runner pod and uses the runner pod IP (10.244.0.0/16) as MOCK_UPSTREAM_HOSTNAME.
-# The backend's `validate_outbound_url` correctly rejects RFC1918 IPs (the
-# block predates v1.1.9 and is unchanged by SSRF cherry-picks #881/#900).
+# STUBBED: blocked on a backend change.
 #
-# The fix is to deploy the mock as a Kubernetes Service in the test namespace
-# so the backend resolves a Service-DNS hostname rather than a private IP,
-# bypassing the IP blocklist while keeping the security behavior intact.
-# Tracked in artifact-keeper-test#122.
+# Why this is stubbed
+# -------------------
+# The fixture (tests/lib/mock-upstream.py, booted by start_mock_upstream in
+# tests/lib/common.sh) runs the mock inside the ARC runner pod and exposes
+# it on the pod IP. In our K8s cluster the pod CIDR is 10.244.0.0/16, which
+# is RFC1918. The backend's validate_outbound_url (backend/src/api/validation.rs)
+# rejects every RFC1918 address via Rust's Ipv4Addr::is_private(). The
+# release-gate workflow sets MOCK_UPSTREAM_HOSTNAME to the runner pod IP,
+# so POST /api/v1/repositories with that upstream_url returns:
 #
-# Until #122 lands, this test emits a clean per-test skip so release-gate
-# does not silent-success-fail. The pre-existing security validation is
-# still exercised by tests/security/test-ssrf-prevention.sh which asserts
-# the same blocklist behavior from the other direction.
+#   HTTP 400 "IP '10.244.0.x' is not allowed (private/internal network)"
+#
+# This is correct production behavior; what's missing is a test-only opt-out.
+#
+# Backend dependency
+# ------------------
+# Tracked as artifact-keeper#1224: add AK_SSRF_ALLOW_PRIVATE_CIDRS env var so
+# the test overlay can allowlist 10.244.0.0/16 for the test namespace. Once
+# that ships:
+#   1. helm/values-test.yaml sets backend.env.AK_SSRF_ALLOW_PRIVATE_CIDRS=10.244.0.0/16
+#   2. this file drops the skip and runs against ${MOCK_BASE_URL}
+#
+# Other approaches that were considered and rejected as out-of-scope for #122:
+#   - Service-DNS mock: deploy mock-upstream.py as a K8s Service. Validator
+#     passes (hostname, not an IP literal), but the fixture would need to
+#     pivot from "exec a Python process on the runner" to "deploy a pod that
+#     shares a state dir with the runner", which breaks the current
+#     filesystem-shared mock-state model.
+#   - NodePort + node IP: same DNS/fixture problem at a different layer.
+#
+# The cross-cutting concern (this fixture, the cache-stampede twin, and any
+# future test that needs the backend to dial a runner-local upstream) is
+# what justifies a single env var on the backend rather than a per-test
+# workaround.
+#
+# Coverage gap mitigation
+# -----------------------
+# tests/security/test-ssrf-prevention.sh continues to assert the blocklist
+# from the other direction, so the security property "backend rejects
+# private-CIDR upstreams" stays under test even while this suite is dark.
 
 source "$(dirname "$0")/../lib/common.sh"
 
 begin_suite "cache-poisoning"
-begin_test "Cache-poisoning suite skipped pending fixture refactor"
-skip "Mock-upstream fixture refactor blocked on artifact-keeper-test#122 (Service-DNS-based mock to bypass SSRF guard for cluster-internal fixtures)"
+begin_test "Cache-poisoning suite skipped pending backend SSRF allowlist"
+skip "Blocked on artifact-keeper#1224 (backend AK_SSRF_ALLOW_PRIVATE_CIDRS env var). Tracking: artifact-keeper-test#122."
 end_suite

--- a/tests/security/test-cache-stampede.sh
+++ b/tests/security/test-cache-stampede.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 # test-cache-stampede.sh - T2-12: Cache stampede / thundering-herd prevention
 #
-# STUBBED: Same mock-upstream fixture issue as test-cache-poisoning.sh.
-# Mock deploys at runner pod IP (RFC1918), backend's SSRF guard correctly
-# rejects. Tracked in artifact-keeper-test#122 (Service-DNS-based mock).
+# STUBBED: same backend dependency as test-cache-poisoning.sh.
 #
-# Until #122 lands, this test emits a clean per-test skip so release-gate
-# does not silent-success-fail.
+# The mock-upstream fixture exposes itself on the ARC runner pod IP
+# (10.244.0.0/16, RFC1918). The backend's validate_outbound_url rejects every
+# RFC1918 address via Ipv4Addr::is_private(), so POST /api/v1/repositories
+# with that upstream_url returns HTTP 400.
+#
+# Backend dependency: artifact-keeper#1224 (add AK_SSRF_ALLOW_PRIVATE_CIDRS
+# env var so the test overlay can allowlist 10.244.0.0/16). Once that ships,
+# helm/values-test.yaml sets the env var and this file drops the skip.
+#
+# Full rationale and rejected alternatives: see test-cache-poisoning.sh.
 
 source "$(dirname "$0")/../lib/common.sh"
 
 begin_suite "cache-stampede"
-begin_test "Cache-stampede suite skipped pending fixture refactor"
-skip "Mock-upstream fixture refactor blocked on artifact-keeper-test#122 (Service-DNS-based mock to bypass SSRF guard for cluster-internal fixtures)"
+begin_test "Cache-stampede suite skipped pending backend SSRF allowlist"
+skip "Blocked on artifact-keeper#1224 (backend AK_SSRF_ALLOW_PRIVATE_CIDRS env var). Tracking: artifact-keeper-test#122."
 end_suite


### PR DESCRIPTION
## Summary

Issue #122 asked us to unstub `tests/security/test-cache-poisoning.sh` and `tests/security/test-cache-stampede.sh`, which were stubbed in #126 because the backend's `validate_outbound_url` rejects the runner pod's RFC1918 IP (`10.244.0.0/16`) when the mock-upstream URL is POSTed as `upstream_url`.

After reading `backend/src/api/validation.rs`, the recommended fix (env-var allowlist for private CIDRs) turns out to require a backend change: `is_blocked_ipv4` calls Rust's built-in `Ipv4Addr::is_private()` and has no override knob. The only existing env var is `BLOCK_CGNAT_OUTBOUND`, which goes the opposite direction.

Time-boxing #122 to test-repo work, this PR:

- Files the backend dependency as **artifact-keeper#1224** (add `AK_SSRF_ALLOW_PRIVATE_CIDRS` env var). Once that ships, `helm/values-test.yaml` sets the env var to `10.244.0.0/16` and these suites drop their skip in a follow-up PR.
- Rewrites the stub comments in both test files so the reason references #1224 and explains why the cluster-DNS / NodePort alternatives were rejected as out-of-scope (they would require reworking the filesystem-shared mock-state fixture, which is larger than the one-line backend env var).
- Documents that `test-ssrf-prevention.sh` continues to assert the blocklist from the other direction, so the security property isn't fully dark on the gate.

No test logic changes. Suites still emit a clean per-test `skip`, so `RELEASE_GATE=1` continues to fail fast (no silent-success regressions).

## Backend dependency

artifact-keeper#1224 must land before the next PR in this thread can flip the skips off. That follow-up PR would:

1. Set `backend.env.AK_SSRF_ALLOW_PRIVATE_CIDRS=10.244.0.0/16` in `helm/values-test.yaml`.
2. Replace the `skip` calls with the real test bodies (already implemented in #84, just gated).
3. Verify the release-gate `security-tests` job exercises both suites end-to-end.

## Test plan

- [x] `bash -n` syntax check on both modified scripts
- [x] `shellcheck -e SC1091` clean on both modified scripts
- [x] No em-dashes, no emoji, no AI attribution in commit messages or PR body
- [ ] Release-gate `security-tests` job still passes (the stub behavior is unchanged, this is a comment-only diff to test logic; included for completeness)

Refs: #122, #126, artifact-keeper#1224