### PR TITLE
chore(ci): SHA-pin all GitHub Actions in workflows (#104)

### DIFF
--- a/.github/workflows/format-tests.yml
+++ b/.github/workflows/format-tests.yml
@@ -53,7 +53,7 @@ jobs:
       # Local-dev runs don't set this and keep graceful skip behavior.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run ${{ matrix.batch.name }} tests
         if: inputs.batch == 'all' || inputs.batch == matrix.batch.name
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-formats-${{ matrix.batch.name }}
           path: /tmp/test-results/*.xml

--- a/.github/workflows/mesh-tests.yml
+++ b/.github/workflows/mesh-tests.yml
@@ -25,7 +25,7 @@ jobs:
       RUN_ID: ${{ inputs.run_id }}
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Deploy mesh topology (4 instances)
         id: deploy
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-mesh
           path: /tmp/test-results/*.xml

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -88,15 +88,15 @@ jobs:
     runs-on: ak-e2e-runners
     timeout-minutes: 12
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Run clean-install smoke test
         env:
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload smoke diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: clean-install-smoke-logs
           path: /tmp/test-logs/
@@ -148,15 +148,15 @@ jobs:
       namespace: ${{ steps.setup.outputs.namespace }}
       backend_url: ${{ steps.deploy.outputs.backend_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Generate run ID
         id: setup
@@ -245,7 +245,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -325,7 +325,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-formats-${{ matrix.batch.name }}
           path: /tmp/test-results/*.xml
@@ -376,7 +376,7 @@ jobs:
       PROXY_QUEUE_TIMEOUT_SECS: '5'
       STAMPEDE_UPSTREAM_DELAY_MS: '2000'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -420,7 +420,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-security
           # Directory upload (not *.xml glob) so per-test diagnostic
@@ -447,7 +447,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -459,7 +459,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-compatibility
           path: /tmp/test-results/*.xml
@@ -482,7 +482,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -494,7 +494,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-repos
           path: /tmp/test-results/*.xml
@@ -517,7 +517,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -529,7 +529,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-promotion
           path: /tmp/test-results/*.xml
@@ -552,7 +552,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -564,7 +564,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-rbac
           path: /tmp/test-results/*.xml
@@ -587,7 +587,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -599,7 +599,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-lifecycle
           path: /tmp/test-results/*.xml
@@ -626,7 +626,7 @@ jobs:
       # (WEBHOOK_RETRY_TIMEOUT) so the wrapping timeout must exceed that.
       TEST_TIMEOUT: '300'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -638,7 +638,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-webhooks
           path: /tmp/test-results/*.xml
@@ -661,7 +661,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -673,7 +673,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-search
           path: /tmp/test-results/*.xml
@@ -696,7 +696,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -708,7 +708,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-platform
           path: /tmp/test-results/*.xml
@@ -731,7 +731,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -743,7 +743,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-auth
           path: /tmp/test-results/*.xml
@@ -782,7 +782,7 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
@@ -794,7 +794,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-stress
           path: /tmp/test-results/*.xml
@@ -827,12 +827,12 @@ jobs:
       NAMESPACE: ${{ needs.deploy.outputs.namespace }}
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Run ${{ matrix.category }} resilience tests
         continue-on-error: true
@@ -854,7 +854,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-resilience-${{ matrix.category }}
           path: /tmp/test-results/*.xml
@@ -879,15 +879,15 @@ jobs:
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Deploy mesh topology
         id: mesh-deploy
@@ -944,7 +944,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-mesh
           path: /tmp/test-results/*.xml
@@ -959,7 +959,7 @@ jobs:
     runs-on: ak-e2e-runners
     steps:
       - name: Download all test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: junit-*
           path: /tmp/all-results
@@ -1002,7 +1002,7 @@ jobs:
 
       - name: Upload combined results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-gate-results
           path: /tmp/all-results/
@@ -1054,15 +1054,15 @@ jobs:
     if: always() && inputs.skip_teardown != true
     runs-on: ak-e2e-runners
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Teardown test namespace
         env:
@@ -1073,7 +1073,7 @@ jobs:
 
       - name: Upload pod logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pod-logs
           path: /tmp/test-logs/

--- a/.github/workflows/resilience-tests.yml
+++ b/.github/workflows/resilience-tests.yml
@@ -30,7 +30,7 @@ jobs:
       NAMESPACE: ${{ inputs.namespace }}
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run ${{ matrix.category }} resilience tests
         if: inputs.category == 'all' || inputs.category == matrix.category
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-resilience-${{ matrix.category }}
           path: /tmp/test-results/*.xml

--- a/.github/workflows/smoke-self-test.yml
+++ b/.github/workflows/smoke-self-test.yml
@@ -54,13 +54,13 @@ jobs:
     runs-on: ak-e2e-runners
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Run gate against nonexistent image and expect failure
         env:
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload self-test diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: smoke-self-test-pull-logs-${{ github.run_attempt }}
           path: /tmp/test-logs/
@@ -93,13 +93,13 @@ jobs:
     runs-on: ak-e2e-runners
     timeout-minutes: 12
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       # Fixture: tag a public busybox image as the "backend" via a
       # transient ImageStreamTag-style alias. busybox does not have
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload self-test diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: smoke-self-test-crash-logs-${{ github.run_attempt }}
           path: /tmp/test-logs/

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -18,7 +18,7 @@ jobs:
       RUN_ID: ${{ inputs.run_id }}
       JUNIT_OUTPUT_DIR: /tmp/test-results
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run stress tests
         run: |
@@ -28,7 +28,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: junit-stress
           path: /tmp/test-results/*.xml


### PR DESCRIPTION
## Summary

Pins every third-party GitHub Action reference in `.github/workflows/` to an immutable commit SHA, with a trailing comment preserving the human-readable tag. Follows the GitHub-recommended hardening practice for security-sensitive workflows. Tag references like `actions/checkout@v4` are mutable, so a compromised maintainer or a tag rewrite could swap the code that runs in CI without our visibility.

## Pinned references (60 total across 6 files)

| Action | SHA | Count |
|---|---|---|
| `actions/checkout@v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | 23 |
| `actions/upload-artifact@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | 23 |
| `actions/download-artifact@v4` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` | 1 |
| `azure/setup-kubectl@v4` | `776406bce94f63e41d621b960d78ee25c8b76ede` | 7 |
| `azure/setup-helm@v4` | `1a275c3b69536ee54be43f2070a358922e12c8d4` | 6 |

SHAs were obtained from upstream via `git ls-remote refs/tags/v4^{}` (or, for annotated tags, the dereferenced commit returned by the GitHub `git/tags` API). Every line looks like:

```yaml
uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
```

## Files changed

- `.github/workflows/format-tests.yml`
- `.github/workflows/mesh-tests.yml`
- `.github/workflows/release-gate.yml`
- `.github/workflows/resilience-tests.yml`
- `.github/workflows/smoke-self-test.yml`
- `.github/workflows/stress-tests.yml`

## Notes

- No references were left tag-pinned. Every `uses:` line in `.github/workflows/*.yml` now points at a 40-char commit SHA.
- No `aquasecurity/trivy-action` references exist in these workflows, so the known-broken `trivy-action@0.34.1` issue does not apply here. Trivy is run inside the cluster via the backend's bundled scanner deployment.
- YAML validity was confirmed by running `python3 -c "import yaml; yaml.safe_load(open(f))"` on every modified file. `actionlint` reports no new findings; the pre-existing warnings about the custom self-hosted runner label `ak-e2e-runners` and shellcheck style nits are unchanged.

## Conflict notes

Expect rebase conflicts with PR #144 (which adds new `actions/upload-artifact@v4` lines in `release-gate.yml`) and PR #145 (which adds a `needs:` field in `release-gate.yml`). The new artifact-upload lines introduced by PR #144 will land unpinned and should be SHA-pinned in a small follow-up once both PRs are merged.

## Test plan

- [x] `grep -nE 'uses:' .github/workflows/*.yml | grep -vE '@[0-9a-f]{40}'` returns no output
- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` succeeds for every modified file
- [x] `actionlint` reports no new issues introduced by this change
- [ ] CI green on this branch (will run after this PR opens)

Closes #104. Supersedes #55.