### PR TITLE
test(stress): upload per-request HTTP-code logs as workflow artifacts

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -777,6 +777,12 @@ jobs:
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
       ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
+      # Per-request HTTP-code logs end up here. The Upload stress-test logs
+      # step below ships this directory as a workflow artifact so a failed
+      # stress run can be debugged endpoint-by-endpoint instead of from
+      # aggregate error counts alone (artifact-keeper-test#138 /
+      # artifact-keeper#1088).
+      STRESS_LOG_DIR: /tmp/stress-logs
       # RELEASE_GATE=1 turns common.sh's skip_suite() into a hard fail.
       # A silently-skipped test in release-gate context is exactly the
       # silent-success class (#870/#871/#888) the gate exists to catch.
@@ -789,8 +795,49 @@ jobs:
       - name: Run stress tests
         run: |
           mkdir -p "$JUNIT_OUTPUT_DIR"
+          mkdir -p "$STRESS_LOG_DIR"
           chmod +x scripts/run-suite.sh
           ./scripts/run-suite.sh --suite stress --run-id "${RUN_ID}"
+
+      - name: Summarize per-request status codes
+        if: always()
+        run: |
+          if [ ! -d "$STRESS_LOG_DIR" ] || [ -z "$(ls -A "$STRESS_LOG_DIR" 2>/dev/null)" ]; then
+            echo "No stress logs were emitted at ${STRESS_LOG_DIR}"
+            exit 0
+          fi
+          echo "## Stress-test per-request status codes" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Per-request rows logged to artifact \`stress-request-logs\` at \`${STRESS_LOG_DIR}\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "Row format: \`<epoch_ms> <suite> <method> <endpoint> <http_code> <elapsed_ms>\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Suite | Total | 2xx | 3xx | 4xx | 5xx | Timeouts (000) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|------:|----:|----:|----:|----:|---------------:|" >> "$GITHUB_STEP_SUMMARY"
+          for log in "$STRESS_LOG_DIR"/*.log; do
+            [ -f "$log" ] || continue
+            suite=$(basename "$log" .log)
+            total=$(wc -l < "$log" | tr -d ' ')
+            s2=$(awk '$5 ~ /^2[0-9][0-9]$/ {c++} END {print c+0}' "$log")
+            s3=$(awk '$5 ~ /^3[0-9][0-9]$/ {c++} END {print c+0}' "$log")
+            s4=$(awk '$5 ~ /^4[0-9][0-9]$/ {c++} END {print c+0}' "$log")
+            s5=$(awk '$5 ~ /^5[0-9][0-9]$/ {c++} END {print c+0}' "$log")
+            s0=$(awk '$5 == "000" {c++} END {print c+0}' "$log")
+            echo "| ${suite} | ${total} | ${s2} | ${s3} | ${s4} | ${s5} | ${s0} |" >> "$GITHUB_STEP_SUMMARY"
+          done
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          # Echo a short per-suite breakdown to the runner log too, so an
+          # operator can scan the job page without first downloading the
+          # artifact. Cap at the top 10 non-2xx endpoints to keep the log
+          # readable.
+          echo "Top non-2xx endpoints per suite:"
+          for log in "$STRESS_LOG_DIR"/*.log; do
+            [ -f "$log" ] || continue
+            suite=$(basename "$log" .log)
+            echo "  ${suite}:"
+            awk '$5 !~ /^2[0-9][0-9]$/ {print $5, $3, $4}' "$log" \
+              | sort | uniq -c | sort -rn | head -n 10 \
+              | sed 's/^/    /'
+          done
 
       - name: Upload test results
         if: always()
@@ -798,6 +845,20 @@ jobs:
         with:
           name: junit-stress
           path: /tmp/test-results/*.xml
+          if-no-files-found: ignore
+
+      - name: Upload stress-test logs
+        # Per-request HTTP-code rows from the stress-test workers. Captured
+        # before namespace teardown so a 50%-error run can be debugged
+        # endpoint-by-endpoint (which path returned what code, how often)
+        # instead of from aggregate counters alone. Investigating
+        # artifact-keeper#1088 (POST /repositories DB contention under
+        # load) would have been faster with this artifact in hand.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stress-request-logs
+          path: /tmp/stress-logs/
           if-no-files-found: ignore
 
   # -------------------------------------------------------------------

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -855,7 +855,7 @@ jobs:
         # artifact-keeper#1088 (POST /repositories DB contention under
         # load) would have been faster with this artifact in hand.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: stress-request-logs
           path: /tmp/stress-logs/

--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -21,7 +21,48 @@ export RUN_ID="${RUN_ID:-local-$(date +%s)}"
 export TEST_TIMEOUT="${TEST_TIMEOUT:-120}"
 export JUNIT_OUTPUT_DIR="${JUNIT_OUTPUT_DIR:-/tmp/test-results}"
 
+# STRESS_LOG_DIR is the deterministic path where stress-test scripts append
+# per-request HTTP status code rows. The release-gate workflow uploads this
+# directory as an artifact so a failed run can be debugged endpoint-by-endpoint
+# (see artifact-keeper-test#138, artifact-keeper#1088). Each row is space-
+# separated: <epoch_ms> <suite> <method> <endpoint> <http_code> <elapsed_ms>.
+export STRESS_LOG_DIR="${STRESS_LOG_DIR:-/tmp/stress-logs}"
+
 mkdir -p "$JUNIT_OUTPUT_DIR"
+mkdir -p "$STRESS_LOG_DIR"
+
+# log_request - Append one per-request row to the stress log for this suite.
+#
+# Usage:
+#   log_request <method> <endpoint> <http_code> <elapsed_ms>
+#
+# The suite name comes from $_SUITE_NAME (set by begin_suite). If begin_suite
+# has not been called yet (e.g. logging from a worker that runs before the
+# suite is named) the suite column falls back to "unknown".
+log_request() {
+  local method="${1:-?}"
+  local endpoint="${2:-?}"
+  local code="${3:-000}"
+  local elapsed_ms="${4:-0}"
+  local suite="${_SUITE_NAME:-unknown}"
+  local ts_ms
+  ts_ms=$(date +%s%3N 2>/dev/null || true)
+  # macOS / BSD date doesn't understand %3N and returns "<seconds>N". Fall
+  # back to seconds-with-zero-millis in that case so the log row stays a
+  # pure integer in the timestamp column. Linux ARC runners (the actual
+  # release-gate environment) emit the millisecond form natively.
+  if [ -z "$ts_ms" ] || ! [[ "$ts_ms" =~ ^[0-9]+$ ]]; then
+    ts_ms="$(date +%s)000"
+  fi
+  # Strip the BASE_URL prefix so the log is portable across runs.
+  endpoint="${endpoint#"${BASE_URL}"}"
+  # Replace any whitespace in the endpoint with %20 so the row stays single-
+  # field-per-column when grep/awk-ed later.
+  endpoint="${endpoint// /%20}"
+  printf '%s %s %s %s %s %s\n' \
+    "$ts_ms" "$suite" "$method" "$endpoint" "$code" "$elapsed_ms" \
+    >> "${STRESS_LOG_DIR}/${suite}.log"
+}
 
 # ---------------------------------------------------------------------------
 # Internal state

--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -55,7 +55,14 @@ log_request() {
     ts_ms="$(date +%s)000"
   fi
   # Strip the BASE_URL prefix so the log is portable across runs.
-  endpoint="${endpoint#"${BASE_URL}"}"
+  # Defensive: BASE_URL is set at top of file but ${VAR:-} guards against
+  # any caller that `unset BASE_URL` before sourcing this helper.
+  endpoint="${endpoint#"${BASE_URL:-}"}"
+  # Strip query strings before logging: defense against future callers that
+  # accidentally log URLs containing `?token=...`, `?api_key=...`, or signed
+  # share-link / pre-signed-S3 URLs. The artifact is retained 90 days; keeping
+  # secrets out by construction is cheaper than scrubbing later.
+  endpoint="${endpoint%%\?*}"
   # Replace any whitespace in the endpoint with %20 so the row stays single-
   # field-per-column when grep/awk-ed later.
   endpoint="${endpoint// /%20}"

--- a/tests/stress/test-auth-saturation.sh
+++ b/tests/stress/test-auth-saturation.sh
@@ -39,6 +39,7 @@ fire_auth_wave() {
       end_ms=$(date +%s%3N 2>/dev/null || date +%s)
       elapsed=$(( end_ms - start_ms ))
       echo "${http_code} ${elapsed}" > "${wave_dir}/${i}.txt"
+      log_request "POST" "/api/v1/auth/login?wave=${count}" "${http_code}" "${elapsed}"
     ) &
   done
   wait

--- a/tests/stress/test-concurrent-api-clients.sh
+++ b/tests/stress/test-concurrent-api-clients.sh
@@ -30,16 +30,23 @@ run_client() {
 
   local result="fail"
   local step="start"
+  local start_ms end_ms http_code
 
   # Step 1: authenticate
   step="auth"
   local token=""
   for _retry in 1 2 3; do
+    start_ms=$(date +%s%3N 2>/dev/null || date +%s)
     if resp=$(curl -sf --max-time 10 -X POST "${BASE_URL}/api/v1/auth/login" \
         -H "Content-Type: application/json" \
         -d "{\"username\":\"${ADMIN_USER}\",\"password\":\"${ADMIN_PASS}\"}" 2>/dev/null); then
+      end_ms=$(date +%s%3N 2>/dev/null || date +%s)
+      log_request "POST" "/api/v1/auth/login" "200" "$(( end_ms - start_ms ))"
       token=$(echo "$resp" | jq -r '.access_token // .token // empty') || true
       [ -n "$token" ] && break
+    else
+      end_ms=$(date +%s%3N 2>/dev/null || date +%s)
+      log_request "POST" "/api/v1/auth/login" "000" "$(( end_ms - start_ms ))"
     fi
     sleep 1
   done
@@ -48,31 +55,45 @@ run_client() {
   # Step 2: create repo
   step="create-repo"
   local repo_key="stress-client-${client_id}-${RUN_ID}"
-  if ! curl -sf --max-time 10 -X POST \
+  start_ms=$(date +%s%3N 2>/dev/null || date +%s)
+  http_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -X POST \
       -H "Authorization: Bearer ${token}" \
       -H "Content-Type: application/json" \
       -d "{\"key\":\"${repo_key}\",\"name\":\"${repo_key}\",\"format\":\"generic\",\"repo_type\":\"local\",\"is_public\":true}" \
-      "${BASE_URL}/api/v1/repositories" > /dev/null 2>&1; then
+      "${BASE_URL}/api/v1/repositories" 2>/dev/null) || http_code="000"
+  end_ms=$(date +%s%3N 2>/dev/null || date +%s)
+  log_request "POST" "/api/v1/repositories" "${http_code}" "$(( end_ms - start_ms ))"
+  if [ "$http_code" -lt 200 ] 2>/dev/null || [ "$http_code" -ge 300 ] 2>/dev/null; then
     echo "${step}" > "${client_dir}/failed"; return
   fi
 
   # Step 3: upload artifact
   step="upload"
+  local upload_path="/api/v1/repositories/${repo_key}/artifacts/test/payload.bin"
   echo "client-${client_id}-payload-${RUN_ID}" > "${client_dir}/payload.bin"
-  if ! curl -sf --max-time 15 -X PUT \
+  start_ms=$(date +%s%3N 2>/dev/null || date +%s)
+  http_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 -X PUT \
       -H "Authorization: Bearer ${token}" \
       -H "Content-Type: application/octet-stream" \
       --data-binary "@${client_dir}/payload.bin" \
-      "${BASE_URL}/api/v1/repositories/${repo_key}/artifacts/test/payload.bin" > /dev/null 2>&1; then
+      "${BASE_URL}${upload_path}" 2>/dev/null) || http_code="000"
+  end_ms=$(date +%s%3N 2>/dev/null || date +%s)
+  log_request "PUT" "${upload_path}" "${http_code}" "$(( end_ms - start_ms ))"
+  if [ "$http_code" -lt 200 ] 2>/dev/null || [ "$http_code" -ge 300 ] 2>/dev/null; then
     echo "${step}" > "${client_dir}/failed"; return
   fi
 
   # Step 4: read back
   step="read"
   sleep 1
-  if ! curl -sf --max-time 10 \
+  local list_path="/api/v1/repositories/${repo_key}/artifacts"
+  start_ms=$(date +%s%3N 2>/dev/null || date +%s)
+  http_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
       -H "Authorization: Bearer ${token}" \
-      "${BASE_URL}/api/v1/repositories/${repo_key}/artifacts" > /dev/null 2>&1; then
+      "${BASE_URL}${list_path}" 2>/dev/null) || http_code="000"
+  end_ms=$(date +%s%3N 2>/dev/null || date +%s)
+  log_request "GET" "${list_path}" "${http_code}" "$(( end_ms - start_ms ))"
+  if [ "$http_code" -lt 200 ] 2>/dev/null || [ "$http_code" -ge 300 ] 2>/dev/null; then
     echo "${step}" > "${client_dir}/failed"; return
   fi
 

--- a/tests/stress/test-concurrent-uploads.sh
+++ b/tests/stress/test-concurrent-uploads.sh
@@ -52,13 +52,17 @@ mkdir -p "${WORK_DIR}/results"
 
 for i in $(seq 1 "$CONCURRENCY"); do
   (
+    endpoint="/api/v1/repositories/${REPO_KEY}/artifacts/stress/file-${i}.bin"
+    start_ms=$(date +%s%3N 2>/dev/null || echo "$(date +%s)000")
     status=$(curl -s -o /dev/null -w '%{http_code}' \
       -X PUT \
       -H "$(auth_header)" \
       -H "Content-Type: application/octet-stream" \
       --data-binary "@${WORK_DIR}/files/file-${i}.bin" \
-      "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/stress/file-${i}.bin") || true
+      "${BASE_URL}${endpoint}") || true
+    end_ms=$(date +%s%3N 2>/dev/null || echo "$(date +%s)000")
     echo "$status" > "${WORK_DIR}/results/upload-${i}.status"
+    log_request "PUT" "${endpoint}" "${status:-000}" "$(( end_ms - start_ms ))"
   ) &
 done
 
@@ -105,9 +109,13 @@ for i in $(seq 1 "$CONCURRENCY"); do
   if [ -f "$status_file" ]; then
     code=$(cat "$status_file")
     if [ "$code" -ge 200 ] 2>/dev/null && [ "$code" -lt 300 ] 2>/dev/null; then
+      dl_endpoint="/api/v1/repositories/${REPO_KEY}/download/stress/file-${i}.bin"
+      dl_start_ms=$(date +%s%3N 2>/dev/null || echo "$(date +%s)000")
       dl_status=$(curl -s -o /dev/null -w '%{http_code}' \
         -H "$(auth_header)" \
-        "${BASE_URL}/api/v1/repositories/${REPO_KEY}/download/stress/file-${i}.bin") || true
+        "${BASE_URL}${dl_endpoint}") || true
+      dl_end_ms=$(date +%s%3N 2>/dev/null || echo "$(date +%s)000")
+      log_request "GET" "${dl_endpoint}" "${dl_status:-000}" "$(( dl_end_ms - dl_start_ms ))"
       if [ "$dl_status" = "200" ]; then
         download_ok=$((download_ok + 1))
       else

--- a/tests/stress/test-sustained-load.sh
+++ b/tests/stress/test-sustained-load.sh
@@ -47,39 +47,55 @@ run_worker() {
     counter=$(( counter + 1 ))
     local op=$(( counter % 4 ))
     local start_s=$(date +%s)
+    local start_ms
+    start_ms=$(date +%s%3N 2>/dev/null || echo "${start_s}000")
     local http_code="000"
+    local method="GET"
+    local endpoint=""
 
     case $op in
       0) # auth
+        method="POST"
+        endpoint="/api/v1/auth/login"
         http_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
-          -X POST "${BASE_URL}/api/v1/auth/login" \
+          -X POST "${BASE_URL}${endpoint}" \
           -H "Content-Type: application/json" \
           -d "{\"username\":\"${ADMIN_USER}\",\"password\":\"${ADMIN_PASS}\"}" 2>/dev/null) || http_code="000"
         ;;
       1) # upload
+        method="PUT"
+        endpoint="/api/v1/repositories/${REPO_KEY}/artifacts/sustained/w${worker_id}-${counter}.bin"
         echo "sustained-${worker_id}-${counter}-${RUN_ID}" > "${WORK_DIR}/w${worker_id}-${counter}.bin"
         http_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
           -X PUT -H "Authorization: Bearer ${ADMIN_TOKEN}" \
           -H "Content-Type: application/octet-stream" \
           --data-binary "@${WORK_DIR}/w${worker_id}-${counter}.bin" \
-          "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/sustained/w${worker_id}-${counter}.bin" 2>/dev/null) || http_code="000"
+          "${BASE_URL}${endpoint}" 2>/dev/null) || http_code="000"
         rm -f "${WORK_DIR}/w${worker_id}-${counter}.bin"
         ;;
       2) # list
+        method="GET"
+        endpoint="/api/v1/repositories/${REPO_KEY}/artifacts"
         http_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
           -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-          "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts" 2>/dev/null) || http_code="000"
+          "${BASE_URL}${endpoint}" 2>/dev/null) || http_code="000"
         ;;
       3) # download
+        method="GET"
+        endpoint="/api/v1/repositories/${REPO_KEY}/artifacts/seed/download-target.bin"
         http_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
           -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-          "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/seed/download-target.bin" 2>/dev/null) || http_code="000"
+          "${BASE_URL}${endpoint}" 2>/dev/null) || http_code="000"
         ;;
     esac
 
     local end_s=$(date +%s)
+    local end_ms
+    end_ms=$(date +%s%3N 2>/dev/null || echo "${end_s}000")
     local elapsed=$(( end_s - start_s ))
+    local elapsed_ms=$(( end_ms - start_ms ))
     echo "${end_s} ${http_code} ${elapsed}" >> "$log_file"
+    log_request "${method}" "${endpoint}" "${http_code}" "${elapsed_ms}"
   done
 }
 

--- a/tests/stress/test-throughput.sh
+++ b/tests/stress/test-throughput.sh
@@ -53,22 +53,30 @@ upload_failures=0
 for i in $(seq 1 "$ITERATIONS"); do
   artifact_path="/api/v1/repositories/${REPO_KEY}/artifacts/bench/iteration-${i}/payload.bin"
 
-  # Use curl's write-out to get total transfer time in seconds (with decimals)
-  timing=$(curl -s -o /dev/null -w '%{time_total}' \
+  # Use curl's write-out to get total transfer time AND status code so the
+  # stress log records which iterations actually succeeded vs which silently
+  # returned a non-2xx but still produced a timing value.
+  curl_out=$(curl -s -o /dev/null -w '%{http_code} %{time_total}' \
     -X PUT \
     -H "$(auth_header)" \
     -H "Content-Type: application/octet-stream" \
     --data-binary "@${WORK_DIR}/payload.bin" \
-    "${BASE_URL}${artifact_path}") || true
+    "${BASE_URL}${artifact_path}") || curl_out="000 0.000000"
+  http_code="${curl_out%% *}"
+  timing="${curl_out##* }"
+
+  # elapsed_ms for the log = round(timing * 1000)
+  elapsed_ms=$(echo "$timing" | awk '{printf "%d", $1 * 1000}')
+  log_request "PUT" "${artifact_path}" "${http_code:-000}" "${elapsed_ms:-0}"
 
   if [ -n "$timing" ] && [ "$timing" != "0.000000" ]; then
     # Use awk for floating point arithmetic
     throughput=$(echo "$FILE_SIZE_MB $timing" | awk '{printf "%.2f", $1 / $2}')
-    echo "  upload ${i}: ${timing}s (${throughput} MB/s)"
+    echo "  upload ${i}: ${timing}s (${throughput} MB/s) [HTTP ${http_code}]"
     upload_total_time=$(echo "$upload_total_time $timing" | awk '{printf "%.6f", $1 + $2}')
   else
     upload_failures=$((upload_failures + 1))
-    echo "  upload ${i}: failed"
+    echo "  upload ${i}: failed [HTTP ${http_code}]"
   fi
 done
 
@@ -99,17 +107,22 @@ download_failures=0
 for i in $(seq 1 "$ITERATIONS"); do
   download_path="/api/v1/repositories/${REPO_KEY}/download/bench/iteration-${i}/payload.bin"
 
-  timing=$(curl -s -o /dev/null -w '%{time_total}' \
+  curl_out=$(curl -s -o /dev/null -w '%{http_code} %{time_total}' \
     -H "$(auth_header)" \
-    "${BASE_URL}${download_path}") || true
+    "${BASE_URL}${download_path}") || curl_out="000 0.000000"
+  http_code="${curl_out%% *}"
+  timing="${curl_out##* }"
+
+  elapsed_ms=$(echo "$timing" | awk '{printf "%d", $1 * 1000}')
+  log_request "GET" "${download_path}" "${http_code:-000}" "${elapsed_ms:-0}"
 
   if [ -n "$timing" ] && [ "$timing" != "0.000000" ]; then
     throughput=$(echo "$FILE_SIZE_MB $timing" | awk '{printf "%.2f", $1 / $2}')
-    echo "  download ${i}: ${timing}s (${throughput} MB/s)"
+    echo "  download ${i}: ${timing}s (${throughput} MB/s) [HTTP ${http_code}]"
     download_total_time=$(echo "$download_total_time $timing" | awk '{printf "%.6f", $1 + $2}')
   else
     download_failures=$((download_failures + 1))
-    echo "  download ${i}: failed"
+    echo "  download ${i}: failed [HTTP ${http_code}]"
   fi
 done
 


### PR DESCRIPTION
## Why

The release-gate stress-tests workers capture per-request status codes during the run, but those logs are ephemeral. The namespace tears down at the end of the job and the data is lost. On a failed run the operator can see "58% error rate" but not which endpoints failed or what HTTP status they returned.

Investigation of artifact-keeper#1088 (POST /repositories DB contention under sustained load) would have moved faster with a per-endpoint breakdown in hand instead of an aggregate error counter.

## What's logged now

`tests/lib/common.sh` exposes a new `STRESS_LOG_DIR` (default `/tmp/stress-logs`) and a `log_request` helper. Each row in `${STRESS_LOG_DIR}/<suite>.log` is space-separated:

```
<epoch_ms> <suite> <method> <endpoint> <http_code> <elapsed_ms>
```

Endpoints have `BASE_URL` stripped so the rows are portable across runs. Timestamp falls back to seconds-with-zero-millis on macOS (BSD `date` does not support `%3N`); Linux ARC runners (the actual release-gate environment) emit real millisecond precision.

All five stress scripts now call `log_request` after each `curl`:

- `test-concurrent-uploads.sh` -- per-upload PUT + per-download GET status codes.
- `test-sustained-load.sh` -- per-operation status code from each worker (auth / upload / list / download mix).
- `test-auth-saturation.sh` -- per-request status code at each wave (5 / 10 / 20 / 40 concurrent).
- `test-throughput.sh` -- per-iteration HTTP code on both upload and download legs (previously only timing was captured, so a non-2xx that still produced a timing was invisible).
- `test-concurrent-api-clients.sh` -- per-step status code for the auth -> create-repo -> upload -> list sequence. This is the direct fix for the visibility gap that hurt the artifact-keeper#1088 investigation: the POST /repositories step now logs its real HTTP code on every client, every wave.

## Workflow plumbing

`.github/workflows/release-gate.yml` `stress-tests` job:

- Sets `STRESS_LOG_DIR=/tmp/stress-logs`.
- Adds a `Summarize per-request status codes` step that builds a per-suite 2xx / 3xx / 4xx / 5xx / 000 table in the workflow summary and prints the top non-2xx endpoints to the runner log, so an operator can scan the job page without first downloading the artifact.
- Adds an `Upload stress-test logs` step using `actions/upload-artifact@v4` (matching the version tag the rest of this workflow uses) with artifact name `stress-request-logs`. Captured before namespace teardown so the data survives the post-job cleanup.

## Where to find it on a failed run

On a stress-tests job page:

1. Scroll to the `Artifacts` section -- new artifact `stress-request-logs`.
2. Inside is one `.log` file per stress suite. Each file is grep / awk friendly.
3. The job page itself also has the summary table and the top non-2xx endpoints per suite, so the most common debug case ("which endpoint went 5xx most often") does not require an artifact download at all.

## Test plan

- [x] `bash -n` clean on all modified scripts.
- [x] `shellcheck` clean on all newly-added lines (pre-existing SC1091 / SC2012 / SC2155 / SC2034 / SC2162 in unchanged code, no new warnings introduced by this PR).
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` clean on the updated workflow.
- [x] Local smoke of `log_request` produces the documented row format including the URL-encoded space case.
- [ ] Next release-gate run on a v1.1.x or v1.2.x backend produces the `stress-request-logs` artifact.

Refs #138, artifact-keeper#1088.