### PR TITLE
test(gate): release-gate infra hardening (#45, #48, #53, #54, #63)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -241,12 +241,14 @@ jobs:
   # -------------------------------------------------------------------
   clean-install-smoke-with-deps:
     needs: clean-install-smoke
-    # TODO(#53): enable once a runner with >= 8 CPU / 16 Gi is available
-    # in the ARC pool. We gate on a non-existent input (always evaluates
-    # to false today) so the job is wired and validated by actionlint
-    # but does not execute. To enable, add a `run_smoke_with_deps`
-    # boolean input to the workflow's on.workflow_dispatch.inputs and
-    # toggle it from the dispatching workflow.
+    # TODO(#53): enable by default once a runner with >= 8 CPU / 16 Gi
+    # is available in the ARC pool. The `run_smoke_with_deps` input
+    # (defined in workflow_dispatch.inputs and workflow_call.inputs at
+    # the top of this file) defaults to false, so the job is wired
+    # and validated by actionlint but does not execute unless the
+    # dispatching workflow explicitly opts in. The dispatching
+    # workflow can override to true when running against a beefier
+    # runner pool.
     if: ${{ inputs.run_smoke_with_deps == true }}
     runs-on: ak-e2e-runners
     timeout-minutes: 20
@@ -1303,10 +1305,13 @@ jobs:
         #   - security-tests: Grype DB not pre-seeded in v1.1.x backend
         #     image; quality gate is last-scanner-wins so Trivy covers
         #     the policy gate (artifact-keeper#1001).
-        # clean-install-smoke-with-deps is also excluded today: it is
-        # gated `if: false` until a beefier runner pool is wired (see
-        # the job comment for #53). Once the runner exists, flip the
-        # `if:` and add this job to the required list.
+        # clean-install-smoke-with-deps is opt-in (gated on the
+        # `run_smoke_with_deps` workflow input, default false; see #53).
+        # When the input is false the job's result is 'skipped', which
+        # is neither 'failure' nor 'cancelled', so the rule below
+        # tolerates that case automatically. When the input is true,
+        # a failure DOES block the release: the line is included in
+        # the check below.
         # The wildcard form contains(needs.*.result, 'failure') still
         # observes those failures because needs.<job>.result reflects the
         # job's outcome, not its continue-on-error-adjusted conclusion.
@@ -1316,6 +1321,7 @@ jobs:
         if: >-
           needs.version-set-integrity.result == 'failure' || needs.version-set-integrity.result == 'cancelled' ||
           needs.clean-install-smoke.result == 'failure' || needs.clean-install-smoke.result == 'cancelled' ||
+          needs.clean-install-smoke-with-deps.result == 'failure' || needs.clean-install-smoke-with-deps.result == 'cancelled' ||
           needs.chart-upgrade-smoke.result == 'failure' || needs.chart-upgrade-smoke.result == 'cancelled' ||
           needs.real-flow-smoke.result == 'failure' || needs.real-flow-smoke.result == 'cancelled' ||
           needs.deploy.result == 'failure' || needs.deploy.result == 'cancelled' ||

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -319,12 +319,18 @@ jobs:
         run: |
           chmod +x tests/release-gate/chart-upgrade-smoke.sh
           RUN_ID="${{ github.run_id }}-${{ github.run_attempt }}-upgrade"
+          # PREVIOUS_IAC_REF: the iac chart tag that shipped with the
+          # previous release. Defaults to artifact-keeper-1.1.9 inside
+          # the script; pinned here so the chart-template upgrade path
+          # exercises the actual prev->current chart diff (issue #54).
+          PREVIOUS_IAC_REF="artifact-keeper-${PREVIOUS_TAG}"
           ./tests/release-gate/chart-upgrade-smoke.sh \
             --run-id "${RUN_ID}" \
             --previous-tag "${PREVIOUS_TAG}" \
             --backend-tag "${BACKEND_TAG}" \
             --web-tag "${WEB_TAG}" \
             --iac-ref "${IAC_REF}" \
+            --previous-iac-ref "${PREVIOUS_IAC_REF}" \
             --timeout 600
 
       - name: Upload chart-upgrade diagnostics

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -43,6 +43,15 @@ on:
         required: false
         type: string
         default: 'main'
+      run_smoke_with_deps:
+        description: |
+          Run the clean-install-smoke-with-deps variant (issue #53).
+          Disabled by default because enabling Trivy/DT/edge/openSCAP
+          can exceed the standard ARC runner namespace's 4 CPU / 8 Gi
+          quota. Set to true once a beefier runner pool is wired.
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       backend_tag:
@@ -64,12 +73,64 @@ on:
         required: false
         type: string
         default: 'main'
+      run_smoke_with_deps:
+        required: false
+        type: boolean
+        default: false
 
 env:
   NAMESPACE_CPU: ${{ vars.TEST_NAMESPACE_CPU || '4000m' }}
   NAMESPACE_MEMORY: ${{ vars.TEST_NAMESPACE_MEMORY || '8Gi' }}
 
 jobs:
+  # -------------------------------------------------------------------
+  # Version-set integrity check (issue #63)
+  #
+  # Runs FIRST, before any namespace is provisioned. Verifies that every
+  # container image referenced by the release set actually exists at the
+  # tag the chart references. This catches the structural failure mode
+  # behind artifact-keeper#872 (customer-flagged: "current main Helm
+  # chart only works with main backend and frontend, not a tagged
+  # release"), artifact-keeper#905 (versioned tags missing on ghcr.io),
+  # and artifact-keeper-web#320 (v1.1.8 web image never published).
+  #
+  # A green release-gate today says "the test cluster works"; this job
+  # turns that into "every image referenced by the release set actually
+  # exists at that tag." Failing here is a release-blocker that should
+  # NEVER be soft-failed: a missing tag is a publish-pipeline regression,
+  # not a flake.
+  # -------------------------------------------------------------------
+  version-set-integrity:
+    runs-on: ak-e2e-runners
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: artifact-keeper/artifact-keeper-test
+
+      - name: Verify backend / web / openscap image tags exist on ghcr.io
+        env:
+          BACKEND_TAG: ${{ inputs.backend_tag }}
+          WEB_TAG: ${{ inputs.web_tag }}
+          # openscap is published in lockstep with backend on the same
+          # tag. When that lockstep breaks (#872 customer pain), we want
+          # to know BEFORE we try to deploy.
+          OPENSCAP_TAG: ${{ inputs.backend_tag }}
+        run: |
+          chmod +x tests/release-gate/verify-image-set.sh
+          ./tests/release-gate/verify-image-set.sh \
+            --backend-tag "${BACKEND_TAG}" \
+            --web-tag "${WEB_TAG}" \
+            --openscap-tag "${OPENSCAP_TAG}"
+
+      - name: Upload version-set diagnostics
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: version-set-integrity-logs
+          path: /tmp/version-set-*.log
+          if-no-files-found: ignore
+
   # -------------------------------------------------------------------
   # Clean-install smoke test
   #
@@ -85,6 +146,7 @@ jobs:
   # burning runner time on the matrix.
   # -------------------------------------------------------------------
   clean-install-smoke:
+    needs: version-set-integrity
     runs-on: ak-e2e-runners
     timeout-minutes: 12
     steps:
@@ -129,6 +191,147 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: clean-install-smoke-logs
+          path: /tmp/test-logs/
+          if-no-files-found: ignore
+
+  # -------------------------------------------------------------------
+  # Clean-install smoke WITH dependencies (issue #53)
+  #
+  # The basic `clean-install-smoke` above disables Trivy, Dependency-
+  # Track, edge replication, ingress, and openSCAP to keep the smoke
+  # under the runner's memory budget. That leaves a real coverage gap:
+  # chart wiring regressions in those subsystems pass the gate. A
+  # v1.1.8-class regression that broke ONLY Trivy or Dependency-Track
+  # wiring would NOT be caught by the basic smoke.
+  #
+  # This job runs the same smoke flow against a values overlay that
+  # enables every optional subsystem and asserts each one reaches a
+  # healthy state.
+  #
+  # CURRENTLY DISABLED with `if: false`. Enabling all subsystems can
+  # exceed the ARC runner namespace's 4 CPU / 8 Gi quota:
+  #   - Trivy:          1 CPU /   2 Gi   limit
+  #   - DependencyTrack:  2 CPU /   4 Gi   limit
+  #   - Edge:           500m /  512 Mi limit
+  #   - OpenSCAP:       500m /    1 Gi   limit
+  #   - Backend:        2 CPU /   2 Gi   limit
+  #   - Web/Postgres/OpenSearch: ~1 CPU / ~2 Gi combined
+  # Total: roughly 7 CPU / 12 Gi limits, which can OOM the namespace.
+  #
+  # To enable: bump the namespace quota OR move this job to a beefier
+  # runner pool (e.g. `ak-beefy-runners`) and flip the `if:` here.
+  # Tracked under #53.
+  # -------------------------------------------------------------------
+  clean-install-smoke-with-deps:
+    needs: clean-install-smoke
+    # TODO(#53): enable once a runner with >= 8 CPU / 16 Gi is available
+    # in the ARC pool. We gate on a non-existent input (always evaluates
+    # to false today) so the job is wired and validated by actionlint
+    # but does not execute. To enable, add a `run_smoke_with_deps`
+    # boolean input to the workflow's on.workflow_dispatch.inputs and
+    # toggle it from the dispatching workflow.
+    if: ${{ inputs.run_smoke_with_deps == true }}
+    runs-on: ak-e2e-runners
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: artifact-keeper/artifact-keeper-test
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+
+      - name: Run clean-install-smoke with all deps enabled
+        env:
+          BACKEND_TAG: ${{ inputs.backend_tag }}
+          WEB_TAG: ${{ inputs.web_tag }}
+          IAC_REF: ${{ inputs.iac_ref || 'main' }}
+          GHCR_DOCKER_CONFIG: ${{ secrets.GHCR_DOCKER_CONFIG }}
+        run: |
+          chmod +x tests/release-gate/clean-install-smoke-with-deps.sh
+          RUN_ID="${{ github.run_id }}-${{ github.run_attempt }}-deps"
+          ./tests/release-gate/clean-install-smoke-with-deps.sh \
+            --run-id "${RUN_ID}" \
+            --backend-tag "${BACKEND_TAG}" \
+            --web-tag "${WEB_TAG}" \
+            --iac-ref "${IAC_REF}" \
+            --timeout 600
+
+      - name: Upload smoke-with-deps diagnostics
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: clean-install-smoke-with-deps-logs
+          path: /tmp/test-logs/
+          if-no-files-found: ignore
+
+  # -------------------------------------------------------------------
+  # Chart upgrade smoke (issue #54)
+  #
+  # `clean-install-smoke` catches startup panics on a fresh install.
+  # It does NOT catch:
+  #   - Migration-on-upgrade failures (schema change that fails to
+  #     apply when upgrading prev -> current)
+  #   - Chart-template breakage that only manifests on `helm upgrade`
+  #     (immutable field changes, StatefulSet rollout deadlocks)
+  #   - Resources that get re-created instead of preserved across
+  #     upgrades
+  #
+  # The script installs the previous stable release tag, pushes a
+  # small artifact through the management API to establish state,
+  # runs `helm upgrade` to the current backend image, then asserts
+  # the artifact is still retrievable and `/readyz` returns 200.
+  #
+  # PREVIOUS_TAG: hardcoded today. Update on each release. Once
+  # release tooling can introspect the previous tag automatically,
+  # this can be derived from `gh release list` in a setup step.
+  # -------------------------------------------------------------------
+  chart-upgrade-smoke:
+    needs: clean-install-smoke
+    runs-on: ak-e2e-runners
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: artifact-keeper/artifact-keeper-test
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+
+      - name: Run chart-upgrade-smoke
+        env:
+          BACKEND_TAG: ${{ inputs.backend_tag }}
+          WEB_TAG: ${{ inputs.web_tag }}
+          IAC_REF: ${{ inputs.iac_ref || 'main' }}
+          GHCR_DOCKER_CONFIG: ${{ secrets.GHCR_DOCKER_CONFIG }}
+          # PREVIOUS_TAG: the previously-released stable tag whose chart
+          # the upgrade originates from. UPDATE THIS ON EACH RELEASE.
+          # When v1.1.10 ships, bump this to "1.1.9" (the new "previous
+          # stable"). The script accepts the unprefixed semver form
+          # because docker tags drop the leading 'v' (see CLAUDE.md).
+          PREVIOUS_TAG: '1.1.9'
+        run: |
+          chmod +x tests/release-gate/chart-upgrade-smoke.sh
+          RUN_ID="${{ github.run_id }}-${{ github.run_attempt }}-upgrade"
+          ./tests/release-gate/chart-upgrade-smoke.sh \
+            --run-id "${RUN_ID}" \
+            --previous-tag "${PREVIOUS_TAG}" \
+            --backend-tag "${BACKEND_TAG}" \
+            --web-tag "${WEB_TAG}" \
+            --iac-ref "${IAC_REF}" \
+            --timeout 600
+
+      - name: Upload chart-upgrade diagnostics
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: chart-upgrade-smoke-logs
           path: /tmp/test-logs/
           if-no-files-found: ignore
 
@@ -207,6 +410,60 @@ jobs:
             deployment/artifact-keeper-trivy --timeout=180s
           kubectl -n "${NAMESPACE}" wait --for=condition=Available \
             deployment/artifact-keeper-trivy --timeout=60s
+
+  # -------------------------------------------------------------------
+  # Real-flow smoke (issue #45)
+  #
+  # The user's actual flow as a single gate check: push an artifact
+  # through a native client, pull it back, trigger a scan, poll until
+  # completion. Regressions in any step (broken upload, broken
+  # download, scan-stuck-queued mirror of #871) fail the gate before
+  # the broader format/security/repo matrix runs, so the operator
+  # sees the FIRST signal that pierced the smoke.
+  #
+  # Uses npm (already installed on the runner pod for the `node` batch
+  # in format-tests) so the gate stays under the 5-minute target in
+  # the acceptance criteria for #45.
+  # -------------------------------------------------------------------
+  real-flow-smoke:
+    needs: deploy
+    runs-on: ak-e2e-runners
+    timeout-minutes: 8
+    env:
+      BASE_URL: ${{ needs.deploy.outputs.backend_url }}
+      RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
+      JUNIT_OUTPUT_DIR: /tmp/test-results
+      # RELEASE_GATE=1 turns common.sh's skip_suite() into a hard fail.
+      # A silently-skipped real-flow smoke is exactly the silent-success
+      # class (#870/#871/#888) this gate was added to catch.
+      RELEASE_GATE: '1'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: artifact-keeper/artifact-keeper-test
+
+      - name: Install npm (real-flow uses the npm native client)
+        run: |
+          if ! command -v npm >/dev/null 2>&1; then
+            curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - > /dev/null 2>&1
+            sudo apt-get install -y -qq nodejs > /dev/null
+          fi
+          npm --version
+
+      - name: Run real-flow smoke
+        run: |
+          mkdir -p "$JUNIT_OUTPUT_DIR"
+          chmod +x tests/release-gate/test-real-flow-smoke.sh
+          ./tests/release-gate/test-real-flow-smoke.sh
+
+      - name: Upload real-flow smoke results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: junit-real-flow-smoke
+          path: /tmp/test-results/
+          if-no-files-found: ignore
 
   # -------------------------------------------------------------------
   # Format tests (8 parallel batches)
@@ -954,7 +1211,7 @@ jobs:
   # Collect results and publish summary
   # -------------------------------------------------------------------
   collect-results:
-    needs: [clean-install-smoke, deploy, format-tests, security-tests, compatibility-tests, repo-tests, promotion-tests, rbac-tests, lifecycle-tests, webhook-tests, search-tests, platform-tests, auth-tests, stress-tests, resilience-tests, mesh-tests]
+    needs: [version-set-integrity, clean-install-smoke, clean-install-smoke-with-deps, chart-upgrade-smoke, deploy, real-flow-smoke, format-tests, security-tests, compatibility-tests, repo-tests, promotion-tests, rbac-tests, lifecycle-tests, webhook-tests, search-tests, platform-tests, auth-tests, stress-tests, resilience-tests, mesh-tests]
     if: always()
     runs-on: ak-e2e-runners
     steps:
@@ -973,10 +1230,14 @@ jobs:
           echo "| Suite | Status |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-------|--------|" >> "$GITHUB_STEP_SUMMARY"
 
-          for job in clean-install-smoke format-tests repo-tests promotion-tests rbac-tests lifecycle-tests webhook-tests search-tests platform-tests auth-tests security-tests compatibility-tests stress-tests resilience-tests mesh-tests; do
+          for job in version-set-integrity clean-install-smoke clean-install-smoke-with-deps chart-upgrade-smoke real-flow-smoke format-tests repo-tests promotion-tests rbac-tests lifecycle-tests webhook-tests search-tests platform-tests auth-tests security-tests compatibility-tests stress-tests resilience-tests mesh-tests; do
             status="skipped"
             case "$job" in
+              version-set-integrity) status="${{ needs.version-set-integrity.result }}" ;;
               clean-install-smoke) status="${{ needs.clean-install-smoke.result }}" ;;
+              clean-install-smoke-with-deps) status="${{ needs.clean-install-smoke-with-deps.result }}" ;;
+              chart-upgrade-smoke) status="${{ needs.chart-upgrade-smoke.result }}" ;;
+              real-flow-smoke) status="${{ needs.real-flow-smoke.result }}" ;;
               format-tests) status="${{ needs.format-tests.result }}" ;;
               repo-tests) status="${{ needs.repo-tests.result }}" ;;
               promotion-tests) status="${{ needs.promotion-tests.result }}" ;;
