### PR TITLE
ci(release-gate): serialize platform-tests after auth-tests (#137)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -681,9 +681,20 @@ jobs:
 
   # -------------------------------------------------------------------
   # Platform tests (signing, SBOM, curation, labels, audit, backup)
+  #
+  # Serialized after auth-tests to avoid cross-suite admin-JWT
+  # contamination. test-admin-password-recovery.sh changes the admin
+  # password, which calls the backend's change_password handler
+  # (backend/src/api/handlers/users.rs) and triggers
+  # invalidate_user_tokens(admin_id). That writes the admin's UUID
+  # into the global CREDENTIAL_INVALIDATIONS map in
+  # backend/src/services/auth_service.rs, so any auth-tests step
+  # running in parallel that uses the admin JWT starts getting 401s
+  # mid-suite once its cached token validation flips to "rejected".
+  # See #137.
   # -------------------------------------------------------------------
   platform-tests:
-    needs: deploy
+    needs: [deploy, auth-tests]
     if: inputs.test_suite == 'all' || inputs.test_suite == 'platform'
     runs-on: ak-e2e-runners
     env:


### PR DESCRIPTION
## Summary

Adds `auth-tests` to the `platform-tests` job's `needs:` so the platform suite can only start after `auth-tests` has finished. Closes the cross-suite admin-JWT contamination window described in #137.

## Root cause

`tests/platform/test-admin-password-recovery.sh` changes the admin password mid-suite. That call lands in the backend's `change_password` handler (`backend/src/api/handlers/users.rs`), which calls `invalidate_user_tokens(admin_id)`. `invalidate_user_tokens` writes the admin UUID into the global `CREDENTIAL_INVALIDATIONS` map in `backend/src/services/auth_service.rs`.

When `platform-tests` and `auth-tests` run concurrently in the release-gate workflow (both currently just `needs: deploy`), any auth-tests step that holds an admin JWT starts getting `401 Unauthorized` mid-run as soon as the platform suite hits the password change. The cached token validation flips to "rejected" by the contaminated invalidation map. It looks like a flaky auth suite, but it is a cross-suite race.

## Fix

Add `auth-tests` to `platform-tests` `needs:`:

```yaml
platform-tests:
  needs: [deploy, auth-tests]
```

`deploy` stays in the list because `platform-tests` reads `needs.deploy.outputs.backend_url`. No other job is reordered, and no other suite is touched. PR #144 (stress-tests log artifacts) touches a different job and should not conflict.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-gate.yml'))"` -> valid
- `actionlint` warnings are all pre-existing (custom `ak-e2e-runners` runner label, shellcheck style notes in other jobs); none introduced by this change.
- Diff is 12 insertions / 1 deletion in a single job.

## Test plan

- [ ] Trigger the release-gate workflow on this branch and confirm `platform-tests` does not start until `auth-tests` reports success.
- [ ] Confirm `auth-tests` no longer shows mid-suite 401s caused by admin-password rotation.
- [ ] Confirm overall release-gate runtime is not significantly worse (platform-tests now waits on auth-tests, but they previously raced and produced flaky failures that re-ran).

Refs #137.