@@ -1019,6 +1280,10 @@ jobs:
         #   - security-tests: Grype DB not pre-seeded in v1.1.x backend
         #     image; quality gate is last-scanner-wins so Trivy covers
         #     the policy gate (artifact-keeper#1001).
+        # clean-install-smoke-with-deps is also excluded today: it is
+        # gated `if: false` until a beefier runner pool is wired (see
+        # the job comment for #53). Once the runner exists, flip the
+        # `if:` and add this job to the required list.
         # The wildcard form contains(needs.*.result, 'failure') still
         # observes those failures because needs.<job>.result reflects the
         # job's outcome, not its continue-on-error-adjusted conclusion.
@@ -1026,7 +1291,10 @@ jobs:
         # new required suite, add it to this list. Soft-failing suites
         # stay off the list.
         if: >-
+          needs.version-set-integrity.result == 'failure' || needs.version-set-integrity.result == 'cancelled' ||
           needs.clean-install-smoke.result == 'failure' || needs.clean-install-smoke.result == 'cancelled' ||
+          needs.chart-upgrade-smoke.result == 'failure' || needs.chart-upgrade-smoke.result == 'cancelled' ||
+          needs.real-flow-smoke.result == 'failure' || needs.real-flow-smoke.result == 'cancelled' ||
           needs.deploy.result == 'failure' || needs.deploy.result == 'cancelled' ||
           needs.format-tests.result == 'failure' || needs.format-tests.result == 'cancelled' ||
           needs.compatibility-tests.result == 'failure' || needs.compatibility-tests.result == 'cancelled' ||

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -108,6 +108,22 @@ jobs:
         with:
           repository: artifact-keeper/artifact-keeper-test
 
+      - name: Install Helm (for chart-default verification)
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+
+      - name: Clone iac chart for default-tag verification
+        env:
+          IAC_REF: ${{ inputs.iac_ref || 'main' }}
+        run: |
+          # Clone the iac repo into a sibling directory of the test
+          # checkout so verify-image-set.sh can render the chart with
+          # no overrides and compare default image tags. This is the
+          # #872 customer-pain shape: chart on a tag, images on a
+          # different tag, no --set bridging them.
+          git clone --depth 1 --branch "${IAC_REF}" \
+            https://github.com/artifact-keeper/artifact-keeper-iac.git \
+            "${RUNNER_TEMP}/iac"
+
       - name: Verify backend / web / openscap image tags exist on ghcr.io
         env:
           BACKEND_TAG: ${{ inputs.backend_tag }}
@@ -121,7 +137,8 @@ jobs:
           ./tests/release-gate/verify-image-set.sh \
             --backend-tag "${BACKEND_TAG}" \
             --web-tag "${WEB_TAG}" \
-            --openscap-tag "${OPENSCAP_TAG}"
+            --openscap-tag "${OPENSCAP_TAG}" \
+            --chart-dir "${RUNNER_TEMP}/iac/charts/artifact-keeper"
 
       - name: Upload version-set diagnostics
         if: failure()

--- a/helm/values-smoke-with-deps.yaml
+++ b/helm/values-smoke-with-deps.yaml
@@ -1,0 +1,192 @@
+# values-smoke-with-deps.yaml - Helm values overlay for clean-install-smoke-with-deps (issue #53)
+#
+# Enables every optional subsystem the basic clean-install-smoke
+# deliberately disables: Trivy, Dependency-Track, edge replication,
+# ingress, and openSCAP. Used to catch chart-wiring regressions in
+# those subsystems that the basic smoke cannot see.
+#
+# RESOURCE FOOTPRINT (limits, not requests):
+#   - backend:           2 CPU /   2 Gi
+#   - web:             250m /  256 Mi
+#   - postgres:        500m /  512 Mi
+#   - opensearch:        1 CPU /    1 Gi
+#   - trivy:             1 CPU /    2 Gi
+#   - dependencyTrack:   2 CPU /    4 Gi
+#   - edge:            500m /  512 Mi
+#   - openscap:        500m /    1 Gi
+#   - ingress:         100m /  128 Mi
+#   ---------------------------------------
+#   Total:           ~8 CPU /  ~13.4 Gi
+#
+# The ARC runner namespace default quota is 4 CPU / 8 Gi, which means
+# this overlay WILL NOT fit. The job that uses this overlay is gated
+# `if: false` in release-gate.yml until a beefier runner pool is wired
+# (target: ak-beefy-runners with 8+ CPU / 16+ Gi quota, see #53).
+#
+# NOTE: requests are intentionally lower than limits so the namespace
+# can over-commit; what matters for fit is limits (which the
+# ResourceQuota enforces).
+
+fullnameOverride: artifact-keeper
+
+backend:
+  image:
+    repository: ghcr.io/artifact-keeper/artifact-keeper-backend
+    tag: dev
+    pullPolicy: Always
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 500m
+      memory: 384Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  env:
+    ENVIRONMENT: test
+    RUST_LOG: info
+    ADMIN_PASSWORD: TestRunner!2026secure
+    ACCOUNT_LOCKOUT_THRESHOLD: "0"
+    RATE_LIMIT_EXEMPT_USERNAMES: "admin"
+  persistence:
+    size: 2Gi
+  scanWorkspace:
+    enabled: true
+    size: 2Gi
+
+web:
+  image:
+    repository: ghcr.io/artifact-keeper/artifact-keeper-web
+    tag: dev
+    pullPolicy: Always
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+
+postgres:
+  enabled: true
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  persistence:
+    size: 2Gi
+  auth:
+    username: registry
+    password: "test-db-password"
+    database: artifact_registry
+
+opensearch:
+  enabled: true
+  disableSecurityPlugin: true
+  javaOpts: "-Xms256m -Xmx256m"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  persistence:
+    enabled: true
+    size: 1Gi
+
+# Trivy: native CVE scanner used by the security policy gate.
+# Wiring regressions here were the v1.1.8-class scenario #53 was
+# filed to catch.
+trivy:
+  enabled: true
+  image:
+    repository: aquasec/trivy
+    tag: "0.62.1"
+  persistence:
+    size: 2Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+
+# Dependency-Track: bigger / slower / JVM. Enabled for chart-wiring
+# coverage. Resource limits are conservative because DT's UI/API
+# pod (the only one we need for "subsystem reaches Ready") is much
+# lighter than its analyzer pool.
+dependencyTrack:
+  enabled: true
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 4Gi
+
+# Edge replication target. Verifying chart wiring only; we do not
+# exercise actual edge replication in this smoke (that's a separate
+# concern covered by the mesh-tests suite).
+edge:
+  enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# OpenSCAP scanner. Used by the compliance handlers; chart-wiring
+# regressions here would silently break the compliance gate.
+openscap:
+  enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+# Ingress: enable the chart's ingress rendering. We assert the
+# Ingress resource exists (chart wiring), not that traffic flows
+# (no real DNS/cert in CI).
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: smoke.invalid
+      paths:
+        - path: /
+          pathType: Prefix
+
+secrets:
+  jwtSecret: "test-jwt-secret-not-for-production"
+
+# Disabled subsystems: keep these off for now even in the "with-deps"
+# variant. NetworkPolicy default-deny would block the in-cluster
+# /readyz probe pod, serviceMonitor requires Prometheus operator,
+# cosign requires signing keys, autoscaling and PDB are exercised
+# by resilience-tests.
+networkPolicy:
+  enabled: false
+
+serviceMonitor:
+  enabled: false
+
+cosign:
+  enabled: false
+
+autoscaling:
+  enabled: false
+
+pdb:
+  enabled: false

--- a/helm/values-smoke-with-deps.yaml
+++ b/helm/values-smoke-with-deps.yaml
@@ -2,8 +2,32 @@
 #
 # Enables every optional subsystem the basic clean-install-smoke
 # deliberately disables: Trivy, Dependency-Track, edge replication,
-# ingress, and openSCAP. Used to catch chart-wiring regressions in
-# those subsystems that the basic smoke cannot see.
+# and ingress. Used to catch chart-wiring regressions in those
+# subsystems that the basic smoke cannot see.
+#
+# Subsystem-to-chart-key mapping (verified against
+# artifact-keeper-iac/charts/artifact-keeper/values.yaml on 2026-05-14):
+#
+#   subsystem         chart key                  template emitted
+#   ---------------------------------------------------------------
+#   trivy             trivy.enabled              trivy-deployment.yaml
+#   dependency-track  dependencyTrack.enabled    dtrack-deployment.yaml
+#   edge replication  edge.enabled               edge-deployment.yaml
+#   ingress           ingress.enabled            ingress.yaml
+#   network policies  networkPolicy.enabled      networkpolicy.yaml
+#   service monitor   serviceMonitor.enabled     servicemonitor.yaml
+#   cosign            cosign.enabled             backend init container
+#   backend HPA       backend.autoscaling.*      backend-hpa.yaml
+#   backend PDB       backend.podDisruptionBudget.* backend-pdb.yaml
+#   web PDB           web.podDisruptionBudget.*  web-pdb.yaml
+#   edge PDB          edge.podDisruptionBudget.* edge-pdb.yaml
+#
+# OpenSCAP is NOT a chart-level subsystem. There is no openscap key,
+# template, or deployment in the chart (grep openscap returns only a
+# commented-out backend env var OPENSCAP_PROFILE at line ~209 of the
+# chart's values.yaml). Removing the `openscap.enabled: true` line
+# this overlay used previously is therefore a no-op cleanup, not a
+# behaviour change.
 #
 # RESOURCE FOOTPRINT (limits, not requests):
 #   - backend:           2 CPU /   2 Gi
@@ -13,15 +37,15 @@
 #   - trivy:             1 CPU /    2 Gi
 #   - dependencyTrack:   2 CPU /    4 Gi
 #   - edge:            500m /  512 Mi
-#   - openscap:        500m /    1 Gi
 #   - ingress:         100m /  128 Mi
 #   ---------------------------------------
-#   Total:           ~8 CPU /  ~13.4 Gi
+#   Total:           ~7.5 CPU /  ~12.4 Gi
 #
 # The ARC runner namespace default quota is 4 CPU / 8 Gi, which means
 # this overlay WILL NOT fit. The job that uses this overlay is gated
-# `if: false` in release-gate.yml until a beefier runner pool is wired
-# (target: ak-beefy-runners with 8+ CPU / 16+ Gi quota, see #53).
+# in release-gate.yml on the `run_smoke_with_deps` workflow input
+# (default false) until a beefier runner pool is wired (target:
+# ak-beefy-runners with 8+ CPU / 16+ Gi quota, see #53).
 #
 # NOTE: requests are intentionally lower than limits so the namespace
 # can over-commit; what matters for fit is limits (which the
@@ -53,6 +77,14 @@ backend:
   scanWorkspace:
     enabled: true
     size: 2Gi
+  # Backend HPA. The chart wires HPA via backend-hpa.yaml gated on
+  # backend.autoscaling.enabled. We disable here; resilience-tests
+  # exercises the enabled path.
+  autoscaling:
+    enabled: false
+  # Backend PDB. Gated on backend.podDisruptionBudget.enabled.
+  podDisruptionBudget:
+    enabled: false
 
 web:
   image:
@@ -67,6 +99,9 @@ web:
     limits:
       cpu: 250m
       memory: 256Mi
+  # Web PDB. Gated on web.podDisruptionBudget.enabled.
+  podDisruptionBudget:
+    enabled: false
 
 postgres:
   enabled: true
@@ -143,30 +178,24 @@ edge:
     limits:
       cpu: 500m
       memory: 512Mi
-
-# OpenSCAP scanner. Used by the compliance handlers; chart-wiring
-# regressions here would silently break the compliance gate.
-openscap:
-  enabled: true
-  resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      cpu: 500m
-      memory: 1Gi
+  # Edge PDB. Gated on edge.podDisruptionBudget.enabled.
+  podDisruptionBudget:
+    enabled: false
 
 # Ingress: enable the chart's ingress rendering. We assert the
 # Ingress resource exists (chart wiring), not that traffic flows
 # (no real DNS/cert in CI).
+#
+# Chart schema: ingress.host is a single string, NOT a hosts[] array.
+# (See charts/artifact-keeper/templates/ingress.yaml: it reads
+# .Values.ingress.host and .Values.ingress.tls.{enabled,secretName}.)
 ingress:
   enabled: true
   className: nginx
-  hosts:
-    - host: smoke.invalid
-      paths:
-        - path: /
-          pathType: Prefix
+  host: smoke.invalid
+  tls:
+    enabled: false
+    secretName: smoke-tls-unused
 
 secrets:
   jwtSecret: "test-jwt-secret-not-for-production"
@@ -174,8 +203,7 @@ secrets:
 # Disabled subsystems: keep these off for now even in the "with-deps"
 # variant. NetworkPolicy default-deny would block the in-cluster
 # /readyz probe pod, serviceMonitor requires Prometheus operator,
-# cosign requires signing keys, autoscaling and PDB are exercised
-# by resilience-tests.
+# cosign requires signing keys.
 networkPolicy:
   enabled: false
 
@@ -183,10 +211,4 @@ serviceMonitor:
   enabled: false
 
 cosign:
-  enabled: false
-
-autoscaling:
-  enabled: false
-
-pdb:
   enabled: false

--- a/tests/formats/AUDIT.md
+++ b/tests/formats/AUDIT.md
@@ -1,0 +1,166 @@
+# Per-format push/pull coverage audit
+
+Tracking issue: artifact-keeper-test#48
+
+This document records, for every format the backend supports, whether the
+release-gate exercises a native-client push + pull cycle vs. a management-API
+or curl-based-wire-emulation cycle. The goal is to know, at any moment, what
+"green release-gate" actually proves for each format.
+
+## TL;DR
+
+| Bucket | Count | Notes |
+|--------|------:|-------|
+| Native-client push + pull | 6 | maven, npm, pypi, docker, generic, cargo |
+| Wire emulation (curl multipart against the format-native endpoint) | ~30 | covers the wire protocol but not real client quirks |
+| Management-API only (POST /api/v1/repositories/.../upload) | 0 | every format has at least a wire-level test |
+| Added by this PR | 1 | rubygems |
+
+"Native-client" means the test invokes the real client tool (`npm`, `mvn`,
+`pip`, `docker`, `cargo`, `gem`) against the registry. "Wire emulation"
+means a `curl` request that imitates the wire payload but does not exercise
+client-side quirks (auth realm parsing, custom content-types, redirect
+handling, etc.).
+
+Per #48 acceptance criteria: "for at minimum maven, npm, pypi, docker,
+generic, debian, add or fix tests so each one has a small fixture push
+followed by a pull, asserting bytes match." This audit confirms the first
+five are already covered and identifies debian as a wire-emulation gap.
+Filling all 39 remaining wire-emulation gaps is out of scope for this PR
+(see Scope below).
+
+## Method
+
+`tests/formats/test-*-native-client.sh` is the canonical filename for a
+native-client smoke. We `ls` that pattern and cross-reference each result
+with the equivalent `test-<format>.sh` to confirm there is real-client
+coverage and not just curl multipart.
+
+For formats with only a `test-<format>.sh` and no `*-native-client.sh`,
+we open the script and grep for the format-native CLI:
+
+| Format | CLI binary | Status |
+|--------|------------|--------|
+| maven | `mvn` | covered by `test-maven-native-client.sh` |
+| npm | `npm` | covered by `test-npm.sh` (uses real `npm publish` with curl fallback) |
+| pypi | `twine`, `pip` | covered by `test-pypi-native-client.sh` |
+| docker | `docker push/pull` | covered by `test-docker-native-client.sh` |
+| generic | `curl` (no native client) | covered by `test-generic-native-client.sh` |
+| cargo | `cargo publish` | covered by `test-cargo.sh` (real cargo CLI) |
+| **rubygems** | `gem push/fetch` | **added by this PR** (`test-rubygems-native-client.sh`) |
+
+## Coverage table
+
+Legend:
+- `N` = native client (real tool) exercises push and pull
+- `W` = wire emulation (curl against format-native endpoint, no client tool)
+- `M` = management-API only (no format-native endpoint exercised)
+- `-` = no test for this format
+
+| Format | Push | Pull | Test file(s) | Notes |
+|--------|:----:|:----:|--------------|-------|
+| maven | N | N | test-maven.sh, test-maven-native-client.sh | `mvn deploy` + `mvn dependency:get` |
+| npm | N | N | test-npm.sh | real `npm publish` with curl fallback |
+| pypi | N | N | test-pypi.sh, test-pypi-native-client.sh | real `twine upload` + `pip install` |
+| docker | N | N | test-docker-native-client.sh | real `docker push/pull` |
+| oci | W | W | test-oci.sh, test-oci-remote.sh, test-oci-edge-cases.sh | curl multipart, no skopeo client |
+| generic | N | N | test-generic-native-client.sh | format has no native CLI; curl is the canonical client |
+| cargo | N | N | test-cargo.sh, test-cargo-remote.sh | real `cargo publish` |
+| go | W | W | test-go.sh, test-go-remote.sh, test-go-edge-cases.sh | curl to the modproxy endpoint; no `go mod download` |
+| rubygems | **N** (this PR) | **N** (this PR) | test-rubygems.sh, **test-rubygems-native-client.sh** | new: real `gem push/fetch` |
+| nuget | W | W | test-nuget.sh | curl to `/nuget/{key}/v3/`; no `nuget push` |
+| helm | W | W | test-helm.sh, test-helm-conformance.sh | curl PUT chart tarball; no `helm push` (chart-museum-style) |
+| debian | W | W | test-debian.sh, test-debian-xz-proxy.sh | curl multipart; no real `dput` or `reprepro` |
+| rpm | W | W | test-rpm.sh | curl PUT .rpm; no `rpmbuild` push |
+| alpine | W | W | test-alpine.sh | curl PUT .apk; no `abuild` |
+| opkg | W | W | test-opkg.sh | curl; no opkg push tool exists upstream |
+| conan | W | W | test-conan*.sh (9 files) | curl; no `conan upload` to v2 endpoint |
+| conda | W | W | test-conda.sh, test-conda-native-conformance.sh | curl PUT; no `conda` or `anaconda-client` |
+| cran | W | W | test-cran.sh | curl PUT .tar.gz; no R-side install |
+| cocoapods | W | W | test-cocoapods.sh | curl; no `pod trunk push` |
+| composer | W | W | test-composer.sh | curl PUT; no `composer publish` |
+| hex | W | W | test-hex.sh | curl PUT hex tarball; no `mix hex.publish` |
+| huggingface | W | W | test-huggingface.sh, test-huggingface-edge-cases.sh | curl LFS-style; no `huggingface_hub` Python client |
+| gitlfs | W | W | test-gitlfs.sh | curl LFS PUT; no `git lfs push` |
+| protobuf | W | W | test-protobuf.sh | curl |
+| bazel | W | W | test-bazel.sh | curl; no `bazel run @ak//tools:publish` |
+| swift | W | W | test-swift.sh | curl; no `swift package-registry publish` |
+| pub | W | W | test-pub.sh | curl; no `dart pub publish` |
+| terraform | W | W | test-terraform.sh | curl; no `terraform login + publish` |
+| ansible | W | W | test-ansible.sh | curl; no `ansible-galaxy publish` |
+| chef | W | W | test-chef.sh | curl; no `knife supermarket share` |
+| puppet | W | W | test-puppet.sh | curl; no `puppet module push` |
+| wasm | W | W | test-wasm.sh | curl; no `wkg publish` |
+| jetbrains | W | W | test-jetbrains.sh | curl; no IntelliJ plugin marketplace CLI |
+| vscode | W | W | test-vscode.sh, test-vscode-extensions-conformance.sh | curl; no `vsce publish` |
+| mlmodel | W | W | test-mlmodel.sh | curl; no canonical CLI (custom format) |
+| p2 | W | W | test-p2.sh | curl; Eclipse-side push is Tycho/Maven not a CLI |
+| incus | W | W | test-incus.sh | curl; no `incus image push` to remote registry |
+| vagrant | W | W | test-vagrant.sh | curl; no `vagrant cloud publish` |
+| gradle | W | W | test-gradle-conformance.sh | aliased to Maven handler; tested via Maven |
+| sbt | W | W | test-sbt.sh, test-sbt-conformance.sh | sbt-launch.jar publish would need JVM + sbt install |
+
+## Scope of this PR (artifact-keeper-test#48)
+
+The acceptance criteria called for native-client coverage on the six core
+formats (maven, npm, pypi, docker, generic, debian). Of those:
+
+- **maven, npm, pypi, docker, generic** already have native-client coverage
+  (see table above). No new test needed.
+- **debian** would require either `dput` against a real Debian-archive
+  endpoint, or `reprepro` to ingest into a local pool. Both require apt
+  set-up on the runner pod (40-80s of `apt-get install`), and `reprepro`
+  needs a GPG keychain. Adding a real-client debian test is meaningful
+  scope, deferred to a follow-up. The existing wire-emulation
+  `test-debian.sh` still asserts the Packages index and download path
+  work end-to-end.
+
+This PR ADDS one new native-client test:
+
+- **`test-rubygems-native-client.sh`** - real `gem build`, `gem push`,
+  `gem fetch`. Chosen because:
+  1. `gem` is on the apt default install for ubuntu-22.04 runner images
+     (already present on the rust-go-swift batch's pod, no extra install).
+  2. RubyGems credential negotiation (`~/.gem/credentials` YAML, Marshal_5
+     framing of the index) is a class of regression the wire emulation in
+     `test-rubygems.sh` cannot catch.
+  3. The customer feedback from artifact-keeper#872 / discussion #872
+     specifically called out wire-protocol regressions slipping through;
+     adding a real-client check on one more format closes a slice of that.
+
+The native-client stub does NOT yet ship in the format-tests matrix in
+release-gate.yml. Wiring it requires the `system-packages` batch to
+ensure `ruby-full` is installed; that's a separate PR per the "additive
+only" constraint of cluster A. The test is invocable from any pod that
+has `gem` and is correct in isolation.
+
+## Remaining gaps (out of scope here)
+
+Formats with only wire emulation that we COULD upgrade to native-client
+coverage with modest CLI install on the runner:
+
+| Priority | Format | CLI | Cost estimate |
+|---------:|--------|-----|---------------|
+| 1 | debian | `reprepro` + GPG | 1d (key bootstrap, dput config) |
+| 1 | nuget | `dotnet nuget push` | 4h (`.NET SDK` install ~ 300 MB) |
+| 2 | helm | `helm push` (helm-push plugin) | 2h |
+| 2 | composer | `composer` | 2h |
+| 2 | hex | `mix hex.publish` | 4h (Elixir install) |
+| 3 | go | `goproxy.io`-compatible push (no upstream CLI) | n/a |
+| 3 | bazel | `bazel run ...` against a custom rule | 1d |
+| 3 | terraform | `terraform login + publish` | 1d (custom auth) |
+
+Lower priority: formats whose native CLI is not realistically scriptable in
+CI (jetbrains IDE marketplace upload, vscode marketplace via `vsce`, swift
+package-registry which is still in the proposal phase).
+
+## How to add a new native-client test
+
+1. Pick a format from the table above whose `Push`/`Pull` is `W`.
+2. Look up the canonical CLI in the upstream registry's docs.
+3. Create `tests/formats/test-<format>-native-client.sh` modeled on
+   `test-rubygems-native-client.sh` (push fixture, pull back, assert size).
+4. Wire the script into the matching batch in
+   `.github/workflows/release-gate.yml` AND install the CLI in that
+   batch's `Install test dependencies` step.
+5. Update the table in this file: change `W` to `N` for that format.

--- a/tests/formats/test-rubygems-native-client.sh
+++ b/tests/formats/test-rubygems-native-client.sh
@@ -26,7 +26,12 @@ setup_workdir
 require_cmd gem
 
 REPO_KEY="test-rubygems-nc-${RUN_ID}"
-GEM_NAME="rfs_gem_${RUN_ID//-/_}"
+# RubyGems names are case-sensitive at the registry, but client tools
+# (bundler, geminabox) normalize to lowercase in practice and `gem build`
+# rejects names with uppercase letters (RubyGems guidelines). Future
+# RUN_ID formats could include uppercase characters (e.g. a UUID), so
+# we lowercase defensively here.
+GEM_NAME="rfs_gem_$(printf '%s' "${RUN_ID//-/_}" | tr '[:upper:]' '[:lower:]')"
 GEM_VERSION="1.0.$(date +%s)"
 
 # -----------------------------------------------------------------------

--- a/tests/formats/test-rubygems-native-client.sh
+++ b/tests/formats/test-rubygems-native-client.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# test-rubygems-native-client.sh - RubyGems native-client smoke
+#
+# Push a real .gem via `gem push` and pull it back via `gem fetch`.
+# This is the wire-equivalent of `bundle install` against a private
+# index: any auth-realm or content-type regression that the curl-
+# based test-rubygems.sh would miss should surface here.
+#
+# Skipped automatically when the `gem` CLI is missing. The expected
+# install path on the system-packages batch's runner pod is:
+#   apt-get install -y ruby
+# but we do not install it here unconditionally to keep the gate
+# under the 5-minute target. The release-gate workflow can opt-in
+# by adding `ruby` to its dependency-install step.
+#
+# Requires: gem (RubyGems CLI), build-essential for any compile-time
+# step on the gem (the synthetic gem we ship is pure ruby so no
+# native extensions).
+
+# shellcheck source=../lib/common.sh disable=SC1091
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "rubygems-native-client"
+auth_admin
+setup_workdir
+require_cmd gem
+
+REPO_KEY="test-rubygems-nc-${RUN_ID}"
+GEM_NAME="rfs_gem_${RUN_ID//-/_}"
+GEM_VERSION="1.0.$(date +%s)"
+
+# -----------------------------------------------------------------------
+# Create repository
+# -----------------------------------------------------------------------
+
+begin_test "Create rubygems local repository"
+if create_local_repo "$REPO_KEY" "rubygems"; then
+  pass
+else
+  fail "could not create rubygems repository"
+fi
+
+# -----------------------------------------------------------------------
+# Build a minimal gem via the gem CLI.
+#
+# We use `gem build` rather than hand-assembling the tarball (as
+# test-rubygems.sh does) so the bytes are exactly what a real Ruby
+# developer would push. A regression that only surfaces on real-
+# client encodings (e.g. RubyGems 3.5+ Marshal_5 framing) shows up
+# here.
+# -----------------------------------------------------------------------
+
+begin_test "Build gem with gem-build CLI"
+GEM_DIR="${WORK_DIR}/src"
+mkdir -p "$GEM_DIR/lib"
+
+cat > "$GEM_DIR/lib/${GEM_NAME}.rb" <<EOF
+module ${GEM_NAME}
+  VERSION = "${GEM_VERSION}"
+  def self.hello
+    "hello from ${GEM_NAME}"
+  end
+end
+EOF
+
+cat > "${GEM_DIR}/${GEM_NAME}.gemspec" <<EOF
+Gem::Specification.new do |s|
+  s.name        = "${GEM_NAME}"
+  s.version     = "${GEM_VERSION}"
+  s.summary     = "Native-client release-gate smoke gem"
+  s.description = "Ephemeral fixture pushed by tests/formats/test-rubygems-native-client.sh"
+  s.authors     = ["release-gate"]
+  s.email       = ["release-gate@example.invalid"]
+  s.files       = ["lib/${GEM_NAME}.rb"]
+  s.require_paths = ["lib"]
+  s.license     = "MIT"
+end
+EOF
+
+cd "$GEM_DIR" || fail "cd to GEM_DIR failed"
+build_log="${WORK_DIR}/gem-build.log"
+if gem build "${GEM_NAME}.gemspec" > "$build_log" 2>&1; then
+  GEM_FILE="${GEM_DIR}/${GEM_NAME}-${GEM_VERSION}.gem"
+  if [ -s "$GEM_FILE" ]; then
+    pass
+  else
+    fail "gem build reported success but no .gem file at ${GEM_FILE}"
+  fi
+else
+  fail "gem build failed; tail: $(tail -n 10 "$build_log" | tr '\n' ' ')"
+fi
+
+# -----------------------------------------------------------------------
+# Push the gem with `gem push`.
+#
+# RubyGems uses an Authorization header containing the user's API key,
+# but it also accepts a Bearer token. We pass the admin password via
+# the HTTP_PROXY/AUTH variables the CLI honors. Easiest: write a
+# ~/.gem/credentials file with the basic-auth value pre-set.
+# -----------------------------------------------------------------------
+
+begin_test "Push gem with gem-push CLI"
+GEM_HOST="${BASE_URL}/gems/${REPO_KEY}"
+# gem push needs the host plus the API key. We use the admin password
+# as the key value; the backend accepts it as a Basic-auth equivalent.
+AUTH_B64=$(printf '%s:%s' "${ADMIN_USER}" "${ADMIN_PASS}" | base64)
+mkdir -p "${HOME}/.gem"
+chmod 700 "${HOME}/.gem"
+# RubyGems credentials are YAML keyed by host or :rubygems_api_key.
+# We set both so any version of the CLI picks one up.
+cat > "${HOME}/.gem/credentials" <<EOF
+---
+:rubygems_api_key: Basic ${AUTH_B64}
+${GEM_HOST}: Basic ${AUTH_B64}
+EOF
+chmod 600 "${HOME}/.gem/credentials"
+
+push_log="${WORK_DIR}/gem-push.log"
+if gem push --host "$GEM_HOST" "${GEM_FILE}" > "$push_log" 2>&1; then
+  pass
+else
+  fail "gem push failed; tail: $(tail -n 10 "$push_log" | tr '\n' ' ')"
+fi
+
+# -----------------------------------------------------------------------
+# Pull the gem back with `gem fetch`.
+#
+# `gem fetch` downloads the .gem without installing it; we then diff
+# the file size with the pushed file. We do NOT install (which would
+# need the gem to compile on the runner pod and dilute the byte-
+# round-trip signal we want).
+# -----------------------------------------------------------------------
+
+begin_test "Pull gem with gem-fetch CLI"
+PULL_DIR="${WORK_DIR}/pull"
+mkdir -p "$PULL_DIR"
+cd "$PULL_DIR" || fail "cd to PULL_DIR failed"
+
+fetch_log="${WORK_DIR}/gem-fetch.log"
+if gem fetch "${GEM_NAME}" --version "${GEM_VERSION}" \
+    --source "$GEM_HOST" > "$fetch_log" 2>&1; then
+  PULLED_GEM=$(find . -maxdepth 1 -name "${GEM_NAME}-${GEM_VERSION}.gem" -print -quit)
+  if [ -n "$PULLED_GEM" ] && [ -s "$PULLED_GEM" ]; then
+    # Compare file sizes. Byte-level equality is too strict because
+    # the registry may re-pack the tar metadata (timestamps,
+    # checksums) without changing the wire-meaningful payload. Size
+    # is the practical assertion that the round-trip is intact.
+    pushed_size=$(wc -c < "$GEM_FILE" | tr -d ' ')
+    pulled_size=$(wc -c < "$PULLED_GEM" | tr -d ' ')
+    if [ "$pushed_size" = "$pulled_size" ]; then
+      pass
+    else
+      fail "size mismatch on round-trip: pushed=${pushed_size}, pulled=${pulled_size}"
+    fi
+  else
+    fail "gem fetch reported success but no .gem file in ${PULL_DIR}"
+  fi
+else
+  fail "gem fetch failed; tail: $(tail -n 10 "$fetch_log" | tr '\n' ' ')"
+fi
+
+# -----------------------------------------------------------------------
+# Verify the management API also lists the artifact (cross-protocol
+# correctness: the format-native push must register the artifact in
+# the management view, not be a write-only "shadow").
+# -----------------------------------------------------------------------
+
+begin_test "Management API lists the pushed gem"
+list_resp=$(api_get "/api/v1/repositories/${REPO_KEY}/artifacts" 2>/dev/null || echo "")
+if [ -z "$list_resp" ]; then
+  fail "could not list artifacts via management API"
+else
+  if echo "$list_resp" | grep -q "${GEM_NAME}"; then
+    pass
+  else
+    fail "pushed gem ${GEM_NAME} not visible in management API artifact list"
+  fi
+fi
+
+end_suite

--- a/tests/release-gate/chart-upgrade-smoke.sh
+++ b/tests/release-gate/chart-upgrade-smoke.sh
@@ -15,7 +15,20 @@
 #       --backend-tag <tag> \
 #       [--web-tag <tag>] \
 #       [--iac-ref <ref>] \
+#       [--previous-iac-ref <ref>] \
+#       [--same-chart] \
 #       [--timeout <seconds>]
+#
+# By default the script clones TWO copies of the iac repo: one at
+# `previous-iac-ref` (default `artifact-keeper-1.1.9`) and one at
+# `iac-ref` (default `main`). It `helm install`s from the previous
+# chart and `helm upgrade`s to the current chart. This is the only
+# way to catch chart-template breakage on upgrade, which is the
+# point of issue #54.
+#
+# Pass `--same-chart` to fall back to the old single-clone behaviour
+# (install and upgrade share one chart, only the image tag changes).
+# This is faster but skips chart-template upgrade coverage.
 #
 # Exit codes:
 #   0 - upgrade succeeded, state preserved, /readyz 200
@@ -31,6 +44,12 @@ PREVIOUS_TAG=""
 BACKEND_TAG=""
 WEB_TAG="dev"
 IAC_REF="main"
+# previous-iac-ref tracks the chart that shipped with the previous
+# release. Default matches PREVIOUS_TAG default in release-gate.yml.
+# Update this default in lockstep with the release pipeline's
+# PREVIOUS_TAG when cutting a new release.
+PREVIOUS_IAC_REF="artifact-keeper-1.1.9"
+SAME_CHART=false
 TIMEOUT_SECONDS=600
 
 CHART_TMPDIR=""
@@ -38,12 +57,14 @@ GHCR_CONFIG_FILE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --run-id)        RUN_ID="${2:-}"; shift 2 ;;
-    --previous-tag)  PREVIOUS_TAG="${2:-}"; shift 2 ;;
-    --backend-tag)   BACKEND_TAG="${2:-}"; shift 2 ;;
-    --web-tag)       WEB_TAG="${2:-}"; shift 2 ;;
-    --iac-ref)       IAC_REF="${2:-}"; shift 2 ;;
-    --timeout)       TIMEOUT_SECONDS="${2:-}"; shift 2 ;;
+    --run-id)            RUN_ID="${2:-}"; shift 2 ;;
+    --previous-tag)      PREVIOUS_TAG="${2:-}"; shift 2 ;;
+    --backend-tag)       BACKEND_TAG="${2:-}"; shift 2 ;;
+    --web-tag)           WEB_TAG="${2:-}"; shift 2 ;;
+    --iac-ref)           IAC_REF="${2:-}"; shift 2 ;;
+    --previous-iac-ref)  PREVIOUS_IAC_REF="${2:-}"; shift 2 ;;
+    --same-chart)        SAME_CHART=true; shift ;;
+    --timeout)           TIMEOUT_SECONDS="${2:-}"; shift 2 ;;
     *)
       echo "Unknown argument: $1" >&2
       exit 1
@@ -68,13 +89,18 @@ ADMIN_PASS="ChartUp!2026secure"
 
 echo "=================================================================="
 echo "Chart upgrade smoke (issue #54)"
-echo "  Namespace:        ${NAMESPACE}"
-echo "  Release:          ${RELEASE_NAME}"
-echo "  Previous tag:     ${PREVIOUS_TAG}"
-echo "  Current tag:      ${BACKEND_TAG}"
-echo "  Web tag:          ${WEB_TAG}"
-echo "  Timeout:          ${TIMEOUT_SECONDS}s"
-echo "  iac ref:          ${IAC_REF}"
+echo "  Namespace:           ${NAMESPACE}"
+echo "  Release:             ${RELEASE_NAME}"
+echo "  Previous tag:        ${PREVIOUS_TAG}"
+echo "  Current tag:         ${BACKEND_TAG}"
+echo "  Web tag:             ${WEB_TAG}"
+echo "  Timeout:             ${TIMEOUT_SECONDS}s"
+echo "  iac ref (current):   ${IAC_REF}"
+if [ "$SAME_CHART" = "true" ]; then
+  echo "  iac ref (previous):  (same as current, --same-chart)"
+else
+  echo "  iac ref (previous):  ${PREVIOUS_IAC_REF}"
+fi
 echo "=================================================================="
 
 # shellcheck disable=SC2329
@@ -106,24 +132,47 @@ cleanup() {
 trap cleanup EXIT
 
 # -----------------------------------------------------------------------
-# Resolve the iac chart. We use the same iac ref for both install and
-# upgrade: the chart-template change being validated is what the
-# release pipeline ships, not a hypothetical bisect across chart
-# refs. If a release ever needs to upgrade a chart from ref-A to
-# ref-B, that's a separate flow.
+# Resolve the iac chart(s).
+#
+# Default flow: clone TWO copies of the iac repo, one at the previous
+# ref and one at the current ref. This is what catches chart-template
+# breakage on upgrade (the actual point of issue #54). A regression
+# that lands in chart templates is invisible when both install and
+# upgrade use the same chart dir.
+#
+# --same-chart: clone once and use the current ref for both. Faster,
+# but only catches image-tag-level upgrade issues (e.g. the new
+# backend binary panicking on the previous DB schema).
 # -----------------------------------------------------------------------
 
 CHART_TMPDIR="$(mktemp -d)"
 echo ""
-echo "Cloning artifact-keeper-iac@${IAC_REF}"
+echo "Cloning artifact-keeper-iac@${IAC_REF} (current)"
 git clone --depth 1 --branch "$IAC_REF" \
   https://github.com/artifact-keeper/artifact-keeper-iac.git \
-  "$CHART_TMPDIR/iac"
-CHART_DIR="${CHART_TMPDIR}/iac/charts/artifact-keeper"
+  "$CHART_TMPDIR/iac-current"
+CURRENT_CHART_DIR="${CHART_TMPDIR}/iac-current/charts/artifact-keeper"
 
-if [ ! -f "${CHART_DIR}/Chart.yaml" ]; then
-  echo "ERROR: chart not found at ${CHART_DIR}" >&2
+if [ ! -f "${CURRENT_CHART_DIR}/Chart.yaml" ]; then
+  echo "ERROR: current chart not found at ${CURRENT_CHART_DIR}" >&2
   exit 1
+fi
+
+if [ "$SAME_CHART" = "true" ]; then
+  PREVIOUS_CHART_DIR="$CURRENT_CHART_DIR"
+  echo "  (--same-chart: reusing current chart for the install step)"
+else
+  echo "Cloning artifact-keeper-iac@${PREVIOUS_IAC_REF} (previous)"
+  git clone --depth 1 --branch "$PREVIOUS_IAC_REF" \
+    https://github.com/artifact-keeper/artifact-keeper-iac.git \
+    "$CHART_TMPDIR/iac-previous"
+  PREVIOUS_CHART_DIR="${CHART_TMPDIR}/iac-previous/charts/artifact-keeper"
+
+  if [ ! -f "${PREVIOUS_CHART_DIR}/Chart.yaml" ]; then
+    echo "ERROR: previous chart not found at ${PREVIOUS_CHART_DIR}" >&2
+    echo "       (tried ref '${PREVIOUS_IAC_REF}')" >&2
+    exit 1
+  fi
 fi
 
 # -----------------------------------------------------------------------
@@ -175,24 +224,33 @@ HELM_BASE_OVERRIDES=(
   --set 'opensearch.javaOpts=-Xms512m -Xmx512m'
   --set 'opensearch.resources.requests.memory=1Gi'
   --set 'opensearch.resources.limits.memory=1Gi'
-  --set 'meilisearch.masterKey=ak-upgrade-meilisearch-test-master-key'
 )
+# NOTE: meilisearch.masterKey was removed: the meilisearch subsystem
+# was deleted from the chart in iac PR #67 (squash-merged before
+# the artifact-keeper-1.1.9 tag). The chart accepts the --set
+# silently (helm tolerates unknown keys), but it was dead code.
 
 # -----------------------------------------------------------------------
 # Step 1: install the previous tag
 # -----------------------------------------------------------------------
 
-PROD_VALUES="${CHART_DIR}/values-production.yaml"
-if [ ! -f "$PROD_VALUES" ]; then
-  echo "ERROR: values-production.yaml not found at ${PROD_VALUES}" >&2
+PREVIOUS_PROD_VALUES="${PREVIOUS_CHART_DIR}/values-production.yaml"
+if [ ! -f "$PREVIOUS_PROD_VALUES" ]; then
+  echo "ERROR: values-production.yaml not found at ${PREVIOUS_PROD_VALUES}" >&2
+  exit 1
+fi
+
+CURRENT_PROD_VALUES="${CURRENT_CHART_DIR}/values-production.yaml"
+if [ ! -f "$CURRENT_PROD_VALUES" ]; then
+  echo "ERROR: values-production.yaml not found at ${CURRENT_PROD_VALUES}" >&2
   exit 1
 fi
 
 echo ""
-echo "Step 1: helm install previous tag ${PREVIOUS_TAG}"
-helm upgrade --install "$RELEASE_NAME" "$CHART_DIR" \
+echo "Step 1: helm install previous tag ${PREVIOUS_TAG} (chart from ${PREVIOUS_IAC_REF})"
+helm upgrade --install "$RELEASE_NAME" "$PREVIOUS_CHART_DIR" \
   --namespace "$NAMESPACE" \
-  --values "$PROD_VALUES" \
+  --values "$PREVIOUS_PROD_VALUES" \
   --set backend.image.tag="$PREVIOUS_TAG" \
   --set web.image.tag="$PREVIOUS_TAG" \
   "${HELM_BASE_OVERRIDES[@]}" \
@@ -262,6 +320,33 @@ stop_port_forward() {
   fi
 }
 
+# wait_for_port_forward LOCAL_PORT
+#
+# Waits up to 30 seconds for the local port to accept TCP, and bails
+# out early if the background port-forward process has died. Replaces
+# the fragile `kubectl port-forward & sleep 5` pattern that races
+# against bind on slow runners.
+wait_for_port_forward() {
+  local port="$1"
+  local i
+  for i in $(seq 1 30); do
+    # Bail if the bg process has exited.
+    if [ -n "$PORT_FORWARD_PID" ] && ! kill -0 "$PORT_FORWARD_PID" 2>/dev/null; then
+      echo "ERROR: kubectl port-forward exited prematurely" >&2
+      return 1
+    fi
+    # nc -z is the most portable TCP probe; fall back to /dev/tcp on
+    # systems without ncat (ARC runners ship busybox netcat but the
+    # /dev/tcp path is bash-native and always available).
+    if (echo >"/dev/tcp/127.0.0.1/${port}") 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ERROR: port-forward did not bind to 127.0.0.1:${port} within 30s" >&2
+  return 1
+}
+
 echo ""
 echo "Step 2: push artifact to establish state"
 
@@ -272,11 +357,13 @@ LOCAL_PORT="18080"
 kubectl port-forward -n "$NAMESPACE" "svc/ak-upgrade-backend" \
   "${LOCAL_PORT}:8080" >/tmp/upgrade-pf.log 2>&1 &
 PORT_FORWARD_PID=$!
-# Give port-forward time to bind. The first request after the bg
-# spawn races the listen.
-sleep 5
-
 trap "stop_port_forward; cleanup" EXIT
+# Block until the local port accepts TCP, instead of a blind sleep.
+# Fails fast (and emits the port-forward log) if the bg process dies.
+if ! wait_for_port_forward "$LOCAL_PORT"; then
+  tail -n 20 /tmp/upgrade-pf.log >&2 || true
+  exit 1
+fi
 
 BASE_URL="http://127.0.0.1:${LOCAL_PORT}"
 
@@ -352,10 +439,10 @@ stop_port_forward
 # -----------------------------------------------------------------------
 
 echo ""
-echo "Step 3: helm upgrade to ${BACKEND_TAG}"
-helm upgrade "$RELEASE_NAME" "$CHART_DIR" \
+echo "Step 3: helm upgrade to ${BACKEND_TAG} (chart from ${IAC_REF})"
+helm upgrade "$RELEASE_NAME" "$CURRENT_CHART_DIR" \
   --namespace "$NAMESPACE" \
-  --values "$PROD_VALUES" \
+  --values "$CURRENT_PROD_VALUES" \
   --set backend.image.tag="$BACKEND_TAG" \
   --set web.image.tag="$WEB_TAG" \
   "${HELM_BASE_OVERRIDES[@]}" \
@@ -439,7 +526,10 @@ echo "Step 5: verify pre-upgrade artifact survives"
 kubectl port-forward -n "$NAMESPACE" "svc/ak-upgrade-backend" \
   "${LOCAL_PORT}:8080" >/tmp/upgrade-pf2.log 2>&1 &
 PORT_FORWARD_PID=$!
-sleep 5
+if ! wait_for_port_forward "$LOCAL_PORT"; then
+  tail -n 20 /tmp/upgrade-pf2.log >&2 || true
+  exit 1
+fi
 
 pulled_body=$(curl -sf --max-time 15 \
   -u "${ADMIN_USER}:${ADMIN_PASS}" \

--- a/tests/release-gate/chart-upgrade-smoke.sh
+++ b/tests/release-gate/chart-upgrade-smoke.sh
@@ -1,0 +1,481 @@
+#!/usr/bin/env bash
+# chart-upgrade-smoke.sh - In-place chart upgrade smoke (issue #54)
+#
+# Installs the previous stable release tag, pushes a small artifact
+# through the management API to establish state, runs `helm upgrade`
+# to the current backend image, then asserts:
+#   - the upgrade completes within the timeout
+#   - the previously-pushed artifact is still retrievable
+#   - /readyz returns 200 (covers post-upgrade migration health)
+#
+# Usage:
+#   ./chart-upgrade-smoke.sh \
+#       --run-id <id> \
+#       --previous-tag <tag> \
+#       --backend-tag <tag> \
+#       [--web-tag <tag>] \
+#       [--iac-ref <ref>] \
+#       [--timeout <seconds>]
+#
+# Exit codes:
+#   0 - upgrade succeeded, state preserved, /readyz 200
+#   1 - usage / install / upgrade failed
+#   2 - rollout did not complete within timeout
+#   3 - /readyz did not return 200 after upgrade
+#   4 - artifact pushed before upgrade is no longer retrievable
+
+set -euo pipefail
+
+RUN_ID=""
+PREVIOUS_TAG=""
+BACKEND_TAG=""
+WEB_TAG="dev"
+IAC_REF="main"
+TIMEOUT_SECONDS=600
+
+CHART_TMPDIR=""
+GHCR_CONFIG_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-id)        RUN_ID="${2:-}"; shift 2 ;;
+    --previous-tag)  PREVIOUS_TAG="${2:-}"; shift 2 ;;
+    --backend-tag)   BACKEND_TAG="${2:-}"; shift 2 ;;
+    --web-tag)       WEB_TAG="${2:-}"; shift 2 ;;
+    --iac-ref)       IAC_REF="${2:-}"; shift 2 ;;
+    --timeout)       TIMEOUT_SECONDS="${2:-}"; shift 2 ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$RUN_ID" ] || [ -z "$BACKEND_TAG" ] || [ -z "$PREVIOUS_TAG" ]; then
+  echo "ERROR: --run-id, --backend-tag, --previous-tag are required" >&2
+  exit 1
+fi
+
+# Strip leading v if a caller passed a raw git tag. Docker tags drop
+# the prefix per CLAUDE.md "Docker tags use semver without v".
+PREVIOUS_TAG="${PREVIOUS_TAG#v}"
+BACKEND_TAG="${BACKEND_TAG#v}"
+
+NAMESPACE="smoke-upgrade-${RUN_ID}"
+RELEASE_NAME="ak-upgrade-${RUN_ID}"
+ADMIN_USER="admin"
+ADMIN_PASS="ChartUp!2026secure"
+
+echo "=================================================================="
+echo "Chart upgrade smoke (issue #54)"
+echo "  Namespace:        ${NAMESPACE}"
+echo "  Release:          ${RELEASE_NAME}"
+echo "  Previous tag:     ${PREVIOUS_TAG}"
+echo "  Current tag:      ${BACKEND_TAG}"
+echo "  Web tag:          ${WEB_TAG}"
+echo "  Timeout:          ${TIMEOUT_SECONDS}s"
+echo "  iac ref:          ${IAC_REF}"
+echo "=================================================================="
+
+# shellcheck disable=SC2329
+cleanup() {
+  local exit_code=$?
+  echo ""
+  echo "Teardown: removing ${NAMESPACE}"
+  if [ "$exit_code" -ne 0 ]; then
+    LOGS_DIR="/tmp/test-logs/upgrade-${RUN_ID}"
+    if mkdir -p "$LOGS_DIR" 2>/dev/null; then
+      kubectl get pods -n "$NAMESPACE" -o wide > "${LOGS_DIR}/pods.txt" 2>/dev/null || true
+      kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' \
+        > "${LOGS_DIR}/events.txt" 2>/dev/null || true
+      kubectl describe pods -n "$NAMESPACE" > "${LOGS_DIR}/describe.txt" 2>/dev/null || true
+      pods=$(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+      for pod in $pods; do
+        kubectl logs "$pod" -n "$NAMESPACE" --all-containers --tail=500 \
+          > "${LOGS_DIR}/${pod}.log" 2>/dev/null || true
+      done
+      echo "Diagnostics saved to ${LOGS_DIR}/"
+    fi
+  fi
+  helm uninstall "$RELEASE_NAME" --namespace "$NAMESPACE" --wait=false 2>/dev/null || true
+  kubectl delete namespace "$NAMESPACE" --wait=false 2>/dev/null || true
+  [ -n "$CHART_TMPDIR" ] && [ -d "$CHART_TMPDIR" ] && rm -rf "$CHART_TMPDIR" 2>/dev/null || true
+  [ -n "$GHCR_CONFIG_FILE" ] && [ -f "$GHCR_CONFIG_FILE" ] && rm -f "$GHCR_CONFIG_FILE" 2>/dev/null || true
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# -----------------------------------------------------------------------
+# Resolve the iac chart. We use the same iac ref for both install and
+# upgrade: the chart-template change being validated is what the
+# release pipeline ships, not a hypothetical bisect across chart
+# refs. If a release ever needs to upgrade a chart from ref-A to
+# ref-B, that's a separate flow.
+# -----------------------------------------------------------------------
+
+CHART_TMPDIR="$(mktemp -d)"
+echo ""
+echo "Cloning artifact-keeper-iac@${IAC_REF}"
+git clone --depth 1 --branch "$IAC_REF" \
+  https://github.com/artifact-keeper/artifact-keeper-iac.git \
+  "$CHART_TMPDIR/iac"
+CHART_DIR="${CHART_TMPDIR}/iac/charts/artifact-keeper"
+
+if [ ! -f "${CHART_DIR}/Chart.yaml" ]; then
+  echo "ERROR: chart not found at ${CHART_DIR}" >&2
+  exit 1
+fi
+
+# -----------------------------------------------------------------------
+# Namespace + GHCR secret
+# -----------------------------------------------------------------------
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+if [ -n "${GHCR_DOCKER_CONFIG:-}" ]; then
+  GHCR_CONFIG_FILE="$(mktemp)"
+  echo "$GHCR_DOCKER_CONFIG" | base64 -d > "$GHCR_CONFIG_FILE"
+  kubectl create secret generic ghcr-creds \
+    --namespace "$NAMESPACE" \
+    --type=kubernetes.io/dockerconfigjson \
+    --from-file=".dockerconfigjson=${GHCR_CONFIG_FILE}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+fi
+
+# -----------------------------------------------------------------------
+# Common helm overrides. Minimal, single-replica, in-cluster postgres.
+# Use the same shape as scripts/clean-install-smoke.sh so the upgrade
+# trajectory matches what we already exercise for fresh installs.
+# -----------------------------------------------------------------------
+
+HELM_BASE_OVERRIDES=(
+  --set fullnameOverride=ak-upgrade
+  --set "backend.env.ADMIN_PASSWORD=${ADMIN_PASS}"
+  --set backend.replicaCount=1
+  --set web.replicaCount=1
+  --set secrets.jwtSecret="upgrade-jwt-secret-not-for-production"
+  --set postgres.enabled=true
+  --set "postgres.auth.username=registry"
+  --set "postgres.auth.password=upgrade-db-password"
+  --set "postgres.auth.database=artifact_registry"
+  --set externalDatabase.host=""
+  --set externalDatabase.existingSecret=""
+  --set externalSecrets.enabled=false
+  --set ingress.enabled=false
+  --set serviceMonitor.enabled=false
+  --set "backend.autoscaling.enabled=false"
+  --set "backend.podDisruptionBudget.enabled=false"
+  --set "web.podDisruptionBudget.enabled=false"
+  --set edge.enabled=false
+  --set trivy.enabled=false
+  --set dependencyTrack.enabled=false
+  --set networkPolicy.enabled=false
+  --set opensearch.replicaCount=1
+  --set opensearch.persistence.enabled=false
+  --set 'opensearch.javaOpts=-Xms512m -Xmx512m'
+  --set 'opensearch.resources.requests.memory=1Gi'
+  --set 'opensearch.resources.limits.memory=1Gi'
+  --set 'meilisearch.masterKey=ak-upgrade-meilisearch-test-master-key'
+)
+
+# -----------------------------------------------------------------------
+# Step 1: install the previous tag
+# -----------------------------------------------------------------------
+
+PROD_VALUES="${CHART_DIR}/values-production.yaml"
+if [ ! -f "$PROD_VALUES" ]; then
+  echo "ERROR: values-production.yaml not found at ${PROD_VALUES}" >&2
+  exit 1
+fi
+
+echo ""
+echo "Step 1: helm install previous tag ${PREVIOUS_TAG}"
+helm upgrade --install "$RELEASE_NAME" "$CHART_DIR" \
+  --namespace "$NAMESPACE" \
+  --values "$PROD_VALUES" \
+  --set backend.image.tag="$PREVIOUS_TAG" \
+  --set web.image.tag="$PREVIOUS_TAG" \
+  "${HELM_BASE_OVERRIDES[@]}" \
+  --wait=false || {
+    echo "ERROR: helm install (previous tag) failed" >&2
+    exit 1
+  }
+
+echo "Waiting for backend rollout..."
+kubectl wait --for=condition=Available deployment/ak-upgrade-backend \
+  -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s" || exit 2
+kubectl wait --for=condition=Available deployment/ak-upgrade-web \
+  -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s" || exit 2
+
+# Probe /readyz to confirm the previous-tag stack is fully usable
+# before we put state into it.
+SERVICE_URL="http://ak-upgrade-backend.${NAMESPACE}.svc.cluster.local:8080"
+BACKEND_POD=$(kubectl get pods -n "$NAMESPACE" \
+  -l "app.kubernetes.io/component=backend" \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+if [ -z "$BACKEND_POD" ]; then
+  echo "ERROR: no backend pod found after install" >&2
+  exit 3
+fi
+
+probe_readyz() {
+  local timeout="${1:-180}"
+  local elapsed=0
+  while [ "$elapsed" -lt "$timeout" ]; do
+    if out=$(kubectl exec -n "$NAMESPACE" "$BACKEND_POD" -- \
+        sh -c "curl -fsS -o /dev/null -w '%{http_code}' --max-time 5 ${SERVICE_URL}/readyz \
+               || wget -q --timeout=5 -O - --server-response ${SERVICE_URL}/readyz 2>&1 \
+                  | grep -i 'HTTP/'" 2>&1); then
+      if echo "$out" | grep -qE '\b200\b'; then
+        return 0
+      fi
+    fi
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+  return 1
+}
+
+echo ""
+echo "Probing /readyz on previous-tag stack"
+if ! probe_readyz 180; then
+  echo "ERROR: /readyz did not return 200 on previous-tag stack" >&2
+  exit 3
+fi
+
+# -----------------------------------------------------------------------
+# Step 2: push state through the management API
+#
+# We use the generic artifact handler (POST /api/v1/repositories/.../upload)
+# rather than a format-native client to keep this script free of
+# format-tool installation. The goal is "did the upgrade preserve
+# state", not "did the npm protocol survive an upgrade". Format-
+# specific upgrade verification is a future enhancement.
+# -----------------------------------------------------------------------
+
+PORT_FORWARD_PID=""
+# shellcheck disable=SC2329
+stop_port_forward() {
+  if [ -n "$PORT_FORWARD_PID" ]; then
+    kill "$PORT_FORWARD_PID" 2>/dev/null || true
+    PORT_FORWARD_PID=""
+  fi
+}
+
+echo ""
+echo "Step 2: push artifact to establish state"
+
+# Port-forward to the backend so we can call the management API from
+# this runner. The 18080:8080 mapping avoids collision with whatever
+# other workflows on the same runner have bound to 8080.
+LOCAL_PORT="18080"
+kubectl port-forward -n "$NAMESPACE" "svc/ak-upgrade-backend" \
+  "${LOCAL_PORT}:8080" >/tmp/upgrade-pf.log 2>&1 &
+PORT_FORWARD_PID=$!
+# Give port-forward time to bind. The first request after the bg
+# spawn races the listen.
+sleep 5
+
+trap "stop_port_forward; cleanup" EXIT
+
+BASE_URL="http://127.0.0.1:${LOCAL_PORT}"
+
+# Auth as admin. Retry: the previous-tag backend just finished its
+# readyz check but may still settle the rate-limiter window for a
+# brief moment.
+TOKEN=""
+for i in 1 2 3 4 5; do
+  resp=$(curl -sf --max-time 10 \
+    -X POST "${BASE_URL}/api/v1/auth/login" \
+    -H "Content-Type: application/json" \
+    -d "{\"username\":\"${ADMIN_USER}\",\"password\":\"${ADMIN_PASS}\"}" \
+    2>/dev/null || echo "")
+  TOKEN=$(echo "$resp" | jq -r '.token // .access_token // empty' 2>/dev/null || echo "")
+  if [ -n "$TOKEN" ]; then
+    break
+  fi
+  echo "  auth attempt ${i}/5 failed, retrying..."
+  sleep 5
+done
+
+if [ -z "$TOKEN" ]; then
+  echo "ERROR: could not authenticate on previous-tag backend" >&2
+  exit 1
+fi
+
+REPO_KEY="upgrade-state-${RUN_ID}"
+ARTIFACT_NAME="upgrade-state.txt"
+ARTIFACT_BODY="hello from previous-tag at $(date -u +%FT%TZ)"
+
+# Create a generic repo
+curl -sf --max-time 15 \
+  -X POST "${BASE_URL}/api/v1/repositories" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"key\":\"${REPO_KEY}\",\"name\":\"${REPO_KEY}\",\"format\":\"generic\",\"repo_type\":\"local\",\"is_public\":true}" \
+  >/dev/null || {
+    echo "ERROR: could not create repository on previous-tag backend" >&2
+    exit 1
+  }
+
+# Push the artifact via the generic format endpoint
+PUSH_PATH="/generic/${REPO_KEY}/${ARTIFACT_NAME}"
+push_status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 \
+  -X PUT \
+  -u "${ADMIN_USER}:${ADMIN_PASS}" \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary "${ARTIFACT_BODY}" \
+  "${BASE_URL}${PUSH_PATH}" 2>/dev/null || echo "000")
+
+if [ "$push_status" != "200" ] && [ "$push_status" != "201" ] && [ "$push_status" != "204" ]; then
+  echo "ERROR: artifact push returned HTTP ${push_status}" >&2
+  exit 1
+fi
+echo "  pushed ${PUSH_PATH} (HTTP ${push_status})"
+
+# Sanity: confirm we can pull it before the upgrade (so a post-
+# upgrade failure indicates the upgrade, not the initial push).
+pulled_body=$(curl -sf --max-time 15 \
+  -u "${ADMIN_USER}:${ADMIN_PASS}" \
+  "${BASE_URL}${PUSH_PATH}" 2>/dev/null || echo "")
+if [ "$pulled_body" != "$ARTIFACT_BODY" ]; then
+  echo "ERROR: pre-upgrade pull did not match push body" >&2
+  echo "  expected: ${ARTIFACT_BODY}"
+  echo "  got:      ${pulled_body}"
+  exit 1
+fi
+
+stop_port_forward
+
+# -----------------------------------------------------------------------
+# Step 3: helm upgrade to the current tag
+# -----------------------------------------------------------------------
+
+echo ""
+echo "Step 3: helm upgrade to ${BACKEND_TAG}"
+helm upgrade "$RELEASE_NAME" "$CHART_DIR" \
+  --namespace "$NAMESPACE" \
+  --values "$PROD_VALUES" \
+  --set backend.image.tag="$BACKEND_TAG" \
+  --set web.image.tag="$WEB_TAG" \
+  "${HELM_BASE_OVERRIDES[@]}" \
+  --wait=false || {
+    echo "ERROR: helm upgrade failed" >&2
+    exit 1
+  }
+
+# Watch for any pod stuck in Pending for >30s (the #54 acceptance
+# criterion about resource that get re-created instead of preserved).
+echo ""
+echo "Watching for Pending pods >30s during upgrade window..."
+STUCK_AT=""
+WATCH_START=$(date +%s)
+WATCH_DEADLINE=$((WATCH_START + TIMEOUT_SECONDS))
+while [ "$(date +%s)" -lt "$WATCH_DEADLINE" ]; do
+  pending_pods=$(kubectl get pods -n "$NAMESPACE" \
+    --field-selector=status.phase=Pending \
+    -o jsonpath='{range .items[*]}{.metadata.name}{" "}{end}' 2>/dev/null || true)
+  if [ -z "$pending_pods" ]; then
+    STUCK_AT=""
+    # No pending pods; check rollout completion.
+    if kubectl rollout status deployment/ak-upgrade-backend \
+        -n "$NAMESPACE" --timeout=10s >/dev/null 2>&1; then
+      echo "  backend rollout completed"
+      break
+    fi
+  else
+    if [ -z "$STUCK_AT" ]; then
+      STUCK_AT=$(date +%s)
+      echo "  Pending pods first seen: ${pending_pods}"
+    else
+      now=$(date +%s)
+      if [ $((now - STUCK_AT)) -gt 30 ]; then
+        echo "ERROR: pods stayed Pending >30s during upgrade: ${pending_pods}" >&2
+        exit 2
+      fi
+    fi
+  fi
+  sleep 5
+done
+
+# Final rollout check (web + backend).
+kubectl wait --for=condition=Available deployment/ak-upgrade-backend \
+  -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s" || exit 2
+kubectl wait --for=condition=Available deployment/ak-upgrade-web \
+  -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s" || exit 2
+
+# -----------------------------------------------------------------------
+# Step 4: probe /readyz on the upgraded stack
+# -----------------------------------------------------------------------
+
+echo ""
+echo "Step 4: probe /readyz post-upgrade"
+# Re-resolve backend pod (rollout may have rotated it).
+BACKEND_POD=$(kubectl get pods -n "$NAMESPACE" \
+  -l "app.kubernetes.io/component=backend" \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+if [ -z "$BACKEND_POD" ]; then
+  echo "ERROR: no backend pod found after upgrade" >&2
+  exit 3
+fi
+
+if ! probe_readyz 180; then
+  echo "ERROR: /readyz did not return 200 after upgrade" >&2
+  exit 3
+fi
+
+# -----------------------------------------------------------------------
+# Step 5: confirm the artifact pushed at step 2 is still retrievable.
+#
+# This indirectly verifies:
+#   - DB migrations applied (artifact metadata table survived)
+#   - Storage path didn't change (the file blob is still where the
+#     backend looks for it)
+#   - The deserialization path for older rows still works
+# -----------------------------------------------------------------------
+
+echo ""
+echo "Step 5: verify pre-upgrade artifact survives"
+kubectl port-forward -n "$NAMESPACE" "svc/ak-upgrade-backend" \
+  "${LOCAL_PORT}:8080" >/tmp/upgrade-pf2.log 2>&1 &
+PORT_FORWARD_PID=$!
+sleep 5
+
+pulled_body=$(curl -sf --max-time 15 \
+  -u "${ADMIN_USER}:${ADMIN_PASS}" \
+  "${BASE_URL}${PUSH_PATH}" 2>/dev/null || echo "")
+if [ "$pulled_body" != "$ARTIFACT_BODY" ]; then
+  echo "ERROR: post-upgrade pull did not match pre-upgrade push body" >&2
+  echo "  expected: ${ARTIFACT_BODY}"
+  echo "  got:      ${pulled_body}"
+  exit 4
+fi
+echo "  pre-upgrade artifact still retrievable (state preserved)"
+
+# -----------------------------------------------------------------------
+# Step 6: confirm a migration-touched endpoint works
+#
+# /api/v1/health/details (or /health) returns a JSON payload that
+# depends on the latest schema (notably the migrations table being
+# queryable). If a migration failed mid-upgrade, this would 500.
+# -----------------------------------------------------------------------
+
+echo ""
+echo "Step 6: probe a schema-dependent endpoint"
+schema_status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+  -u "${ADMIN_USER}:${ADMIN_PASS}" \
+  "${BASE_URL}/api/v1/repositories" 2>/dev/null || echo "000")
+if [ "$schema_status" != "200" ]; then
+  echo "ERROR: /api/v1/repositories returned HTTP ${schema_status} (migration regression?)" >&2
+  exit 4
+fi
+echo "  /api/v1/repositories returns HTTP 200 (schema healthy)"
+
+stop_port_forward
+
+echo ""
+echo "=================================================================="
+echo "Chart upgrade smoke PASSED"
+echo "  Upgrade from ${PREVIOUS_TAG} to ${BACKEND_TAG} preserved state."
+echo "=================================================================="
+exit 0

--- a/tests/release-gate/clean-install-smoke-with-deps.sh
+++ b/tests/release-gate/clean-install-smoke-with-deps.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# clean-install-smoke-with-deps.sh - Full-stack clean-install smoke (issue #53)
+#
+# Variant of scripts/clean-install-smoke.sh that enables Trivy,
+# Dependency-Track, edge replication, ingress, and openSCAP. Catches
+# chart-wiring regressions in subsystems the basic smoke disables.
+#
+# Usage:
+#   ./clean-install-smoke-with-deps.sh \
+#       --run-id <id> \
+#       --backend-tag <tag> \
+#       [--web-tag <tag>] \
+#       [--iac-ref <ref>] \
+#       [--timeout <seconds>] \
+#       [--keep-namespace]
+#
+# Exit codes:
+#   0 - All Deployments + StatefulSets Ready, /readyz returned 200
+#   1 - Usage / helm install failed
+#   2 - Rollout did not complete within timeout
+#   3 - /readyz did not return 200 within timeout
+#   4 - At least one optional subsystem did not reach Ready
+
+set -euo pipefail
+
+RUN_ID=""
+BACKEND_TAG=""
+WEB_TAG="dev"
+IAC_REF="main"
+TIMEOUT_SECONDS=600
+KEEP_NAMESPACE=false
+
+CHART_TMPDIR=""
+GHCR_CONFIG_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-id)         RUN_ID="${2:-}"; shift 2 ;;
+    --backend-tag)    BACKEND_TAG="${2:-}"; shift 2 ;;
+    --web-tag)        WEB_TAG="${2:-}"; shift 2 ;;
+    --iac-ref)        IAC_REF="${2:-}"; shift 2 ;;
+    --timeout)        TIMEOUT_SECONDS="${2:-}"; shift 2 ;;
+    --keep-namespace) KEEP_NAMESPACE=true; shift ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$RUN_ID" ] || [ -z "$BACKEND_TAG" ]; then
+  echo "ERROR: --run-id and --backend-tag are required" >&2
+  exit 1
+fi
+
+NAMESPACE="smoke-deps-${RUN_ID}"
+RELEASE_NAME="ak-smoke-deps-${RUN_ID}"
+
+# Repo root: this script lives in tests/release-gate; go up two.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+VALUES_OVERLAY="${REPO_ROOT}/helm/values-smoke-with-deps.yaml"
+
+if [ ! -f "$VALUES_OVERLAY" ]; then
+  echo "ERROR: values overlay not found at ${VALUES_OVERLAY}" >&2
+  exit 1
+fi
+
+echo "=================================================================="
+echo "Clean-install smoke WITH dependencies (issue #53)"
+echo "  Namespace:    ${NAMESPACE}"
+echo "  Release:      ${RELEASE_NAME}"
+echo "  Backend tag:  ${BACKEND_TAG}"
+echo "  Web tag:      ${WEB_TAG}"
+echo "  Timeout:      ${TIMEOUT_SECONDS}s"
+echo "  iac ref:      ${IAC_REF}"
+echo "  Values:       ${VALUES_OVERLAY}"
+echo "=================================================================="
+
+# shellcheck disable=SC2329  # invoked via trap
+cleanup() {
+  local exit_code=$?
+  if [ "$KEEP_NAMESPACE" = "true" ]; then
+    echo ""
+    echo "Skipping teardown (--keep-namespace set). Namespace ${NAMESPACE} retained."
+    exit "$exit_code"
+  fi
+  echo ""
+  echo "Teardown: removing ${NAMESPACE}"
+  if [ "$exit_code" -ne 0 ]; then
+    LOGS_DIR="/tmp/test-logs/smoke-deps-${RUN_ID}"
+    if mkdir -p "$LOGS_DIR" 2>/dev/null; then
+      kubectl get pods -n "$NAMESPACE" -o wide > "${LOGS_DIR}/pods.txt" 2>/dev/null || true
+      kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' \
+        > "${LOGS_DIR}/events.txt" 2>/dev/null || true
+      pods=$(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+      for pod in $pods; do
+        kubectl logs "$pod" -n "$NAMESPACE" --all-containers --tail=500 \
+          > "${LOGS_DIR}/${pod}.log" 2>/dev/null || true
+      done
+      echo "Diagnostics saved to ${LOGS_DIR}/"
+    fi
+  fi
+  helm uninstall "$RELEASE_NAME" --namespace "$NAMESPACE" --wait=false 2>/dev/null || true
+  kubectl delete namespace "$NAMESPACE" --wait=false 2>/dev/null || true
+  [ -n "$CHART_TMPDIR" ] && [ -d "$CHART_TMPDIR" ] && rm -rf "$CHART_TMPDIR" 2>/dev/null || true
+  [ -n "$GHCR_CONFIG_FILE" ] && [ -f "$GHCR_CONFIG_FILE" ] && rm -f "$GHCR_CONFIG_FILE" 2>/dev/null || true
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# -----------------------------------------------------------------------
+# Resolve chart
+# -----------------------------------------------------------------------
+
+CHART_TMPDIR="$(mktemp -d)"
+echo "Cloning artifact-keeper-iac@${IAC_REF}"
+git clone --depth 1 --branch "$IAC_REF" \
+  https://github.com/artifact-keeper/artifact-keeper-iac.git \
+  "$CHART_TMPDIR/iac"
+CHART_DIR="${CHART_TMPDIR}/iac/charts/artifact-keeper"
+
+if [ ! -f "${CHART_DIR}/Chart.yaml" ]; then
+  echo "ERROR: chart not found at ${CHART_DIR}" >&2
+  exit 1
+fi
+
+# -----------------------------------------------------------------------
+# Namespace + GHCR secret
+# -----------------------------------------------------------------------
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+if [ -n "${GHCR_DOCKER_CONFIG:-}" ]; then
+  GHCR_CONFIG_FILE="$(mktemp)"
+  echo "$GHCR_DOCKER_CONFIG" | base64 -d > "$GHCR_CONFIG_FILE"
+  kubectl create secret generic ghcr-creds \
+    --namespace "$NAMESPACE" \
+    --type=kubernetes.io/dockerconfigjson \
+    --from-file=".dockerconfigjson=${GHCR_CONFIG_FILE}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+fi
+
+# -----------------------------------------------------------------------
+# Helm install with the with-deps overlay
+# -----------------------------------------------------------------------
+
+echo ""
+echo "Installing release ${RELEASE_NAME} with full deps"
+helm upgrade --install "$RELEASE_NAME" "$CHART_DIR" \
+  --namespace "$NAMESPACE" \
+  --values "$VALUES_OVERLAY" \
+  --set backend.image.tag="$BACKEND_TAG" \
+  --set web.image.tag="$WEB_TAG" \
+  --wait=false || {
+    echo "ERROR: helm install failed" >&2
+    exit 1
+  }
+
+# -----------------------------------------------------------------------
+# Wait for each optional subsystem
+#
+# We walk the expected deployment/statefulset list and rollout-wait
+# each. A specific subsystem timing out is more useful than a
+# generic "stack did not come up" message.
+# -----------------------------------------------------------------------
+
+EXPECTED_DEPLOYMENTS=(
+  "artifact-keeper-backend"
+  "artifact-keeper-web"
+  "artifact-keeper-trivy"
+  "artifact-keeper-edge"
+  "artifact-keeper-openscap"
+)
+
+# Some subsystems land as StatefulSet. Postgres, OpenSearch, DT.
+EXPECTED_STATEFULSETS=(
+  "artifact-keeper-postgres"
+  "artifact-keeper-opensearch"
+  "artifact-keeper-dependency-track"
+)
+
+failed_subsystems=()
+
+wait_for_workload_exists() {
+  local kind="$1"  # deployment or statefulset
+  local name="$2"
+  local timeout=60
+  local elapsed=0
+  while [ "$elapsed" -lt "$timeout" ]; do
+    if kubectl get "$kind" "$name" -n "$NAMESPACE" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+  return 1
+}
+
+for d in "${EXPECTED_DEPLOYMENTS[@]}"; do
+  echo ""
+  echo "Waiting for deployment/${d} to exist..."
+  if ! wait_for_workload_exists deployment "$d"; then
+    echo "  deployment/${d} did not appear (likely chart wiring regression for this subsystem)"
+    failed_subsystems+=("deployment/${d}:missing")
+    continue
+  fi
+  echo "Polling deployment/${d} rollout (timeout ${TIMEOUT_SECONDS}s)"
+  if ! kubectl rollout status "deployment/${d}" -n "$NAMESPACE" \
+        --timeout="${TIMEOUT_SECONDS}s"; then
+    failed_subsystems+=("deployment/${d}:not-ready")
+  fi
+done
+
+for s in "${EXPECTED_STATEFULSETS[@]}"; do
+  echo ""
+  echo "Waiting for statefulset/${s} to exist..."
+  if ! wait_for_workload_exists statefulset "$s"; then
+    echo "  statefulset/${s} did not appear"
+    failed_subsystems+=("statefulset/${s}:missing")
+    continue
+  fi
+  echo "Polling statefulset/${s} rollout (timeout ${TIMEOUT_SECONDS}s)"
+  if ! kubectl rollout status "statefulset/${s}" -n "$NAMESPACE" \
+        --timeout="${TIMEOUT_SECONDS}s"; then
+    failed_subsystems+=("statefulset/${s}:not-ready")
+  fi
+done
+
+# -----------------------------------------------------------------------
+# Ingress: verify the chart rendered the resource
+# -----------------------------------------------------------------------
+
+echo ""
+echo "Checking Ingress resource exists"
+if ! kubectl get ingress -n "$NAMESPACE" -o name 2>/dev/null | grep -q .; then
+  echo "  No Ingress resource found in ${NAMESPACE} (chart wiring regression?)"
+  failed_subsystems+=("ingress:missing")
+fi
+
+# -----------------------------------------------------------------------
+# Probe /readyz
+# -----------------------------------------------------------------------
+
+echo ""
+SERVICE_URL="http://artifact-keeper-backend.${NAMESPACE}.svc.cluster.local:8080"
+BACKEND_POD=$(kubectl get pods -n "$NAMESPACE" \
+  -l "app.kubernetes.io/component=backend" \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+
+if [ -n "$BACKEND_POD" ]; then
+  echo "Polling ${SERVICE_URL}/readyz from ${BACKEND_POD}"
+  ready_ok=false
+  elapsed=0
+  while [ "$elapsed" -lt 180 ]; do
+    if out=$(kubectl exec -n "$NAMESPACE" "$BACKEND_POD" -- \
+        sh -c "curl -fsS -o /dev/null -w '%{http_code}' --max-time 5 ${SERVICE_URL}/readyz \
+               || wget -q --timeout=5 -O - --server-response ${SERVICE_URL}/readyz 2>&1 \
+                  | grep -i 'HTTP/'" 2>&1); then
+      if echo "$out" | grep -qE '\b200\b'; then
+        ready_ok=true
+        break
+      fi
+    fi
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+  if ! $ready_ok; then
+    failed_subsystems+=("readyz:not-200")
+  fi
+else
+  failed_subsystems+=("readyz:no-backend-pod")
+fi
+
+# -----------------------------------------------------------------------
+# Final verdict
+# -----------------------------------------------------------------------
+
+echo ""
+echo "=================================================================="
+if [ "${#failed_subsystems[@]}" -eq 0 ]; then
+  echo "Clean-install smoke WITH deps PASSED"
+  echo "  All subsystems reached Ready and /readyz returned 200."
+  echo "=================================================================="
+  exit 0
+fi
+
+echo "Clean-install smoke WITH deps FAILED"
+echo ""
+echo "Failing subsystems:"
+for f in "${failed_subsystems[@]}"; do
+  echo "  - ${f}"
+done
+echo "=================================================================="
+exit 4

--- a/tests/release-gate/clean-install-smoke-with-deps.sh
+++ b/tests/release-gate/clean-install-smoke-with-deps.sh
@@ -2,8 +2,13 @@
 # clean-install-smoke-with-deps.sh - Full-stack clean-install smoke (issue #53)
 #
 # Variant of scripts/clean-install-smoke.sh that enables Trivy,
-# Dependency-Track, edge replication, ingress, and openSCAP. Catches
-# chart-wiring regressions in subsystems the basic smoke disables.
+# Dependency-Track, edge replication, and ingress. Catches chart-wiring
+# regressions in subsystems the basic smoke disables.
+#
+# OpenSCAP is intentionally NOT enabled here: the chart has no openscap
+# subsystem (verified 2026-05-14, see helm/values-smoke-with-deps.yaml
+# header comment). When the chart grows one, add it to the expected
+# deployments list and re-enable it in the overlay.
 #
 # Usage:
 #   ./clean-install-smoke-with-deps.sh \
@@ -165,19 +170,23 @@ helm upgrade --install "$RELEASE_NAME" "$CHART_DIR" \
 # generic "stack did not come up" message.
 # -----------------------------------------------------------------------
 
+# Resource shape verified via `helm template charts/artifact-keeper -f
+# helm/values-smoke-with-deps.yaml` against artifact-keeper-iac@main
+# on 2026-05-14. Single-replica OpenSearch renders as a Deployment
+# (Recreate strategy), Postgres alone is a StatefulSet, DependencyTrack
+# is named `dtrack` not `dependency-track`, and the chart has no
+# openscap subsystem (see overlay header comment).
 EXPECTED_DEPLOYMENTS=(
   "artifact-keeper-backend"
   "artifact-keeper-web"
   "artifact-keeper-trivy"
+  "artifact-keeper-dtrack"
   "artifact-keeper-edge"
-  "artifact-keeper-openscap"
+  "artifact-keeper-opensearch"
 )
 
-# Some subsystems land as StatefulSet. Postgres, OpenSearch, DT.
 EXPECTED_STATEFULSETS=(
   "artifact-keeper-postgres"
-  "artifact-keeper-opensearch"
-  "artifact-keeper-dependency-track"
 )
 
 failed_subsystems=()

--- a/tests/release-gate/test-real-flow-smoke.sh
+++ b/tests/release-gate/test-real-flow-smoke.sh
@@ -17,10 +17,17 @@
 #   2. Create a local npm repository via the management API
 #   3. Publish a tarball through `npm publish` (real client wire format)
 #   4. Pull the tarball through `npm pack <name>@<version>`
-#   5. Diff the published and pulled tarballs
-#   6. POST /api/v1/security/artifacts/{id}/rescan to trigger a scan
-#   7. Poll the scan endpoint until completion or 60s timeout
-#   8. Assert scan status is `completed`/`clean` and findings_count is numeric
+#   5. Look up the artifact's UUID via GET /api/v1/repositories/{key}/artifacts
+#   6. POST /api/v1/security/scan with {artifact_id, force:true}
+#   7. Poll GET /api/v1/security/artifacts/{id}/scans until terminal status (completed/failed) or 60s timeout
+#   8. Assert scan status is `completed` and findings_count is numeric
+#
+# Backend route sources of truth (verified against
+# artifact-keeper/backend/src/api/handlers/security.rs at this branch):
+#   - trigger_scan       POST /api/v1/security/scan         (line ~474)
+#   - list_artifact_scans GET /api/v1/security/artifacts/{artifact_id}/scans  (line ~920)
+#   - list_artifacts     GET /api/v1/repositories/{key}/artifacts  (handlers/repositories.rs ~1172)
+# artifact_id is a Uuid, not an integer.
 #
 # Exit codes:
 #   0 - All steps passed
@@ -152,97 +159,124 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# 5. Trigger a scan
+# 5. Resolve the artifact's UUID
 #
-# Use the security rescan endpoint. The artifact id (or path) is
-# what the policy gate keys against. The backend exposes a few
-# variants of the rescan path across 1.1.x/1.2.x; the management
-# artifact-path form has been stable since 1.1.6.
-#
-# We POST and accept 200/202 as success: 202 means "queued",
-# the poll below settles the final state.
+# The scan trigger endpoint keys against artifact_id (a Uuid),
+# not the repo-key + path tuple. We look it up via the repo's
+# artifact listing endpoint. The path npm published lives under
+# `<name>/-/<name>-<version>.tgz` for scoped-package layout.
 # -------------------------------------------------------------------------
 
-begin_test "Trigger scan via rescan endpoint"
+begin_test "Resolve artifact UUID via repository listing"
 ARTIFACT_PATH="${PKG_NAME}/-/${PKG_NAME}-${PKG_VERSION}.tgz"
-rescan_status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
-  -X POST \
-  -H "$(auth_header)" \
-  -H "Content-Type: application/json" \
-  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/${ARTIFACT_PATH}/security/rescan" \
-  2>/dev/null || echo "000")
-
-if [ "$rescan_status" = "200" ] || [ "$rescan_status" = "202" ] || [ "$rescan_status" = "204" ]; then
-  pass
-elif [ "$rescan_status" = "404" ]; then
-  # Older backends expose the rescan path under /artifacts/scan/rescan.
-  # Try the fallback before reporting failure.
-  fallback_status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
-    -X POST \
-    -H "$(auth_header)" \
-    -H "Content-Type: application/json" \
-    "${BASE_URL}/api/v1/security/artifacts/${REPO_KEY}/${ARTIFACT_PATH}/rescan" \
-    2>/dev/null || echo "000")
-  if [ "$fallback_status" = "200" ] || [ "$fallback_status" = "202" ] || [ "$fallback_status" = "204" ]; then
-    pass
-  else
-    fail "rescan endpoint returned ${rescan_status} (primary) / ${fallback_status} (fallback)"
+ARTIFACT_ID=""
+# Poll briefly: npm publish returns when the index update commits,
+# but the artifact row may take a beat to appear in the listing.
+for _ in 1 2 3 4 5; do
+  list_resp=$(curl -s --max-time 15 -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts?per_page=100" \
+    2>/dev/null || echo "{}")
+  ARTIFACT_ID=$(echo "$list_resp" | jq -r --arg p "$ARTIFACT_PATH" \
+    '.items[]? | select(.path == $p) | .id' 2>/dev/null | head -n1)
+  if [ -n "$ARTIFACT_ID" ] && [ "$ARTIFACT_ID" != "null" ]; then
+    break
   fi
+  sleep 2
+done
+
+if [ -z "$ARTIFACT_ID" ] || [ "$ARTIFACT_ID" = "null" ]; then
+  fail "could not resolve artifact UUID for path ${ARTIFACT_PATH}; resp: $(echo "$list_resp" | head -c 300)"
 else
-  fail "rescan endpoint returned HTTP ${rescan_status}"
+  echo "  artifact_id: ${ARTIFACT_ID}"
+  pass
 fi
 
 # -------------------------------------------------------------------------
-# 6. Poll scan status until completion or timeout
+# 6. Trigger a scan
 #
-# wait_for_scan already handles polling. Use it to drive the state
-# transition rather than reinventing the loop. 60s matches the
-# acceptance criteria in #45.
+# POST /api/v1/security/scan with {artifact_id, force:true}.
+# Verified against backend handler `trigger_scan` in
+# backend/src/api/handlers/security.rs line ~474.
+#
+# The handler returns 200 with `{message, artifacts_queued}` and
+# spawns the scan in a background task. There is no 202: the queue-
+# vs-finish split is handled by polling the scans endpoint below.
+# -------------------------------------------------------------------------
+
+begin_test "Trigger scan via POST /api/v1/security/scan"
+trigger_body=$(jq -n --arg id "$ARTIFACT_ID" '{artifact_id: $id, force: true}')
+trigger_status=$(curl -s -o /tmp/rfs-trigger-resp.json -w '%{http_code}' --max-time 15 \
+  -X POST \
+  -H "$(auth_header)" \
+  -H "Content-Type: application/json" \
+  -d "$trigger_body" \
+  "${BASE_URL}/api/v1/security/scan" \
+  2>/dev/null || echo "000")
+
+if [ "$trigger_status" = "200" ]; then
+  pass
+else
+  trigger_resp=$(head -c 300 /tmp/rfs-trigger-resp.json 2>/dev/null || echo "")
+  fail "POST /api/v1/security/scan returned HTTP ${trigger_status}; body: ${trigger_resp}"
+fi
+
+# -------------------------------------------------------------------------
+# 7. Poll scan status until completion or timeout
+#
+# GET /api/v1/security/artifacts/{artifact_id}/scans returns a
+# ScanListResponse {items, total}. The most recent scan is the
+# first item (the service sorts by created_at desc). Terminal
+# statuses are `completed` and `failed`. `pending` and `scanning`
+# are in-flight.
 # -------------------------------------------------------------------------
 
 begin_test "Scan reaches a terminal state within 60s"
 final_status=""
-if final_status=$(wait_for_scan "$REPO_KEY" "$ARTIFACT_PATH" 60); then
-  echo "  scan terminal status: ${final_status}"
-  # Acceptance: 'completed' or 'clean' is success. 'failed' on the
-  # scanner-side is still a terminal state we report so the operator
-  # can see the actual error class in the logs, but it's a fail for
-  # the gate.
-  if [ "$final_status" = "completed" ] || [ "$final_status" = "clean" ]; then
-    pass
-  else
-    fail "scan finished with status='${final_status}', expected 'completed' or 'clean'"
+elapsed=0
+LATEST_SCAN_JSON=""
+while [ "$elapsed" -lt 60 ]; do
+  scans_resp=$(curl -s --max-time 15 -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/security/artifacts/${ARTIFACT_ID}/scans?per_page=5" \
+    2>/dev/null || echo "{}")
+  # Pick the most recent scan (the handler returns items in
+  # descending created_at order; tolerate either field name in case
+  # the backend re-orders later).
+  LATEST_SCAN_JSON=$(echo "$scans_resp" | jq -c '.items[0] // empty' 2>/dev/null || echo "")
+  if [ -n "$LATEST_SCAN_JSON" ]; then
+    final_status=$(echo "$LATEST_SCAN_JSON" | jq -r '.status // "unknown"')
+    if [ "$final_status" = "completed" ] || [ "$final_status" = "failed" ]; then
+      break
+    fi
   fi
+  sleep 3
+  elapsed=$(( elapsed + 3 ))
+done
+
+echo "  scan terminal status: ${final_status:-unknown}"
+if [ "$final_status" = "completed" ]; then
+  pass
+elif [ "$final_status" = "failed" ]; then
+  err_msg=$(echo "$LATEST_SCAN_JSON" | jq -r '.error_message // "(none)"')
+  fail "scan ended with status='failed', error_message: ${err_msg}"
 else
   fail "scan did not reach a terminal state within 60s (last status: ${final_status:-unknown})"
 fi
 
 # -------------------------------------------------------------------------
-# 7. findings_count is a number (any value)
+# 8. findings_count is a number (any value)
 #
 # The acceptance criteria in #45 is "findings_count is a number (any
 # value)", not "non-zero". The npm tarball we built is a trivial
 # package with no vulnerable deps; expecting findings would flap.
-# What we DO want to assert is that the scan emitted a usable
-# response shape and the count field is numeric.
+# Backend ScanResponse always emits findings_count (i32) per
+# security.rs:125, so the field MUST be a number on a healthy backend.
 # -------------------------------------------------------------------------
 
 begin_test "Scan response includes a numeric findings_count"
-scan_resp=$(curl -s --max-time 15 -H "$(auth_header)" \
-  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/${ARTIFACT_PATH}/security/scan" \
-  2>/dev/null || echo "{}")
-
-# The 1.1.x backend reports `.findings | length`, 1.2.x adds an
-# explicit `.findings_count`. Tolerate both.
-findings_count=$(echo "$scan_resp" | jq '
-  if .findings_count != null then .findings_count
-  elif .findings != null then (.findings | length)
-  else null
-  end
-' 2>/dev/null || echo "null")
+findings_count=$(echo "$LATEST_SCAN_JSON" | jq -r '.findings_count // "null"' 2>/dev/null || echo "null")
 
 if [ "$findings_count" = "null" ] || [ -z "$findings_count" ]; then
-  fail "scan response has no findings_count or findings field; resp: $(echo "$scan_resp" | head -c 300)"
+  fail "scan response has no findings_count field; resp: $(echo "$LATEST_SCAN_JSON" | head -c 300)"
 elif [[ "$findings_count" =~ ^[0-9]+$ ]]; then
   echo "  findings_count: ${findings_count}"
   pass

--- a/tests/release-gate/test-real-flow-smoke.sh
+++ b/tests/release-gate/test-real-flow-smoke.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# test-real-flow-smoke.sh - Real artifact push, pull, and scan end-to-end.
+#
+# This is the user's actual flow as a single gate check: helm install,
+# push an artifact through a native client, pull it back, trigger a
+# scan, poll until completion. Regressions in any step fail the release
+# gate before the broader matrix even runs.
+#
+# Why npm rather than maven (the issue's example): the runner pods ship
+# node + npm out of the box (system-packages batch in format-tests
+# already exercises that). Maven would add ~120s of apt-get install and
+# an HTTPS dance against a private maven settings.xml on every run.
+# We picked npm so the gate stays under the 5-minute target in #45.
+#
+# Steps:
+#   1. Confirm backend is reachable (wait-for-ready.sh)
+#   2. Create a local npm repository via the management API
+#   3. Publish a tarball through `npm publish` (real client wire format)
+#   4. Pull the tarball through `npm pack <name>@<version>`
+#   5. Diff the published and pulled tarballs
+#   6. POST /api/v1/security/artifacts/{id}/rescan to trigger a scan
+#   7. Poll the scan endpoint until completion or 60s timeout
+#   8. Assert scan status is `completed`/`clean` and findings_count is numeric
+#
+# Exit codes:
+#   0 - All steps passed
+#   non-zero - Any step failed; end_suite emits the final outcome
+#
+# Required env:
+#   BASE_URL   - Backend service URL (set by the workflow's needs.deploy.outputs)
+#   ADMIN_PASS - Bootstrap admin password (defaults to common.sh value)
+#   RUN_ID     - Unique run identifier so the repo key doesn't collide
+
+# shellcheck source=../lib/common.sh disable=SC1091
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "real-flow-smoke"
+auth_admin
+setup_workdir
+require_cmd npm
+require_cmd jq
+
+REPO_KEY="rfs-${RUN_ID}"
+PKG_NAME="rfs-pkg-${RUN_ID//[^a-z0-9]/}"
+# npm package names must be lower-case; trim again in case RUN_ID has caps.
+PKG_NAME=$(echo "$PKG_NAME" | tr '[:upper:]' '[:lower:]')
+PKG_VERSION="1.0.$(date +%s)"
+NPM_REGISTRY="${BASE_URL}/npm/${REPO_KEY}/"
+
+# -------------------------------------------------------------------------
+# 1. Backend reachability gate
+#
+# auth_admin already exercised /readyz (or /health), but we re-check
+# /health here so a flaky backend at the moment of suite-start surfaces
+# as a clear "backend unreachable" message rather than a downstream
+# 500 on the first management-API call.
+# -------------------------------------------------------------------------
+
+begin_test "Backend health probe"
+health_status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "${BASE_URL}/health" 2>/dev/null || echo "000")
+if [ "$health_status" = "200" ]; then
+  pass
+else
+  fail "GET ${BASE_URL}/health returned HTTP ${health_status}"
+fi
+
+# -------------------------------------------------------------------------
+# 2. Create the target repository
+# -------------------------------------------------------------------------
+
+begin_test "Create npm local repository"
+if create_local_repo "$REPO_KEY" "npm"; then
+  pass
+else
+  fail "could not create npm repository ${REPO_KEY}"
+fi
+
+# -------------------------------------------------------------------------
+# 3. Build the package and configure npm with both auth modes
+#
+# Same dual-auth shape used by test-npm.sh: some npm client versions
+# emit _auth (basic), others emit _authToken (bearer). The backend
+# accepts both. Writing both keeps this test stable across runner
+# image upgrades.
+# -------------------------------------------------------------------------
+
+begin_test "Publish package with npm"
+cd "$WORK_DIR" || fail "cd to WORK_DIR failed"
+mkdir -p pkg-src
+cd pkg-src || fail "cd to pkg-src failed"
+
+cat > package.json <<EOF
+{
+  "name": "${PKG_NAME}",
+  "version": "${PKG_VERSION}",
+  "description": "Release-gate real-flow smoke package",
+  "main": "index.js",
+  "license": "MIT"
+}
+EOF
+
+cat > index.js <<EOF
+module.exports = { version: "${PKG_VERSION}" };
+EOF
+
+AUTH_B64=$(printf '%s:%s' "${ADMIN_USER}" "${ADMIN_PASS}" | base64)
+REGISTRY_HOST=$(echo "$NPM_REGISTRY" | sed -E 's|https?:||')
+REGISTRY_HOST_NOSLASH="${REGISTRY_HOST%/}"
+
+cat > .npmrc <<EOF
+registry=${NPM_REGISTRY}
+${REGISTRY_HOST_NOSLASH}/:_auth=${AUTH_B64}
+${REGISTRY_HOST_NOSLASH}/:_authToken=${AUTH_B64}
+${REGISTRY_HOST}:_auth=${AUTH_B64}
+${REGISTRY_HOST}:_authToken=${AUTH_B64}
+always-auth=true
+EOF
+
+publish_log="${WORK_DIR}/npm-publish.log"
+if npm publish --registry "$NPM_REGISTRY" > "$publish_log" 2>&1; then
+  pass
+else
+  fail "npm publish failed; tail: $(tail -n 10 "$publish_log" | tr '\n' ' ')"
+fi
+
+# -------------------------------------------------------------------------
+# 4. Pull the artifact back
+#
+# `npm pack` against the same registry downloads the tarball without
+# evaluating package scripts, so it's the safest equivalent of a real
+# `npm install` for byte-level round-trip assertions.
+# -------------------------------------------------------------------------
+
+begin_test "Pull package with npm pack"
+PULL_DIR="${WORK_DIR}/pull"
+mkdir -p "$PULL_DIR"
+cd "$PULL_DIR" || fail "cd to PULL_DIR failed"
+# Reuse the same .npmrc so auth flows through.
+cp "${WORK_DIR}/pkg-src/.npmrc" .
+
+pack_log="${WORK_DIR}/npm-pack.log"
+if npm pack "${PKG_NAME}@${PKG_VERSION}" \
+    --registry "$NPM_REGISTRY" > "$pack_log" 2>&1; then
+  PULLED_TARBALL=$(find . -maxdepth 1 -name "${PKG_NAME}-*.tgz" -print -quit)
+  if [ -n "$PULLED_TARBALL" ] && [ -s "$PULLED_TARBALL" ]; then
+    pass
+  else
+    fail "npm pack reported success but no tarball was written (log: $(tail -n 5 "$pack_log" | tr '\n' ' '))"
+  fi
+else
+  fail "npm pack failed; tail: $(tail -n 10 "$pack_log" | tr '\n' ' ')"
+fi
+
+# -------------------------------------------------------------------------
+# 5. Trigger a scan
+#
+# Use the security rescan endpoint. The artifact id (or path) is
+# what the policy gate keys against. The backend exposes a few
+# variants of the rescan path across 1.1.x/1.2.x; the management
+# artifact-path form has been stable since 1.1.6.
+#
+# We POST and accept 200/202 as success: 202 means "queued",
+# the poll below settles the final state.
+# -------------------------------------------------------------------------
+
+begin_test "Trigger scan via rescan endpoint"
+ARTIFACT_PATH="${PKG_NAME}/-/${PKG_NAME}-${PKG_VERSION}.tgz"
+rescan_status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
+  -X POST \
+  -H "$(auth_header)" \
+  -H "Content-Type: application/json" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/${ARTIFACT_PATH}/security/rescan" \
+  2>/dev/null || echo "000")
+
+if [ "$rescan_status" = "200" ] || [ "$rescan_status" = "202" ] || [ "$rescan_status" = "204" ]; then
+  pass
+elif [ "$rescan_status" = "404" ]; then
+  # Older backends expose the rescan path under /artifacts/scan/rescan.
+  # Try the fallback before reporting failure.
+  fallback_status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
+    -X POST \
+    -H "$(auth_header)" \
+    -H "Content-Type: application/json" \
+    "${BASE_URL}/api/v1/security/artifacts/${REPO_KEY}/${ARTIFACT_PATH}/rescan" \
+    2>/dev/null || echo "000")
+  if [ "$fallback_status" = "200" ] || [ "$fallback_status" = "202" ] || [ "$fallback_status" = "204" ]; then
+    pass
+  else
+    fail "rescan endpoint returned ${rescan_status} (primary) / ${fallback_status} (fallback)"
+  fi
+else
+  fail "rescan endpoint returned HTTP ${rescan_status}"
+fi
+
+# -------------------------------------------------------------------------
+# 6. Poll scan status until completion or timeout
+#
+# wait_for_scan already handles polling. Use it to drive the state
+# transition rather than reinventing the loop. 60s matches the
+# acceptance criteria in #45.
+# -------------------------------------------------------------------------
+
+begin_test "Scan reaches a terminal state within 60s"
+final_status=""
+if final_status=$(wait_for_scan "$REPO_KEY" "$ARTIFACT_PATH" 60); then
+  echo "  scan terminal status: ${final_status}"
+  # Acceptance: 'completed' or 'clean' is success. 'failed' on the
+  # scanner-side is still a terminal state we report so the operator
+  # can see the actual error class in the logs, but it's a fail for
+  # the gate.
+  if [ "$final_status" = "completed" ] || [ "$final_status" = "clean" ]; then
+    pass
+  else
+    fail "scan finished with status='${final_status}', expected 'completed' or 'clean'"
+  fi
+else
+  fail "scan did not reach a terminal state within 60s (last status: ${final_status:-unknown})"
+fi
+
+# -------------------------------------------------------------------------
+# 7. findings_count is a number (any value)
+#
+# The acceptance criteria in #45 is "findings_count is a number (any
+# value)", not "non-zero". The npm tarball we built is a trivial
+# package with no vulnerable deps; expecting findings would flap.
+# What we DO want to assert is that the scan emitted a usable
+# response shape and the count field is numeric.
+# -------------------------------------------------------------------------
+
+begin_test "Scan response includes a numeric findings_count"
+scan_resp=$(curl -s --max-time 15 -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/${ARTIFACT_PATH}/security/scan" \
+  2>/dev/null || echo "{}")
+
+# The 1.1.x backend reports `.findings | length`, 1.2.x adds an
+# explicit `.findings_count`. Tolerate both.
+findings_count=$(echo "$scan_resp" | jq '
+  if .findings_count != null then .findings_count
+  elif .findings != null then (.findings | length)
+  else null
+  end
+' 2>/dev/null || echo "null")
+
+if [ "$findings_count" = "null" ] || [ -z "$findings_count" ]; then
+  fail "scan response has no findings_count or findings field; resp: $(echo "$scan_resp" | head -c 300)"
+elif [[ "$findings_count" =~ ^[0-9]+$ ]]; then
+  echo "  findings_count: ${findings_count}"
+  pass
+else
+  fail "findings_count is not numeric: '${findings_count}'"
+fi
+
+end_suite

--- a/tests/release-gate/verify-image-set.sh
+++ b/tests/release-gate/verify-image-set.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# verify-image-set.sh - Confirm every image in the release set exists on ghcr.io
+#
+# Usage:
+#   ./verify-image-set.sh \
+#       --backend-tag <tag> \
+#       --web-tag <tag> \
+#       --openscap-tag <tag>
+#
+# Probes the GHCR registry's manifest endpoint for each image at the
+# specified tag. A missing tag fails fast with a clear error. Catches
+# the structural failure behind:
+#   - artifact-keeper#872 (chart tagged but referenced images absent)
+#   - artifact-keeper#905 (versioned tags missing on ghcr.io)
+#   - artifact-keeper-web#320 (v1.1.8 web image never published)
+#
+# We use the OCI Registry HTTP API v2 directly (HEAD against
+# /v2/<name>/manifests/<tag>) rather than `crane manifest` or
+# `docker manifest inspect`. Rationale:
+#   * Zero binary install in CI; only depends on `curl`.
+#   * Works against public-anon ghcr.io with a `Bearer` exchange
+#     against ghcr.io/token, which we do inline. The token exchange
+#     for public repos returns an unscoped token without credentials.
+#   * Tolerates schema 1 and schema 2 manifests (we just need a 200).
+#
+# Exit codes:
+#   0 - All images exist at their tags
+#   1 - Usage error
+#   2 - At least one image is missing
+#
+# Required env: none. Optional: GHCR_REGISTRY (default ghcr.io),
+#               GHCR_NAMESPACE (default artifact-keeper).
+
+set -euo pipefail
+
+BACKEND_TAG=""
+WEB_TAG=""
+OPENSCAP_TAG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --backend-tag)  BACKEND_TAG="${2:-}"; shift 2 ;;
+    --web-tag)      WEB_TAG="${2:-}"; shift 2 ;;
+    --openscap-tag) OPENSCAP_TAG="${2:-}"; shift 2 ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: verify-image-set.sh --backend-tag <tag> --web-tag <tag> --openscap-tag <tag>" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$BACKEND_TAG" ] || [ -z "$WEB_TAG" ] || [ -z "$OPENSCAP_TAG" ]; then
+  echo "ERROR: --backend-tag, --web-tag, --openscap-tag are all required" >&2
+  exit 1
+fi
+
+REGISTRY="${GHCR_REGISTRY:-ghcr.io}"
+NAMESPACE="${GHCR_NAMESPACE:-artifact-keeper}"
+
+# GHCR docker images live at <namespace>/<image-name>. The web image
+# is published under artifact-keeper-web, the backend under
+# artifact-keeper-backend, the openscap helper under
+# artifact-keeper-openscap. These names ARE the source of truth: the
+# org's CI publishes to these exact paths.
+#
+# Strip the leading 'v' if a workflow input passed a raw git tag
+# (e.g. v1.1.9). Docker tags drop the prefix per CLAUDE.md "Docker
+# tags use semver without v" convention.
+_strip_v() { echo "${1#v}"; }
+
+BACKEND_TAG_NORM=$(_strip_v "$BACKEND_TAG")
+WEB_TAG_NORM=$(_strip_v "$WEB_TAG")
+OPENSCAP_TAG_NORM=$(_strip_v "$OPENSCAP_TAG")
+
+LOG_DIR="/tmp"
+LOG_FILE="${LOG_DIR}/version-set-${RANDOM}.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+echo "=================================================================="
+echo "Version-set integrity check"
+echo "  Registry:      ${REGISTRY}"
+echo "  Namespace:     ${NAMESPACE}"
+echo "  Backend tag:   ${BACKEND_TAG_NORM}"
+echo "  Web tag:       ${WEB_TAG_NORM}"
+echo "  Openscap tag:  ${OPENSCAP_TAG_NORM}"
+echo "=================================================================="
+
+# -----------------------------------------------------------------------
+# probe_image <image-name> <tag>
+#
+# Returns 0 if the manifest exists, non-zero otherwise. Echoes a
+# human-readable status line in either case.
+#
+# GHCR requires a Bearer token even for anonymous reads of public
+# images. The token endpoint accepts unauthenticated requests for
+# pull scope on public images and returns a short-lived token.
+# Token URL shape: https://ghcr.io/token?scope=repository:<name>:pull
+# -----------------------------------------------------------------------
+probe_image() {
+  local image="$1"
+  local tag="$2"
+  local image_path="${NAMESPACE}/${image}"
+  local token_url="https://${REGISTRY}/token?scope=repository:${image_path}:pull"
+  local manifest_url="https://${REGISTRY}/v2/${image_path}/manifests/${tag}"
+
+  echo ""
+  echo "Probing ${image_path}:${tag}"
+
+  local token
+  token=$(curl -sf --max-time 15 "$token_url" 2>/dev/null \
+    | jq -r '.token // .access_token // empty' 2>/dev/null) || true
+
+  if [ -z "$token" ]; then
+    echo "  ERROR: could not obtain pull token from ${token_url}"
+    return 1
+  fi
+
+  # Use HEAD so we don't pull the manifest body. Accept both the OCI
+  # and Docker manifest media types so we don't false-fail on a 404
+  # when the server only serves one variant for our Accept header.
+  # OCI image index (manifest list) is also valid, so include that.
+  local accept_hdr="application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json"
+  local status
+  status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
+    -I \
+    -H "Authorization: Bearer ${token}" \
+    -H "Accept: ${accept_hdr}" \
+    "$manifest_url" 2>/dev/null || echo "000")
+
+  if [ "$status" = "200" ]; then
+    echo "  OK: ${image_path}:${tag} (HTTP 200)"
+    return 0
+  fi
+
+  # A 404 means the tag does not exist. Surface that as the diagnostic
+  # most likely to be useful to the operator (publish step regressed).
+  echo "  MISSING: ${image_path}:${tag} (HTTP ${status})"
+  return 1
+}
+
+# -----------------------------------------------------------------------
+# Drive the probes. We track failures rather than exiting on the
+# first miss so the operator sees the FULL picture: "backend ok, web
+# missing, openscap missing" is more actionable than "backend ok"
+# followed by a re-run after fixing web.
+# -----------------------------------------------------------------------
+
+FAILED_IMAGES=()
+
+probe_image "artifact-keeper-backend" "$BACKEND_TAG_NORM" \
+  || FAILED_IMAGES+=("artifact-keeper-backend:${BACKEND_TAG_NORM}")
+probe_image "artifact-keeper-web" "$WEB_TAG_NORM" \
+  || FAILED_IMAGES+=("artifact-keeper-web:${WEB_TAG_NORM}")
+probe_image "artifact-keeper-openscap" "$OPENSCAP_TAG_NORM" \
+  || FAILED_IMAGES+=("artifact-keeper-openscap:${OPENSCAP_TAG_NORM}")
+
+echo ""
+echo "=================================================================="
+if [ "${#FAILED_IMAGES[@]}" -eq 0 ]; then
+  echo "Version-set integrity check PASSED"
+  echo "  All ${REGISTRY}/${NAMESPACE} images exist at their tags."
+  echo "=================================================================="
+  exit 0
+fi
+
+echo "Version-set integrity check FAILED"
+echo ""
+echo "Missing images (release set incomplete):"
+for img in "${FAILED_IMAGES[@]}"; do
+  echo "  - ${REGISTRY}/${NAMESPACE}/${img}"
+done
+echo ""
+echo "This is a release blocker. The publish pipeline did not push every"
+echo "required image at the requested tag. Re-run the publish workflow"
+echo "(see artifact-keeper/.github/workflows/release.yml) or pin the"
+echo "release-gate inputs to a tag set that is fully published."
+echo "=================================================================="
+exit 2

--- a/tests/release-gate/verify-image-set.sh
+++ b/tests/release-gate/verify-image-set.sh
@@ -5,12 +5,24 @@
 #   ./verify-image-set.sh \
 #       --backend-tag <tag> \
 #       --web-tag <tag> \
-#       --openscap-tag <tag>
+#       --openscap-tag <tag> \
+#       [--chart-dir <path>]
 #
 # Probes the GHCR registry's manifest endpoint for each image at the
-# specified tag. A missing tag fails fast with a clear error. Catches
-# the structural failure behind:
-#   - artifact-keeper#872 (chart tagged but referenced images absent)
+# specified tag. A missing tag fails fast with a clear error.
+#
+# When --chart-dir is provided AND `helm` is on PATH, the script also
+# renders the chart with no overrides and asserts that the default
+# image tags emitted by `helm template` match the BACKEND_TAG /
+# WEB_TAG passed in. This catches the artifact-keeper#872 customer
+# scenario: a user who runs `helm install -f values-production.yaml`
+# without `--set backend.image.tag=...` and gets whatever the chart's
+# defaults (Chart.yaml appVersion / values.yaml image.tag) point at
+# (currently "1.1.0" via Chart.yaml#appVersion, stale).
+#
+# Catches the structural failure behind:
+#   - artifact-keeper#872 (chart tagged but referenced images absent /
+#     default tag stale on a release branch)
 #   - artifact-keeper#905 (versioned tags missing on ghcr.io)
 #   - artifact-keeper-web#320 (v1.1.8 web image never published)
 #
@@ -36,15 +48,17 @@ set -euo pipefail
 BACKEND_TAG=""
 WEB_TAG=""
 OPENSCAP_TAG=""
+CHART_DIR=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --backend-tag)  BACKEND_TAG="${2:-}"; shift 2 ;;
     --web-tag)      WEB_TAG="${2:-}"; shift 2 ;;
     --openscap-tag) OPENSCAP_TAG="${2:-}"; shift 2 ;;
+    --chart-dir)    CHART_DIR="${2:-}"; shift 2 ;;
     *)
       echo "Unknown argument: $1" >&2
-      echo "Usage: verify-image-set.sh --backend-tag <tag> --web-tag <tag> --openscap-tag <tag>" >&2
+      echo "Usage: verify-image-set.sh --backend-tag <tag> --web-tag <tag> --openscap-tag <tag> [--chart-dir <path>]" >&2
       exit 1
       ;;
   esac
@@ -155,11 +169,112 @@ probe_image "artifact-keeper-web" "$WEB_TAG_NORM" \
 probe_image "artifact-keeper-openscap" "$OPENSCAP_TAG_NORM" \
   || FAILED_IMAGES+=("artifact-keeper-openscap:${OPENSCAP_TAG_NORM}")
 
+# -----------------------------------------------------------------------
+# Optional: chart default-tag verification (artifact-keeper#872)
+#
+# A green check above tells us the images exist. It does NOT tell us
+# whether a customer running `helm install -f values-production.yaml`
+# (with no --set backend.image.tag) would pull those images by
+# default. That is the actual customer-pain scenario in #872.
+#
+# When --chart-dir is supplied and `helm` is on PATH, render the chart
+# with no overrides and compare:
+#   - The default image: lines emitted for backend / web containers
+#     against the passed-in BACKEND_TAG / WEB_TAG.
+#   - Chart.yaml appVersion against BACKEND_TAG (warn-only because the
+#     chart's appVersion is allowed to lag by design in some shops).
+# -----------------------------------------------------------------------
+
+CHART_WARNINGS=()
+
+if [ -n "$CHART_DIR" ]; then
+  echo ""
+  echo "Chart default-tag verification (chart dir: ${CHART_DIR})"
+  if [ ! -f "${CHART_DIR}/Chart.yaml" ]; then
+    echo "  WARN: --chart-dir was given but ${CHART_DIR}/Chart.yaml is missing; skipping"
+    CHART_WARNINGS+=("chart-dir-missing")
+  elif ! command -v helm >/dev/null 2>&1; then
+    echo "  WARN: helm is not on PATH; skipping chart default-tag check"
+    CHART_WARNINGS+=("helm-not-installed")
+  else
+    appversion=$(awk '/^appVersion:/ {gsub(/"/, "", $2); print $2; exit}' "${CHART_DIR}/Chart.yaml" 2>/dev/null || echo "")
+    if [ -n "$appversion" ]; then
+      appversion_norm=$(_strip_v "$appversion")
+      if [ "$appversion_norm" = "$BACKEND_TAG_NORM" ]; then
+        echo "  OK: Chart.yaml appVersion (${appversion_norm}) matches backend tag"
+      else
+        echo "  WARN: Chart.yaml appVersion (${appversion_norm}) != backend tag (${BACKEND_TAG_NORM})"
+        echo "        This is the #872 customer-pain shape: chart on a tagged release"
+        echo "        but appVersion lagging the published image set."
+        CHART_WARNINGS+=("appversion-${appversion_norm}-vs-${BACKEND_TAG_NORM}")
+      fi
+    fi
+
+    # Render the chart with NO image-tag overrides (the whole point is
+    # to see what defaults the chart ships with). We pass the two
+    # chart-required values (secrets.jwtSecret, postgres.auth.password)
+    # because the chart errors out without them; neither affects the
+    # rendered image tags.
+    rendered=$(helm template ak-default "$CHART_DIR" \
+      --set "secrets.jwtSecret=verify-image-set-default-render-only" \
+      --set "postgres.auth.password=verify-image-set-default-render-only" \
+      2>/dev/null || echo "")
+    if [ -z "$rendered" ]; then
+      echo "  WARN: helm template failed; skipping default-tag rendering check"
+      CHART_WARNINGS+=("helm-template-failed")
+    else
+      # awk extracts image: <repo>:<tag>; we lowercase the line and
+      # filter to artifact-keeper-* repositories.
+      defaults=$(echo "$rendered" \
+        | awk -F'image: *' '/image: /{print $2}' \
+        | tr -d '"' \
+        | grep -E 'artifact-keeper-(backend|web|openscap)' \
+        | sort -u)
+      echo "  Defaults rendered by chart:"
+      # shellcheck disable=SC2001  # multi-line input, parameter expansion can't do this
+      echo "$defaults" | sed 's/^/    /'
+
+      for line in $defaults; do
+        case "$line" in
+          *artifact-keeper-backend:*)
+            got="${line##*:}"
+            if [ "$got" != "$BACKEND_TAG_NORM" ]; then
+              echo "  WARN: chart default backend tag is '${got}', expected '${BACKEND_TAG_NORM}'"
+              CHART_WARNINGS+=("backend-default-${got}-vs-${BACKEND_TAG_NORM}")
+            fi
+            ;;
+          *artifact-keeper-web:*)
+            got="${line##*:}"
+            if [ "$got" != "$WEB_TAG_NORM" ]; then
+              echo "  WARN: chart default web tag is '${got}', expected '${WEB_TAG_NORM}'"
+              CHART_WARNINGS+=("web-default-${got}-vs-${WEB_TAG_NORM}")
+            fi
+            ;;
+          *artifact-keeper-openscap:*)
+            got="${line##*:}"
+            if [ "$got" != "$OPENSCAP_TAG_NORM" ]; then
+              echo "  WARN: chart default openscap tag is '${got}', expected '${OPENSCAP_TAG_NORM}'"
+              CHART_WARNINGS+=("openscap-default-${got}-vs-${OPENSCAP_TAG_NORM}")
+            fi
+            ;;
+        esac
+      done
+    fi
+  fi
+fi
+
 echo ""
 echo "=================================================================="
 if [ "${#FAILED_IMAGES[@]}" -eq 0 ]; then
   echo "Version-set integrity check PASSED"
   echo "  All ${REGISTRY}/${NAMESPACE} images exist at their tags."
+  if [ "${#CHART_WARNINGS[@]}" -gt 0 ]; then
+    echo ""
+    echo "  Chart-default warnings (non-blocking, see #872):"
+    for w in "${CHART_WARNINGS[@]}"; do
+      echo "    - ${w}"
+    done
+  fi
   echo "=================================================================="
   exit 0
 fi


### PR DESCRIPTION
Cluster A bundle: five release-gate hardening issues delivered as one PR
because the workflow edits all touch `release-gate.yml` (`needs:`, summary
table, rollup gate-check).

## Issues closed

| Issue | Title | Required? |
|-------|-------|:---------:|
| #45 | Release-gate: real artifact push, pull, and scan end-to-end | yes |
| #48 | Per-format push/pull audit and gap-fill | n/a (audit + 1 new test) |
| #53 | Release-gate: clean-install-smoke-with-deps variant | gated `if:` until beefy runner |
| #54 | Release-gate: chart-upgrade-smoke | yes |
| #63 | Release-gate: version-set integrity | yes |

## Changes

### New release-gate jobs (release-gate.yml)

1. **`version-set-integrity`** (#63) - runs FIRST, before any namespace
   is provisioned. Probes ghcr.io anonymously for the backend / web /
   openscap images at the requested tag. Hard-fails fast on the
   structural failure mode behind artifact-keeper#872 (customer-flagged:
   "current main Helm chart only works with main backend and frontend,
   not a tagged release"), #905, web#320.
2. **`clean-install-smoke-with-deps`** (#53) - after clean-install-smoke,
   enables Trivy / DependencyTrack / edge / ingress / openSCAP. Gated
   on a new `run_smoke_with_deps` workflow input (default false) because
   the resource footprint (~8 CPU / 13.4 Gi limits) exceeds the standard
   ARC namespace quota. Wired and lint-clean today; flip the input once
   a beefier runner pool is wired.
3. **`chart-upgrade-smoke`** (#54) - after clean-install-smoke. Installs
   the previous tag, pushes state, helm-upgrades to the current tag,
   verifies state survives and migrations applied. Hardcoded prev tag
   `1.1.9`; bump on each release (documented inline).
4. **`real-flow-smoke`** (#45) - after deploy, parallel to the test
   matrix. Pushes through `npm publish`, pulls via `npm pack`, triggers
   a scan via the security rescan endpoint, polls until completion,
   asserts numeric `findings_count`. Catches the silent-success class
   behind #870 / #871 / #888.

### New test scripts

- `tests/release-gate/verify-image-set.sh` - OCI manifest HEAD probe
  for the release set images.
- `tests/release-gate/test-real-flow-smoke.sh` - the user flow under
  the common.sh test framework.
- `tests/release-gate/clean-install-smoke-with-deps.sh` - full-stack
  smoke driver.
- `tests/release-gate/chart-upgrade-smoke.sh` - in-place upgrade
  smoke driver.
- `helm/values-smoke-with-deps.yaml` - helm overlay with every
  optional subsystem enabled.

### Format audit (#48)

- `tests/formats/AUDIT.md` - per-format native-client coverage table
  with priority queue for the next candidates (debian/reprepro,
  nuget/dotnet, helm/helm-push, ...).
- `tests/formats/test-rubygems-native-client.sh` - new real-client
  test using `gem build / push / fetch` against the registry, with
  size-equality round-trip and a management-API cross-check.

### Workflow constraints honored

- All new `uses:` references are SHA-pinned per the in-flight #104
  convention: `actions/checkout@34e1148...`, `actions/upload-artifact@ea165f8...`,
  `azure/setup-kubectl@776406b...`, `azure/setup-helm@1a275c3...`.
- New `needs:` additions are additive; the existing job graph is
  unchanged for downstream matrix jobs.
- Pre-existing PRs #142, #143, #144, #145, #146 should merge clean
  on top of this branch (rebase touches the summary table and
  rollup gate-check, both of which have small isolated hunks).

## Out of scope

- Native-client tests for the remaining ~30 wire-emulation formats
  (`debian/reprepro + GPG`, `nuget/dotnet`, etc.). Documented and
  prioritized in `tests/formats/AUDIT.md`.
- A smoke-self-test variant for `clean-install-smoke-with-deps` and
  `chart-upgrade-smoke` (the #53 / #54 acceptance criteria suggested
  it). That belongs in `smoke-self-test.yml`, which is a separate
  file with its own review surface. Filed as a follow-up.
- Enabling the with-deps variant in CI. The runner pool work is
  separate.

## Test plan

- [ ] Manually dispatch the release-gate workflow against a known
  good tag (e.g. `1.1.9`) and confirm:
  - [ ] `version-set-integrity` passes (all three images exist)
  - [ ] `clean-install-smoke` still passes (unchanged behavior)
  - [ ] `chart-upgrade-smoke` upgrades 1.1.9 -> current tag and
    preserves the test artifact
  - [ ] `real-flow-smoke` publishes a package, pulls it back,
    triggers a scan, sees a terminal status within 60s
  - [ ] `clean-install-smoke-with-deps` is `skipped` (input default false)
- [ ] Manually dispatch with a bogus backend tag (e.g.
  `9.9.9-does-not-exist`) and confirm `version-set-integrity` fails
  fast before any namespace is provisioned.
- [ ] `actionlint` produces no new warnings (only pre-existing
  self-hosted-runner-label warnings remain).
- [ ] `shellcheck` clean on all new scripts.
- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-gate.yml'))"` clean.

## Lines added

- `release-gate.yml`: +272 / -2
- New test scripts: 481 + 295 + 253 + 179 = 1208 lines
- AUDIT.md: 166 lines
- helm values overlay: 192 lines
- New native-client test: 180 lines