### PR TITLE
test: webhook v2 + search/browse E2E coverage (#85, #75, #73)

### DIFF
--- a/tests/search/test-search-advanced-filters.sh
+++ b/tests/search/test-search-advanced-filters.sh
@@ -23,6 +23,19 @@ begin_suite "search-advanced-filters"
 auth_admin
 setup_workdir
 
+# Preflight: when OpenSearch is down or unwired the search endpoints
+# either return 503 or hang past the CURL_TIMEOUT window. Skipping the
+# suite at the suite level is faster (1-2s vs 60-120s of failed assertions)
+# and produces a clean signal for the release-gate dashboard.
+preflight_status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/search?q=preflight&per_page=1" 2>/dev/null || echo "000")
+case "$preflight_status" in
+  503|504|000)
+    skip_suite "search backend unavailable (HTTP ${preflight_status}); OpenSearch may be down"
+    ;;
+esac
+
 REPO_KEY="srch-adv-${RUN_ID}"
 DECOY_REPO_KEY="srch-adv-decoy-${RUN_ID}"
 UNIQUE_TERM="advfilt${RUN_ID//[^a-z0-9]/}"

--- a/tests/search/test-search-advanced-filters.sh
+++ b/tests/search/test-search-advanced-filters.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# test-search-advanced-filters.sh - Advanced search filter contract
+#
+# Epic 8 sub-tasks 8.1, 8.2, 8.5 (artifact-keeper-test#73). Drives the
+# /api/v1/search/advanced endpoint with size, date, and repository_key
+# filters and asserts that:
+#   1. min_size / max_size cleanly bound the result set.
+#   2. created_after with a future timestamp returns an empty result set.
+#   3. repository_key scopes results to that repo.
+#
+# We upload three sentinels with distinct sizes (small, medium, large)
+# into a fresh repo so the assertions don't collide with whatever else
+# happens to live on the indexer. Each assertion skips cleanly if the
+# advanced search endpoint isn't wired on this backend, but a wired
+# endpoint that returns cross-filter results (e.g. min_size returning
+# a sub-min file) fails the test.
+#
+# Requires: curl, jq
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "search-advanced-filters"
+auth_admin
+setup_workdir
+
+REPO_KEY="srch-adv-${RUN_ID}"
+DECOY_REPO_KEY="srch-adv-decoy-${RUN_ID}"
+UNIQUE_TERM="advfilt${RUN_ID//[^a-z0-9]/}"
+
+# -------------------------------------------------------------------------
+# Build a known corpus.
+# -------------------------------------------------------------------------
+
+begin_test "Create primary and decoy repos"
+ok1=true
+ok2=true
+create_local_repo "$REPO_KEY"       "generic" >/dev/null 2>&1 || ok1=false
+create_local_repo "$DECOY_REPO_KEY" "generic" >/dev/null 2>&1 || ok2=false
+if [ "$ok1" = true ] && [ "$ok2" = true ]; then
+  pass
+else
+  fail "could not create test repos"
+  end_suite
+fi
+
+SMALL_FILE="${WORK_DIR}/small-${UNIQUE_TERM}.bin"
+MED_FILE="${WORK_DIR}/med-${UNIQUE_TERM}.bin"
+LARGE_FILE="${WORK_DIR}/large-${UNIQUE_TERM}.bin"
+
+dd if=/dev/zero of="$SMALL_FILE" bs=1   count=512   2>/dev/null   # 512 B
+dd if=/dev/zero of="$MED_FILE"   bs=1024 count=16    2>/dev/null  # 16 KB
+dd if=/dev/zero of="$LARGE_FILE" bs=1024 count=128   2>/dev/null  # 128 KB
+
+begin_test "Upload three sentinels of distinct sizes"
+api_upload "/api/v1/repositories/${REPO_KEY}/artifacts/${UNIQUE_TERM}/small.bin"  "$SMALL_FILE" >/dev/null 2>&1 || true
+api_upload "/api/v1/repositories/${REPO_KEY}/artifacts/${UNIQUE_TERM}/med.bin"    "$MED_FILE"   >/dev/null 2>&1 || true
+api_upload "/api/v1/repositories/${REPO_KEY}/artifacts/${UNIQUE_TERM}/large.bin"  "$LARGE_FILE" >/dev/null 2>&1 || true
+# Decoy upload in a separate repo with the same UNIQUE_TERM so the
+# repository_key filter has something to discriminate against.
+api_upload "/api/v1/repositories/${DECOY_REPO_KEY}/artifacts/${UNIQUE_TERM}/decoy.bin" "$MED_FILE" >/dev/null 2>&1 || true
+pass
+
+sleep 4   # allow async indexing
+
+# -------------------------------------------------------------------------
+# 8.1 size filters.
+# -------------------------------------------------------------------------
+
+begin_test "min_size=4096 excludes 512 B sentinel"
+if resp=$(api_get "/api/v1/search/advanced?q=${UNIQUE_TERM}&min_size=4096" 2>/dev/null); then
+  hit=$(echo "$resp" | jq -r '
+    if type=="array" then .
+    elif .results then .results
+    elif .hits    then .hits
+    else [] end
+    | map(.name // .path // .artifact_path // "")
+    | join(" ")' 2>/dev/null || echo "")
+  if echo "$hit" | grep -q 'small.bin'; then
+    fail "min_size=4096 returned the 512 B small.bin sentinel"
+  else
+    pass
+  fi
+else
+  skip "advanced search endpoint not available"
+fi
+
+begin_test "max_size=4096 excludes 128 KB sentinel"
+if resp=$(api_get "/api/v1/search/advanced?q=${UNIQUE_TERM}&max_size=4096" 2>/dev/null); then
+  hit=$(echo "$resp" | jq -r '
+    if type=="array" then .
+    elif .results then .results
+    elif .hits    then .hits
+    else [] end
+    | map(.name // .path // .artifact_path // "")
+    | join(" ")' 2>/dev/null || echo "")
+  if echo "$hit" | grep -q 'large.bin'; then
+    fail "max_size=4096 returned the 128 KB large.bin sentinel"
+  else
+    pass
+  fi
+else
+  skip "advanced search endpoint not available"
+fi
+
+# -------------------------------------------------------------------------
+# 8.2 date filters: future created_after must return nothing.
+# -------------------------------------------------------------------------
+
+begin_test "created_after=year-2099 returns empty result set"
+future="2099-01-01T00:00:00Z"
+if resp=$(api_get "/api/v1/search/advanced?q=${UNIQUE_TERM}&created_after=${future}" 2>/dev/null); then
+  count=$(echo "$resp" | jq -r '
+    if type=="array" then length
+    elif .results then (.results|length)
+    elif .hits    then (.hits|length)
+    elif .total   then .total
+    else 0 end' 2>/dev/null || echo 0)
+  if [ "${count:-0}" = "0" ]; then
+    pass
+  else
+    fail "future created_after returned ${count} hits, expected 0"
+  fi
+else
+  skip "advanced search did not accept created_after"
+fi
+
+# -------------------------------------------------------------------------
+# 8.5 repository_key scoping.
+# -------------------------------------------------------------------------
+
+begin_test "repository_key=primary excludes decoy repo hits"
+if resp=$(api_get "/api/v1/search/advanced?q=${UNIQUE_TERM}&repository_key=${REPO_KEY}" 2>/dev/null); then
+  decoy=$(echo "$resp" | jq -r --arg dk "$DECOY_REPO_KEY" '
+    if type=="array" then .
+    elif .results then .results
+    elif .hits    then .hits
+    else [] end
+    | map(select(.repository_key == $dk or .repo_key == $dk))
+    | length' 2>/dev/null || echo 0)
+  if [ "$decoy" = "0" ]; then
+    pass
+  else
+    fail "repository_key filter leaked ${decoy} decoy-repo hits"
+  fi
+else
+  skip "advanced search did not accept repository_key"
+fi
+
+# -------------------------------------------------------------------------
+# Cleanup.
+# -------------------------------------------------------------------------
+
+api_delete "/api/v1/repositories/${REPO_KEY}"       >/dev/null 2>&1 || true
+api_delete "/api/v1/repositories/${DECOY_REPO_KEY}" >/dev/null 2>&1 || true
+
+end_suite

--- a/tests/search/test-search-pagination.sh
+++ b/tests/search/test-search-pagination.sh
@@ -23,6 +23,19 @@ begin_suite "search-pagination"
 auth_admin
 setup_workdir
 
+# Preflight: when OpenSearch is down or unwired the search endpoints
+# either return 503 or hang past the CURL_TIMEOUT window. Skipping the
+# suite at the suite level is faster (1-2s vs 60-120s of failed assertions)
+# and produces a clean signal for the release-gate dashboard.
+preflight_status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/search?q=preflight&per_page=1" 2>/dev/null || echo "000")
+case "$preflight_status" in
+  503|504|000)
+    skip_suite "search backend unavailable (HTTP ${preflight_status}); OpenSearch may be down"
+    ;;
+esac
+
 REPO_KEY="pag-${RUN_ID}"
 UNIQUE_TERM="pagn${RUN_ID//[^a-z0-9]/}"
 
@@ -153,6 +166,83 @@ else
       skip "indexing did not surface the sentinel within budget (best-effort)"
     fi
   fi
+fi
+
+# -------------------------------------------------------------------------
+# 5. page beyond total: requesting page=total_pages+1 must return an empty
+#    hits list AND a self-consistent total field. This catches off-by-one
+#    bugs in the offset arithmetic that would otherwise look "fine"
+#    against page=1.
+# -------------------------------------------------------------------------
+
+begin_test "page beyond total returns empty hits with consistent total"
+# First find the current total for our unique term.
+resp_first=$(curl -sf $CURL_TIMEOUT -H "$(auth_header)" \
+  "${BASE_URL}${SEARCH_BASE}?q=${UNIQUE_TERM}&page=1&per_page=1" 2>/dev/null || echo '')
+if [ -z "$resp_first" ]; then
+  skip "page=1 query returned no response, cannot derive total"
+else
+  total_first=$(echo "$resp_first" | jq -r '
+    .total // .total_hits // .total_results //
+    (if type=="array" then length
+     elif .results then (.results|length)
+     elif .hits    then (.hits|length)
+     else 0 end)' 2>/dev/null || echo 0)
+  # Coerce empty / null to 0 so the arithmetic below stays well-formed.
+  case "$total_first" in
+    ''|null) total_first=0 ;;
+  esac
+  # Bound the requested page so a backend that mis-reports total=0 doesn't
+  # turn this into a probe on page=1 (which we already cover above).
+  per_page_probe=10
+  if [ "$total_first" -le 0 ] 2>/dev/null; then
+    # Indexer may not have surfaced anything yet; probe page=999 anyway,
+    # since the goal is "page-beyond-total must not 5xx or report rows".
+    probe_page=999
+  else
+    # ceil(total / per_page) + 1
+    probe_page=$(( total_first / per_page_probe + 2 ))
+  fi
+  resp_far=$(curl -s -w $'\n%{http_code}' $CURL_TIMEOUT -H "$(auth_header)" \
+    "${BASE_URL}${SEARCH_BASE}?q=${UNIQUE_TERM}&page=${probe_page}&per_page=${per_page_probe}" 2>/dev/null || printf '\n000')
+  # Split body (everything before the last newline) from status (final line).
+  # `head -n -1` is GNU-only; awk handles both BSD and GNU portably.
+  body_far=$(printf '%s' "$resp_far" | awk 'NR>1{print prev}{prev=$0}')
+  status_far=$(printf '%s' "$resp_far" | awk 'END{print}')
+  case "$status_far" in
+    5*)
+      fail "page-beyond-total (page=${probe_page}) returned HTTP ${status_far}"
+      ;;
+    2*)
+      hits_far=$(echo "$body_far" | jq -r '
+        if type=="array" then length
+        elif .results then (.results|length)
+        elif .hits    then (.hits|length)
+        else 0 end' 2>/dev/null || echo 0)
+      total_far=$(echo "$body_far" | jq -r '
+        .total // .total_hits // .total_results // empty' 2>/dev/null || echo "")
+      # The page must be empty (no rows past the last page).
+      if [ "$hits_far" != "0" ]; then
+        fail "page=${probe_page} returned ${hits_far} hits, expected 0 (beyond total=${total_first})"
+      # And the total, if present, must agree with the first-page total so
+      # the response is internally consistent across the page parameter.
+      elif [ -n "$total_far" ] && [ "$total_far" != "null" ] && \
+           [ "$total_first" -gt 0 ] 2>/dev/null && \
+           [ "$total_far" != "$total_first" ]; then
+        fail "total field changes with page (page=1 total=${total_first}, page=${probe_page} total=${total_far})"
+      else
+        pass
+      fi
+      ;;
+    4*)
+      # 4xx is acceptable: some backends explicitly reject out-of-range
+      # pages. The contract we care about is "no panic, no phantom rows".
+      pass
+      ;;
+    *)
+      skip "page-beyond-total returned HTTP ${status_far}; not a clean signal"
+      ;;
+  esac
 fi
 
 # -------------------------------------------------------------------------

--- a/tests/search/test-search-pagination.sh
+++ b/tests/search/test-search-pagination.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# test-search-pagination.sh - Pagination edge cases for search
+#
+# Epic 8 sub-task 8.11 (artifact-keeper-test#73). The advanced search
+# endpoint accepts page / per_page parameters. Edge cases that have no
+# E2E coverage today:
+#
+#   1. page=0 must not return an HTTP 5xx; it should either redirect to
+#      page 1 semantics or return 400. The previous behaviour panicked
+#      on a usize underflow in the offset math.
+#   2. Negative page (-1) must be rejected with 4xx, not silently
+#      treated as a huge unsigned offset.
+#   3. per_page=0 must not return an empty paged result with a non-zero
+#      "total" field that contradicts itself.
+#   4. A normal page=1 request after the corpus is indexed returns at
+#      least one hit (sanity).
+#
+# Requires: curl, jq
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "search-pagination"
+auth_admin
+setup_workdir
+
+REPO_KEY="pag-${RUN_ID}"
+UNIQUE_TERM="pagn${RUN_ID//[^a-z0-9]/}"
+
+begin_test "Create repo and upload sentinel"
+if create_local_repo "$REPO_KEY" "generic" >/dev/null 2>&1; then
+  echo "pagination-sentinel-${UNIQUE_TERM}" > "${WORK_DIR}/${UNIQUE_TERM}.txt"
+  api_upload "/api/v1/repositories/${REPO_KEY}/artifacts/${UNIQUE_TERM}/${UNIQUE_TERM}.txt" \
+    "${WORK_DIR}/${UNIQUE_TERM}.txt" >/dev/null 2>&1 || true
+  pass
+else
+  fail "could not create repo"
+  end_suite
+fi
+
+sleep 3
+
+# Pick whichever search endpoint the backend exposes; reuse the same one
+# for every pagination probe so the assertions are apples-to-apples.
+SEARCH_BASE=""
+for candidate in "/api/v1/search" "/api/v1/search/advanced"; do
+  if curl -sf $CURL_TIMEOUT -o /dev/null -H "$(auth_header)" \
+     "${BASE_URL}${candidate}?q=${UNIQUE_TERM}" 2>/dev/null; then
+    SEARCH_BASE="$candidate"
+    break
+  fi
+done
+
+begin_test "Search base endpoint reachable"
+if [ -n "$SEARCH_BASE" ]; then
+  pass
+else
+  skip "no search endpoint responded 200 for the test corpus"
+  end_suite
+fi
+
+# -------------------------------------------------------------------------
+# 1. page=0 must not 5xx.
+# -------------------------------------------------------------------------
+
+begin_test "page=0 returns a non-5xx response"
+status=$(curl -s -o /dev/null -w "%{http_code}" $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}${SEARCH_BASE}?q=${UNIQUE_TERM}&page=0&per_page=10" 2>/dev/null || echo 000)
+case "$status" in
+  5*) fail "page=0 panicked at ${SEARCH_BASE}: HTTP ${status}" ;;
+  *)  pass ;;
+esac
+
+# -------------------------------------------------------------------------
+# 2. negative page must 4xx.
+# -------------------------------------------------------------------------
+
+begin_test "page=-1 returns 4xx, not 5xx"
+status=$(curl -s -o /dev/null -w "%{http_code}" $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}${SEARCH_BASE}?q=${UNIQUE_TERM}&page=-1&per_page=10" 2>/dev/null || echo 000)
+case "$status" in
+  4*) pass ;;
+  5*) fail "page=-1 returned ${status}; expected 4xx" ;;
+  *)
+    # Some backends coerce to page=1 silently. Permit 2xx as long as the
+    # body still parses; the strict-contract version of this assertion is
+    # planned for v1.2.0 once the API contract is finalized.
+    skip "page=-1 returned ${status}; not a hard error in this revision"
+    ;;
+esac
+
+# -------------------------------------------------------------------------
+# 3. per_page=0 must not yield a self-contradicting page.
+# -------------------------------------------------------------------------
+
+begin_test "per_page=0 is internally consistent"
+resp=$(curl -sf $CURL_TIMEOUT -H "$(auth_header)" \
+  "${BASE_URL}${SEARCH_BASE}?q=${UNIQUE_TERM}&page=1&per_page=0" 2>/dev/null || echo '')
+if [ -z "$resp" ]; then
+  skip "per_page=0 rejected (acceptable)"
+else
+  hits=$(echo "$resp" | jq -r '
+    if type=="array" then length
+    elif .results then (.results|length)
+    elif .hits    then (.hits|length)
+    else 0 end' 2>/dev/null || echo 0)
+  total=$(echo "$resp" | jq -r '.total // .total_hits // empty' 2>/dev/null || echo "")
+  if [ "$hits" = "0" ]; then
+    # Even an explicit total > 0 with hits == 0 is fine; the page itself
+    # is consistent. We only fail if the response claims it returned
+    # rows that aren't there.
+    pass
+  else
+    if [ -n "$total" ] && [ "$total" != "null" ] && [ "$hits" -gt "$total" ]; then
+      fail "per_page=0 returned ${hits} rows but total=${total}"
+    else
+      pass
+    fi
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# 4. page=1 sanity.
+# -------------------------------------------------------------------------
+
+begin_test "page=1,per_page=10 returns at least one hit"
+resp=$(curl -sf $CURL_TIMEOUT -H "$(auth_header)" \
+  "${BASE_URL}${SEARCH_BASE}?q=${UNIQUE_TERM}&page=1&per_page=10" 2>/dev/null || echo '')
+if [ -z "$resp" ]; then
+  skip "page=1 request returned error"
+else
+  hits=$(echo "$resp" | jq -r '
+    if type=="array" then length
+    elif .results then (.results|length)
+    elif .hits    then (.hits|length)
+    else 0 end' 2>/dev/null || echo 0)
+  if [ "$hits" -ge 1 ]; then
+    pass
+  else
+    # Indexer may need a few more seconds on slow runners.
+    sleep 5
+    resp=$(curl -sf $CURL_TIMEOUT -H "$(auth_header)" \
+      "${BASE_URL}${SEARCH_BASE}?q=${UNIQUE_TERM}&page=1&per_page=10" 2>/dev/null || echo '')
+    hits=$(echo "$resp" | jq -r '
+      if type=="array" then length
+      elif .results then (.results|length)
+      elif .hits    then (.hits|length)
+      else 0 end' 2>/dev/null || echo 0)
+    if [ "$hits" -ge 1 ]; then
+      pass
+    else
+      skip "indexing did not surface the sentinel within budget (best-effort)"
+    fi
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Cleanup.
+# -------------------------------------------------------------------------
+
+api_delete "/api/v1/repositories/${REPO_KEY}" >/dev/null 2>&1 || true
+
+end_suite

--- a/tests/search/test-search-tree-browse.sh
+++ b/tests/search/test-search-tree-browse.sh
@@ -10,9 +10,12 @@
 #   2. Repo-level listing returns the first path segment.
 #   3. Leaf listing returns the artifact filename.
 #
-# The exact response shape varies by backend version (some return
-# {"nodes":[...]}, some return {"entries":[...]}). We accept either as
-# long as the expected name appears anywhere in the response body.
+# The response shape varies by backend version (some return
+# {"nodes":[...]}, some return {"entries":[...]}, some {"children":[...]}
+# or a bare array). We extract candidate name/path fields via jq and
+# check membership against the structured field set, rather than grep on
+# the raw JSON which would false-positive on bytes that happen to occur
+# in unrelated fields (e.g. an opaque encoded "next_page_token").
 #
 # Requires: curl, jq
 
@@ -25,6 +28,56 @@ setup_workdir
 REPO_KEY="tree-${RUN_ID}"
 SEGMENT="alpha-${RUN_ID}"
 FILENAME="beta-${RUN_ID}.txt"
+
+# _tree_names <json>
+#
+# Extract the list of node names/paths from a tree-browse response into a
+# newline-delimited list on stdout. Handles every wrapper shape we have
+# seen in the wild without falling back to substring grep on raw JSON.
+_tree_names() {
+  local json="$1"
+  echo "$json" | jq -r '
+    def entries:
+      if type == "array" then .
+      elif (.nodes? | type) == "array"    then .nodes
+      elif (.entries? | type) == "array"  then .entries
+      elif (.children? | type) == "array" then .children
+      elif (.items? | type) == "array"    then .items
+      elif (.results? | type) == "array"  then .results
+      else [] end;
+    entries
+    | map(
+        (.name // empty),
+        (.path // empty),
+        (.key // empty)
+      )
+    | flatten
+    | map(select(. != null and . != ""))
+    | .[]
+  ' 2>/dev/null || true
+}
+
+# _names_contain <names-list-newline-delim> <needle>
+# Returns 0 if any name equals or has a final path component equal to needle.
+_names_contain() {
+  local list="$1"
+  local needle="$2"
+  if [ -z "$list" ]; then
+    return 1
+  fi
+  local line base
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    if [ "$line" = "$needle" ]; then
+      return 0
+    fi
+    base="${line##*/}"
+    if [ "$base" = "$needle" ]; then
+      return 0
+    fi
+  done <<< "$list"
+  return 1
+}
 
 begin_test "Create repo and upload a nested artifact"
 ok=true
@@ -65,27 +118,29 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# Root: must surface our repo key.
+# Root: must surface our repo key in a structured name/path field.
 # -------------------------------------------------------------------------
 
 begin_test "Root listing surfaces the test repo"
-if resp=$(api_get "$TREE_BASE" 2>/dev/null); then
-  if echo "$resp" | grep -q "$REPO_KEY"; then
+root_resp=""
+if r=$(api_get "$TREE_BASE" 2>/dev/null); then
+  root_resp="$r"
+elif r=$(api_get "${TREE_BASE}?path=/" 2>/dev/null); then
+  root_resp="$r"
+fi
+if [ -z "$root_resp" ]; then
+  skip "root listing returned error"
+else
+  names=$(_tree_names "$root_resp")
+  if _names_contain "$names" "$REPO_KEY"; then
     pass
   else
-    # Some implementations require an explicit "/" or "?path=" param.
-    if resp2=$(api_get "${TREE_BASE}?path=/" 2>/dev/null) && echo "$resp2" | grep -q "$REPO_KEY"; then
-      pass
-    else
-      fail "root listing did not contain ${REPO_KEY}"
-    fi
+    fail "root listing did not surface ${REPO_KEY} in any name/path field (got names: $(echo "$names" | tr '\n' ',' | head -c 300))"
   fi
-else
-  skip "root listing returned error"
 fi
 
 # -------------------------------------------------------------------------
-# Repo level: must surface the first path segment.
+# Repo level: must surface the first path segment as a structured node.
 # -------------------------------------------------------------------------
 
 begin_test "Repo-level listing surfaces the path segment"
@@ -96,16 +151,19 @@ for path_form in "${TREE_BASE}/${REPO_KEY}" "${TREE_BASE}?path=/${REPO_KEY}" "${
     break
   fi
 done
-if [ -n "$repo_resp" ] && echo "$repo_resp" | grep -q "$SEGMENT"; then
-  pass
-elif [ -z "$repo_resp" ]; then
+if [ -z "$repo_resp" ]; then
   skip "no repo-level tree response"
 else
-  fail "repo-level listing did not contain segment ${SEGMENT}"
+  names=$(_tree_names "$repo_resp")
+  if _names_contain "$names" "$SEGMENT"; then
+    pass
+  else
+    fail "repo-level listing did not surface segment ${SEGMENT} in any name/path field (got names: $(echo "$names" | tr '\n' ',' | head -c 300))"
+  fi
 fi
 
 # -------------------------------------------------------------------------
-# Leaf level: must surface the filename.
+# Leaf level: must surface the filename as a structured node.
 # -------------------------------------------------------------------------
 
 begin_test "Path-level listing surfaces the artifact filename"
@@ -119,12 +177,15 @@ for path_form in \
     break
   fi
 done
-if [ -n "$leaf_resp" ] && echo "$leaf_resp" | grep -q "$FILENAME"; then
-  pass
-elif [ -z "$leaf_resp" ]; then
+if [ -z "$leaf_resp" ]; then
   skip "no path-level tree response"
 else
-  fail "path-level listing did not contain ${FILENAME}"
+  names=$(_tree_names "$leaf_resp")
+  if _names_contain "$names" "$FILENAME"; then
+    pass
+  else
+    fail "path-level listing did not surface ${FILENAME} in any name/path field (got names: $(echo "$names" | tr '\n' ',' | head -c 300))"
+  fi
 fi
 
 # -------------------------------------------------------------------------

--- a/tests/search/test-search-tree-browse.sh
+++ b/tests/search/test-search-tree-browse.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# test-search-tree-browse.sh - Tree browse API smoke
+#
+# Epic 8 sub-task 8.10 (artifact-keeper-test#73). The tree browse handler
+# (backend/src/api/handlers/tree.rs, ~709 lines) has zero E2E coverage.
+# This script puts a known artifact tree in place and walks the browse
+# endpoint at three levels:
+#
+#   1. Root listing returns the repository as a node.
+#   2. Repo-level listing returns the first path segment.
+#   3. Leaf listing returns the artifact filename.
+#
+# The exact response shape varies by backend version (some return
+# {"nodes":[...]}, some return {"entries":[...]}). We accept either as
+# long as the expected name appears anywhere in the response body.
+#
+# Requires: curl, jq
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "search-tree-browse"
+auth_admin
+setup_workdir
+
+REPO_KEY="tree-${RUN_ID}"
+SEGMENT="alpha-${RUN_ID}"
+FILENAME="beta-${RUN_ID}.txt"
+
+begin_test "Create repo and upload a nested artifact"
+ok=true
+create_local_repo "$REPO_KEY" "generic" >/dev/null 2>&1 || ok=false
+echo "tree-browse-${RUN_ID}" > "${WORK_DIR}/${FILENAME}"
+api_upload "/api/v1/repositories/${REPO_KEY}/artifacts/${SEGMENT}/${FILENAME}" \
+  "${WORK_DIR}/${FILENAME}" >/dev/null 2>&1 || ok=false
+if [ "$ok" = true ]; then
+  pass
+else
+  fail "could not set up corpus"
+  end_suite
+fi
+
+sleep 2  # allow listing index to settle
+
+# -------------------------------------------------------------------------
+# Probe a few candidate tree endpoints. The browse handler is mounted at
+# /api/v1/tree in the current backend; older revisions used /api/v1/browse.
+# We try both and use whichever one responds 200.
+# -------------------------------------------------------------------------
+
+TREE_BASE=""
+for candidate in "/api/v1/tree" "/api/v1/browse"; do
+  if curl -sf $CURL_TIMEOUT -H "$(auth_header)" -o /dev/null \
+     "${BASE_URL}${candidate}" 2>/dev/null; then
+    TREE_BASE="$candidate"
+    break
+  fi
+done
+
+begin_test "Tree browse base endpoint is reachable"
+if [ -n "$TREE_BASE" ]; then
+  pass
+else
+  skip "no tree/browse endpoint responded 200"
+  end_suite
+fi
+
+# -------------------------------------------------------------------------
+# Root: must surface our repo key.
+# -------------------------------------------------------------------------
+
+begin_test "Root listing surfaces the test repo"
+if resp=$(api_get "$TREE_BASE" 2>/dev/null); then
+  if echo "$resp" | grep -q "$REPO_KEY"; then
+    pass
+  else
+    # Some implementations require an explicit "/" or "?path=" param.
+    if resp2=$(api_get "${TREE_BASE}?path=/" 2>/dev/null) && echo "$resp2" | grep -q "$REPO_KEY"; then
+      pass
+    else
+      fail "root listing did not contain ${REPO_KEY}"
+    fi
+  fi
+else
+  skip "root listing returned error"
+fi
+
+# -------------------------------------------------------------------------
+# Repo level: must surface the first path segment.
+# -------------------------------------------------------------------------
+
+begin_test "Repo-level listing surfaces the path segment"
+repo_resp=""
+for path_form in "${TREE_BASE}/${REPO_KEY}" "${TREE_BASE}?path=/${REPO_KEY}" "${TREE_BASE}/${REPO_KEY}/"; do
+  if r=$(api_get "$path_form" 2>/dev/null); then
+    repo_resp="$r"
+    break
+  fi
+done
+if [ -n "$repo_resp" ] && echo "$repo_resp" | grep -q "$SEGMENT"; then
+  pass
+elif [ -z "$repo_resp" ]; then
+  skip "no repo-level tree response"
+else
+  fail "repo-level listing did not contain segment ${SEGMENT}"
+fi
+
+# -------------------------------------------------------------------------
+# Leaf level: must surface the filename.
+# -------------------------------------------------------------------------
+
+begin_test "Path-level listing surfaces the artifact filename"
+leaf_resp=""
+for path_form in \
+  "${TREE_BASE}/${REPO_KEY}/${SEGMENT}" \
+  "${TREE_BASE}?path=/${REPO_KEY}/${SEGMENT}" \
+  "${TREE_BASE}/${REPO_KEY}/${SEGMENT}/"; do
+  if r=$(api_get "$path_form" 2>/dev/null); then
+    leaf_resp="$r"
+    break
+  fi
+done
+if [ -n "$leaf_resp" ] && echo "$leaf_resp" | grep -q "$FILENAME"; then
+  pass
+elif [ -z "$leaf_resp" ]; then
+  skip "no path-level tree response"
+else
+  fail "path-level listing did not contain ${FILENAME}"
+fi
+
+# -------------------------------------------------------------------------
+# Cleanup.
+# -------------------------------------------------------------------------
+
+api_delete "/api/v1/repositories/${REPO_KEY}" >/dev/null 2>&1 || true
+
+end_suite

--- a/tests/webhooks/test-events-sse-stream.sh
+++ b/tests/webhooks/test-events-sse-stream.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# test-events-sse-stream.sh - SSE event stream consumption smoke
+#
+# Epic 7 sub-task 7.15 (artifact-keeper-test#75). The backend exposes a
+# server-sent-events stream at /api/v1/events/stream that bridges the
+# in-process EventBus to external HTTP consumers. The platform suite
+# already verifies the endpoint returns 200 but doesn't read any frames
+# off the wire, so this test:
+#
+#   1. Opens a curl SSE connection in the background, writing frames to
+#      a temp file with a hard 10s wall-clock cap (curl --max-time).
+#   2. Triggers a domain event by creating a generic repository, which
+#      should emit a repository.* event onto the bus.
+#   3. Greps the frame log for an SSE-formatted "data:" line. We do NOT
+#      assert event name (the bus -> SSE mapping is version-sensitive)
+#      because the producer wire-up gate (webhook_event_producer) is
+#      v1.2.0; on 1.1.x the SSE bridge may not emit a frame even though
+#      the endpoint is live. Hence: skip cleanly if no frame appears,
+#      and only fail on protocol-shape violations (e.g. the endpoint
+#      returns HTML instead of an event stream).
+#
+# This is intentionally a thin proof-of-concept; the full SSE coverage
+# (back-pressure, lagged-event handling, JSON payload schema, named
+# event types, last-event-id resumption) is broken out in the epic
+# tracking comment.
+#
+# Requires: curl, jq
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "events-sse-stream"
+auth_admin
+setup_workdir
+
+REPO_KEY="sse-trigger-${RUN_ID}"
+SSE_LOG="${WORK_DIR}/sse-frames.log"
+SSE_HDR="${WORK_DIR}/sse-headers.log"
+SSE_PID=""
+
+cleanup_and_finalize() {
+  local code=$?
+  if [ -n "${SSE_PID}" ] && kill -0 "${SSE_PID}" 2>/dev/null; then
+    kill "${SSE_PID}" 2>/dev/null || true
+    wait "${SSE_PID}" 2>/dev/null || true
+  fi
+  api_delete "/api/v1/repositories/${REPO_KEY}" >/dev/null 2>&1 || true
+  exit "$code"
+}
+trap cleanup_and_finalize EXIT
+
+# -------------------------------------------------------------------------
+# Open SSE stream in background.
+# -------------------------------------------------------------------------
+
+begin_test "Open SSE stream against /api/v1/events/stream"
+# --max-time bounds the listener. Use -N to disable curl buffering so frames
+# land in the log as they arrive. -D writes response headers to SSE_HDR so we
+# can assert content-type without parsing the streamed body.
+curl -sN $CURL_TIMEOUT --max-time 10 \
+  -H "$(auth_header)" \
+  -H "Accept: text/event-stream" \
+  -D "$SSE_HDR" \
+  -o "$SSE_LOG" \
+  "${BASE_URL}/api/v1/events/stream" &
+SSE_PID=$!
+
+# Give the connection a moment to land before we start emitting events.
+sleep 1
+if kill -0 "$SSE_PID" 2>/dev/null; then
+  pass
+else
+  skip "SSE stream did not open (endpoint may not be available)"
+  end_suite
+fi
+
+# -------------------------------------------------------------------------
+# Verify response headers look like an event stream.
+# -------------------------------------------------------------------------
+
+begin_test "Stream returns text/event-stream content-type"
+# Wait briefly for response headers to flush to disk.
+ct=""
+for _ in $(seq 1 10); do
+  if [ -s "$SSE_HDR" ]; then
+    ct=$(grep -i '^content-type:' "$SSE_HDR" | head -1 | tr -d '\r')
+    [ -n "$ct" ] && break
+  fi
+  sleep 0.3
+done
+if echo "$ct" | grep -qi 'text/event-stream'; then
+  pass
+elif [ -z "$ct" ]; then
+  skip "no response headers captured (endpoint may have closed immediately)"
+  end_suite
+else
+  # Not a hard fail: some deployments serve plain JSON polling under the
+  # same path. We only insist when the path is wired as a real SSE source.
+  skip "endpoint returned non-SSE content-type: ${ct}"
+  end_suite
+fi
+
+# -------------------------------------------------------------------------
+# Trigger a domain event.
+# -------------------------------------------------------------------------
+
+begin_test "Trigger domain event by creating a repository"
+if create_local_repo "$REPO_KEY" "generic"; then
+  pass
+else
+  fail "could not create trigger repo"
+  end_suite
+fi
+
+# -------------------------------------------------------------------------
+# Wait for a frame.
+# -------------------------------------------------------------------------
+
+begin_test "SSE log accumulates a 'data:' frame within 5s"
+saw_frame=false
+for _ in $(seq 1 10); do
+  if grep -qE '^data:|^event:|^id:' "$SSE_LOG" 2>/dev/null; then
+    saw_frame=true
+    break
+  fi
+  sleep 0.5
+done
+if [ "$saw_frame" = true ]; then
+  pass
+else
+  # On 1.1.x backends with the producer disabled, the SSE bridge may be
+  # idle. Skip rather than fail so the test reports a clean signal once
+  # producer wire-up lands.
+  skip "no SSE frame observed; producer may not be wired (v1.1.x)"
+fi
+
+# -------------------------------------------------------------------------
+# Frame shape sanity: if we saw a frame, it must be parseable as SSE.
+# -------------------------------------------------------------------------
+
+if [ "$saw_frame" = true ]; then
+  begin_test "First data frame is non-empty and not HTML"
+  first_data=$(grep '^data:' "$SSE_LOG" | head -1 | sed 's/^data: *//')
+  if [ -n "$first_data" ] && ! echo "$first_data" | grep -qiE '<html|<!doctype'; then
+    pass
+  else
+    fail "first data frame looks invalid: '${first_data:0:100}'"
+  fi
+fi
+
+end_suite

--- a/tests/webhooks/test-events-sse-stream.sh
+++ b/tests/webhooks/test-events-sse-stream.sh
@@ -4,25 +4,23 @@
 # Epic 7 sub-task 7.15 (artifact-keeper-test#75). The backend exposes a
 # server-sent-events stream at /api/v1/events/stream that bridges the
 # in-process EventBus to external HTTP consumers. The platform suite
-# already verifies the endpoint returns 200 but doesn't read any frames
+# already verifies the endpoint returns 200 but does not read any frames
 # off the wire, so this test:
 #
 #   1. Opens a curl SSE connection in the background, writing frames to
 #      a temp file with a hard 10s wall-clock cap (curl --max-time).
 #   2. Triggers a domain event by creating a generic repository, which
-#      should emit a repository.* event onto the bus.
-#   3. Greps the frame log for an SSE-formatted "data:" line. We do NOT
-#      assert event name (the bus -> SSE mapping is version-sensitive)
-#      because the producer wire-up gate (webhook_event_producer) is
-#      v1.2.0; on 1.1.x the SSE bridge may not emit a frame even though
-#      the endpoint is live. Hence: skip cleanly if no frame appears,
-#      and only fail on protocol-shape violations (e.g. the endpoint
-#      returns HTML instead of an event stream).
+#      should emit a repository_created event onto the bus.
+#   3. Asserts an SSE-formatted frame appears in the log within 5s.
 #
-# This is intentionally a thin proof-of-concept; the full SSE coverage
-# (back-pressure, lagged-event handling, JSON payload schema, named
-# event types, last-event-id resumption) is broken out in the epic
-# tracking comment.
+# Gating: SSE-bus frame emission depends on the same producer wire-up
+# that powers webhook deliveries (webhook_event_producer, v1.2.0). On
+# older backends the endpoint is live but the bus does not emit frames
+# for domain events, so the assertion would fail for an unshipped
+# feature. The suite is skipped at the suite level when the producer is
+# unavailable; on supported backends, missing-frame is a HARD FAIL, not
+# a silent skip. This replaces the previous behaviour where the assertion
+# called skip on missing frames (false-green pattern).
 #
 # Requires: curl, jq
 
@@ -32,6 +30,17 @@ begin_suite "events-sse-stream"
 auth_admin
 setup_workdir
 
+# Suite-level gate. If the producer wire-up that powers SSE frames is
+# absent (v1.1.x), skip the whole suite cleanly instead of leaving
+# individual assertions to skip on missing frames.
+backend_ver=$(get_backend_version)
+if [ "$backend_ver" != "unknown" ]; then
+  min_ver=$(_feature_min_version "webhook_event_producer")
+  if ! version_ge "$backend_ver" "$min_ver"; then
+    skip_suite "events SSE producer requires backend >= ${min_ver}, running ${backend_ver}"
+  fi
+fi
+
 REPO_KEY="sse-trigger-${RUN_ID}"
 SSE_LOG="${WORK_DIR}/sse-frames.log"
 SSE_HDR="${WORK_DIR}/sse-headers.log"
@@ -40,7 +49,18 @@ SSE_PID=""
 cleanup_and_finalize() {
   local code=$?
   if [ -n "${SSE_PID}" ] && kill -0 "${SSE_PID}" 2>/dev/null; then
+    # SIGTERM first, then SIGKILL after a brief grace, so a curl that
+    # has already drained its connection exits cleanly while a wedged
+    # one is force-killed. The bounded sleep means cleanup can't hang.
     kill "${SSE_PID}" 2>/dev/null || true
+    for _ in 1 2 3 4 5; do
+      kill -0 "${SSE_PID}" 2>/dev/null || break
+      sleep 0.2
+    done
+    kill -9 "${SSE_PID}" 2>/dev/null || true
+    # The wait builtin returns immediately when the child has exited;
+    # it doesn't block on the curl --max-time window since we've already
+    # signalled. Redirect any "Killed" message from the shell.
     wait "${SSE_PID}" 2>/dev/null || true
   fi
   api_delete "/api/v1/repositories/${REPO_KEY}" >/dev/null 2>&1 || true
@@ -69,7 +89,10 @@ sleep 1
 if kill -0 "$SSE_PID" 2>/dev/null; then
   pass
 else
-  skip "SSE stream did not open (endpoint may not be available)"
+  # The producer feature was gated above; reaching here with a dead
+  # listener means the endpoint itself is not reachable on a backend
+  # that claims to support the feature. Fail hard.
+  fail "SSE listener died within 1s on a backend that claims webhook_event_producer support"
   end_suite
 fi
 
@@ -90,12 +113,10 @@ done
 if echo "$ct" | grep -qi 'text/event-stream'; then
   pass
 elif [ -z "$ct" ]; then
-  skip "no response headers captured (endpoint may have closed immediately)"
+  fail "no response headers captured within 3s; SSE endpoint may be unreachable on a producer-enabled backend"
   end_suite
 else
-  # Not a hard fail: some deployments serve plain JSON polling under the
-  # same path. We only insist when the path is wired as a real SSE source.
-  skip "endpoint returned non-SSE content-type: ${ct}"
+  fail "endpoint returned non-SSE content-type: ${ct}"
   end_suite
 fi
 
@@ -112,12 +133,20 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# Wait for a frame.
+# Wait for a frame. On a feature-enabled backend, missing-frame is a
+# hard FAIL (not a skip): we are explicitly asserting the bus -> SSE
+# bridge emits something when a domain event fires.
 # -------------------------------------------------------------------------
 
 begin_test "SSE log accumulates a 'data:' frame within 5s"
+# Bound the wait against a wall-clock deadline so a wedged grep cannot
+# exceed the expected budget. We compute the deadline once and break out
+# as soon as a frame appears OR the deadline passes; 10 polls of 0.5s
+# would total 5s but a slow grep run could drift past that, so the
+# deadline guard is the load-bearing budget.
 saw_frame=false
-for _ in $(seq 1 10); do
+deadline=$(( $(date +%s) + 6 ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
   if grep -qE '^data:|^event:|^id:' "$SSE_LOG" 2>/dev/null; then
     saw_frame=true
     break
@@ -127,10 +156,7 @@ done
 if [ "$saw_frame" = true ]; then
   pass
 else
-  # On 1.1.x backends with the producer disabled, the SSE bridge may be
-  # idle. Skip rather than fail so the test reports a clean signal once
-  # producer wire-up lands.
-  skip "no SSE frame observed; producer may not be wired (v1.1.x)"
+  fail "no SSE frame observed within 6s after firing repository_created on a producer-enabled backend"
 fi
 
 # -------------------------------------------------------------------------

--- a/tests/webhooks/test-webhook-custom-headers.sh
+++ b/tests/webhooks/test-webhook-custom-headers.sh
@@ -22,10 +22,13 @@
 source "$(dirname "$0")/../lib/common.sh"
 
 begin_suite "webhook-custom-headers"
+auth_admin
+setup_workdir
 
 WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18772}"
 WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
-WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-customhdr-${RUN_ID}.log}"
+WEBHOOK_RECEIVER_LOG="${WORK_DIR}/mock-webhook-receiver-customhdr.log"
+WEBHOOK_RECEIVER_STDERR="${WORK_DIR}/mock-webhook-receiver-customhdr.stderr"
 RECEIVER_PID=""
 
 cleanup_and_finalize() {
@@ -34,12 +37,11 @@ cleanup_and_finalize() {
     kill "${RECEIVER_PID}" 2>/dev/null || true
     wait "${RECEIVER_PID}" 2>/dev/null || true
   fi
-  rm -f "${WEBHOOK_RECEIVER_LOG}"
+  # WORK_DIR (and the logs inside it) are cleaned by setup_workdir's
+  # registered exit handler. No /tmp leakage.
   exit "$code"
 }
 trap cleanup_and_finalize EXIT
-
-auth_admin
 
 # -------------------------------------------------------------------------
 # Pre-flight + receiver.
@@ -55,12 +57,22 @@ if [ -n "$miss" ]; then
 fi
 pass
 
+# Port-collision pre-flight: if something is already listening on
+# WEBHOOK_RECEIVER_PORT, fail loudly rather than silently attaching to a
+# foreign receiver from another concurrent run.
+begin_test "Receiver port ${WEBHOOK_RECEIVER_PORT} is free"
+if curl -sf --max-time 1 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__health" >/dev/null 2>&1; then
+  fail "127.0.0.1:${WEBHOOK_RECEIVER_PORT} already serves /__health (concurrent run? stale receiver?); set WEBHOOK_RECEIVER_PORT to a free port"
+  end_suite
+fi
+pass
+
 begin_test "Start mock receiver"
 WEBHOOK_RECEIVER_PORT="$WEBHOOK_RECEIVER_PORT" \
   WEBHOOK_FAIL_FIRST_N=0 \
   WEBHOOK_RECEIVER_LOG="$WEBHOOK_RECEIVER_LOG" \
   python3 "$(dirname "$0")/../lib/mock-webhook-receiver.py" \
-  >/tmp/mock-webhook-receiver-customhdr-${RUN_ID}.stderr 2>&1 &
+  >"$WEBHOOK_RECEIVER_STDERR" 2>&1 &
 RECEIVER_PID=$!
 
 ready=false

--- a/tests/webhooks/test-webhook-custom-headers.sh
+++ b/tests/webhooks/test-webhook-custom-headers.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# test-webhook-custom-headers.sh - Custom header injection on webhook deliveries
+#
+# Epic 7 sub-task 7.7 (artifact-keeper-test#75). Webhooks v2 wire contract
+# allows operators to pin a small map of custom HTTP headers on a webhook
+# row (commonly used to attach an auth token or routing key for the
+# receiver). Each delivery must carry those headers verbatim alongside the
+# standard X-ArtifactKeeper-* set, and the value must not be reordered or
+# stripped by the delivery worker.
+#
+# Sub-checks:
+#   1. Create a webhook with two custom headers (one ASCII, one with a
+#      symbol-heavy value). POST /api/v1/webhooks/{id}/test fires a
+#      synchronous delivery against the local mock receiver.
+#   2. The receiver records both custom headers with the exact values
+#      supplied at create time.
+#   3. The standard X-ArtifactKeeper-Delivery header is still present
+#      (custom headers must augment, not replace).
+#
+# Requires: curl, jq, python3
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "webhook-custom-headers"
+
+WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18772}"
+WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
+WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-customhdr-${RUN_ID}.log}"
+RECEIVER_PID=""
+
+cleanup_and_finalize() {
+  local code=$?
+  if [ -n "${RECEIVER_PID}" ] && kill -0 "${RECEIVER_PID}" 2>/dev/null; then
+    kill "${RECEIVER_PID}" 2>/dev/null || true
+    wait "${RECEIVER_PID}" 2>/dev/null || true
+  fi
+  rm -f "${WEBHOOK_RECEIVER_LOG}"
+  exit "$code"
+}
+trap cleanup_and_finalize EXIT
+
+auth_admin
+
+# -------------------------------------------------------------------------
+# Pre-flight + receiver.
+# -------------------------------------------------------------------------
+
+begin_test "python3 and jq available"
+miss=""
+command -v python3 >/dev/null 2>&1 || miss="${miss} python3"
+command -v jq      >/dev/null 2>&1 || miss="${miss} jq"
+if [ -n "$miss" ]; then
+  skip "missing tools:${miss}"
+  end_suite
+fi
+pass
+
+begin_test "Start mock receiver"
+WEBHOOK_RECEIVER_PORT="$WEBHOOK_RECEIVER_PORT" \
+  WEBHOOK_FAIL_FIRST_N=0 \
+  WEBHOOK_RECEIVER_LOG="$WEBHOOK_RECEIVER_LOG" \
+  python3 "$(dirname "$0")/../lib/mock-webhook-receiver.py" \
+  >/tmp/mock-webhook-receiver-customhdr-${RUN_ID}.stderr 2>&1 &
+RECEIVER_PID=$!
+
+ready=false
+for _ in $(seq 1 25); do
+  if curl -sf --max-time 1 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__health" >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 0.2
+done
+if [ "$ready" = true ]; then
+  pass
+else
+  fail "mock receiver did not come up on 127.0.0.1:${WEBHOOK_RECEIVER_PORT}"
+  end_suite
+fi
+
+# -------------------------------------------------------------------------
+# Create webhook with custom headers.
+# -------------------------------------------------------------------------
+
+WEBHOOK_NAME="custhdr-${RUN_ID}"
+CUSTOM_TOKEN_VALUE="secret.token.value-${RUN_ID}"
+CUSTOM_ROUTE_VALUE="route/key=abc+xyz"
+
+WEBHOOK_ID=""
+
+begin_test "Create webhook with custom headers"
+payload=$(jq -nc \
+  --arg name "$WEBHOOK_NAME" \
+  --arg url  "$WEBHOOK_RECEIVER_URL" \
+  --arg tok  "$CUSTOM_TOKEN_VALUE" \
+  --arg rte  "$CUSTOM_ROUTE_VALUE" \
+  '{
+    name: $name,
+    url:  $url,
+    events: ["artifact.uploaded"],
+    enabled: true,
+    headers: {
+      "X-Test-Auth-Token": $tok,
+      "X-Test-Route-Key":  $rte
+    }
+  }')
+if resp=$(api_post "/api/v1/webhooks" "$payload" 2>/dev/null); then
+  WEBHOOK_ID=$(echo "$resp" | jq -r '.id // empty')
+  if [ -n "$WEBHOOK_ID" ] && [ "$WEBHOOK_ID" != "null" ]; then
+    pass
+  else
+    skip "webhook create returned no id (custom headers may not be supported on this backend)"
+    end_suite
+  fi
+else
+  skip "webhook create not available or rejected custom headers"
+  end_suite
+fi
+
+# -------------------------------------------------------------------------
+# Trigger synchronous test delivery.
+# -------------------------------------------------------------------------
+
+begin_test "POST /webhooks/{id}/test fires a delivery"
+if api_post "/api/v1/webhooks/${WEBHOOK_ID}/test" "" >/dev/null 2>&1; then
+  pass
+else
+  skip "test delivery endpoint not available"
+  end_suite
+fi
+
+# Allow async receiver to record the request.
+seen=0
+for _ in $(seq 1 20); do
+  seen=$(curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__count" 2>/dev/null || echo 0)
+  if [ "$seen" -gt 0 ]; then
+    break
+  fi
+  sleep 0.5
+done
+
+begin_test "Receiver observed at least one delivery"
+if [ "$seen" -gt 0 ]; then
+  pass
+else
+  fail "receiver did not see any delivery"
+  end_suite
+fi
+
+# -------------------------------------------------------------------------
+# Inspect headers on the last delivery.
+# -------------------------------------------------------------------------
+
+last=$(tail -n1 "$WEBHOOK_RECEIVER_LOG" 2>/dev/null || echo '{}')
+if [ -z "$last" ]; then
+  last='{}'
+fi
+
+begin_test "Custom header X-Test-Auth-Token present with exact value"
+got_tok=$(echo "$last" | jq -r '
+  (.headers["X-Test-Auth-Token"] //
+   .headers["x-test-auth-token"] //
+   empty)')
+if [ "$got_tok" = "$CUSTOM_TOKEN_VALUE" ]; then
+  pass
+else
+  fail "X-Test-Auth-Token: expected='${CUSTOM_TOKEN_VALUE}' got='${got_tok}'"
+fi
+
+begin_test "Custom header X-Test-Route-Key preserves symbol-heavy value"
+got_rte=$(echo "$last" | jq -r '
+  (.headers["X-Test-Route-Key"] //
+   .headers["x-test-route-key"] //
+   empty)')
+if [ "$got_rte" = "$CUSTOM_ROUTE_VALUE" ]; then
+  pass
+else
+  fail "X-Test-Route-Key: expected='${CUSTOM_ROUTE_VALUE}' got='${got_rte}'"
+fi
+
+begin_test "Standard X-ArtifactKeeper-Delivery still present alongside custom headers"
+delivery_id=$(echo "$last" | jq -r '
+  (.headers["X-ArtifactKeeper-Delivery"] //
+   .headers["x-artifactkeeper-delivery"] //
+   empty)')
+if [ -n "$delivery_id" ] && [ "$delivery_id" != "null" ]; then
+  pass
+else
+  fail "X-ArtifactKeeper-Delivery missing on delivery with custom headers"
+fi
+
+# -------------------------------------------------------------------------
+# Cleanup.
+# -------------------------------------------------------------------------
+
+api_delete "/api/v1/webhooks/${WEBHOOK_ID}" >/dev/null 2>&1 || true
+
+end_suite

--- a/tests/webhooks/test-webhook-multi-event-filter.sh
+++ b/tests/webhooks/test-webhook-multi-event-filter.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# test-webhook-multi-event-filter.sh - Multi-event subscription routing
+#
+# Epic 7 sub-task 7.11 (artifact-keeper-test#75). Existing webhook tests
+# only assert delivery of a single event type. The producer must also
+# route every subscribed event independently: a webhook subscribed to
+# "artifact.uploaded" must NOT receive a delivery for "repository.created"
+# fired against an unrelated repo, and vice versa.
+#
+# This test creates two webhooks pointing at the SAME mock receiver but
+# subscribed to disjoint event sets, then triggers a synchronous test
+# delivery on each one. We assert by X-ArtifactKeeper-Event that each
+# delivery only carries the expected event name, and that listing
+# deliveries per webhook returns only that webhook's events.
+#
+# The webhook /test endpoint is intentionally used instead of driving a
+# real artifact upload because we want to keep the test self-contained
+# and avoid the v1.1.x producer-feature-flag gate.
+#
+# Requires: curl, jq, python3
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "webhook-multi-event-filter"
+
+WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18773}"
+WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
+WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-multievt-${RUN_ID}.log}"
+RECEIVER_PID=""
+WEBHOOK_A_ID=""
+WEBHOOK_B_ID=""
+
+cleanup_and_finalize() {
+  local code=$?
+  if [ -n "${RECEIVER_PID}" ] && kill -0 "${RECEIVER_PID}" 2>/dev/null; then
+    kill "${RECEIVER_PID}" 2>/dev/null || true
+    wait "${RECEIVER_PID}" 2>/dev/null || true
+  fi
+  for id in "${WEBHOOK_A_ID}" "${WEBHOOK_B_ID}"; do
+    if [ -n "$id" ] && [ "$id" != "null" ]; then
+      api_delete "/api/v1/webhooks/${id}" >/dev/null 2>&1 || true
+    fi
+  done
+  rm -f "${WEBHOOK_RECEIVER_LOG}"
+  exit "$code"
+}
+trap cleanup_and_finalize EXIT
+
+auth_admin
+
+# -------------------------------------------------------------------------
+# Pre-flight + receiver.
+# -------------------------------------------------------------------------
+
+begin_test "python3 and jq available"
+miss=""
+command -v python3 >/dev/null 2>&1 || miss="${miss} python3"
+command -v jq      >/dev/null 2>&1 || miss="${miss} jq"
+if [ -n "$miss" ]; then
+  skip "missing tools:${miss}"
+  end_suite
+fi
+pass
+
+begin_test "Start mock receiver"
+WEBHOOK_RECEIVER_PORT="$WEBHOOK_RECEIVER_PORT" \
+  WEBHOOK_FAIL_FIRST_N=0 \
+  WEBHOOK_RECEIVER_LOG="$WEBHOOK_RECEIVER_LOG" \
+  python3 "$(dirname "$0")/../lib/mock-webhook-receiver.py" \
+  >/tmp/mock-webhook-receiver-multievt-${RUN_ID}.stderr 2>&1 &
+RECEIVER_PID=$!
+
+ready=false
+for _ in $(seq 1 25); do
+  if curl -sf --max-time 1 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__health" >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 0.2
+done
+if [ "$ready" = true ]; then
+  pass
+else
+  fail "mock receiver did not come up on 127.0.0.1:${WEBHOOK_RECEIVER_PORT}"
+  end_suite
+fi
+
+# -------------------------------------------------------------------------
+# Create two webhooks with disjoint event subscriptions.
+# -------------------------------------------------------------------------
+
+WEBHOOK_A_NAME="multievt-a-${RUN_ID}"
+WEBHOOK_B_NAME="multievt-b-${RUN_ID}"
+
+begin_test "Create webhook A subscribed to artifact.uploaded only"
+payload_a=$(jq -nc \
+  --arg name "$WEBHOOK_A_NAME" \
+  --arg url  "$WEBHOOK_RECEIVER_URL" \
+  '{name: $name, url: $url, events: ["artifact.uploaded"], enabled: true}')
+if resp=$(api_post "/api/v1/webhooks" "$payload_a" 2>/dev/null); then
+  WEBHOOK_A_ID=$(echo "$resp" | jq -r '.id // empty')
+  if [ -n "$WEBHOOK_A_ID" ] && [ "$WEBHOOK_A_ID" != "null" ]; then
+    pass
+  else
+    skip "webhook A create returned no id"
+    end_suite
+  fi
+else
+  skip "webhook create endpoint not available"
+  end_suite
+fi
+
+begin_test "Create webhook B subscribed to repository.created only"
+payload_b=$(jq -nc \
+  --arg name "$WEBHOOK_B_NAME" \
+  --arg url  "$WEBHOOK_RECEIVER_URL" \
+  '{name: $name, url: $url, events: ["repository.created"], enabled: true}')
+if resp=$(api_post "/api/v1/webhooks" "$payload_b" 2>/dev/null); then
+  WEBHOOK_B_ID=$(echo "$resp" | jq -r '.id // empty')
+  if [ -n "$WEBHOOK_B_ID" ] && [ "$WEBHOOK_B_ID" != "null" ]; then
+    pass
+  else
+    skip "webhook B create returned no id (backend may not support repository.created subscriptions)"
+    end_suite
+  fi
+else
+  skip "webhook B create rejected"
+  end_suite
+fi
+
+# -------------------------------------------------------------------------
+# Fire a synchronous test delivery on each webhook and inspect the
+# X-ArtifactKeeper-Event header to confirm each row carries its own event
+# name, not a cross-contaminated one.
+# -------------------------------------------------------------------------
+
+begin_test "Trigger test delivery on webhook A"
+if api_post "/api/v1/webhooks/${WEBHOOK_A_ID}/test" "" >/dev/null 2>&1; then
+  pass
+else
+  skip "test delivery endpoint not available"
+  end_suite
+fi
+
+begin_test "Trigger test delivery on webhook B"
+if api_post "/api/v1/webhooks/${WEBHOOK_B_ID}/test" "" >/dev/null 2>&1; then
+  pass
+else
+  skip "test delivery endpoint not available for webhook B"
+  end_suite
+fi
+
+# Wait for receiver to record two deliveries.
+seen=0
+for _ in $(seq 1 30); do
+  seen=$(curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__count" 2>/dev/null || echo 0)
+  if [ "$seen" -ge 2 ]; then
+    break
+  fi
+  sleep 0.5
+done
+
+begin_test "Receiver observed both deliveries"
+if [ "$seen" -ge 2 ]; then
+  pass
+else
+  fail "receiver count=${seen}, expected >=2"
+  end_suite
+fi
+
+# -------------------------------------------------------------------------
+# Parse the log and verify each delivery's event header matches the
+# subscribed event. The /test endpoint commonly emits a "webhook.test"
+# event rather than the subscribed event in some backend versions, so
+# we accept either the subscribed name or "webhook.test" as the wire
+# value, but require both webhooks to NOT see each other's domain event.
+# -------------------------------------------------------------------------
+
+mapfile -t event_headers < <(
+  jq -r '(.headers["X-ArtifactKeeper-Event"] //
+          .headers["x-artifactkeeper-event"] //
+          "")' "$WEBHOOK_RECEIVER_LOG" 2>/dev/null || true
+)
+
+begin_test "All deliveries carry a non-empty X-ArtifactKeeper-Event header"
+missing=0
+for ev in "${event_headers[@]}"; do
+  if [ -z "$ev" ]; then
+    missing=$(( missing + 1 ))
+  fi
+done
+if [ "$missing" -eq 0 ] && [ "${#event_headers[@]}" -ge 2 ]; then
+  pass
+else
+  fail "missing event header on ${missing}/${#event_headers[@]} deliveries"
+fi
+
+begin_test "At most one delivery per subscribed event reached the receiver"
+# We can't separate A's vs B's deliveries from the shared receiver log
+# without the X-ArtifactKeeper-Delivery -> webhook_id mapping the
+# producer doesn't expose on the wire. What we can verify is that two
+# /test calls produced exactly two deliveries (not 4, which would imply
+# cross-subscription leakage where webhook A also received B's event).
+if [ "${#event_headers[@]}" -le 3 ]; then
+  pass
+else
+  fail "expected <=3 deliveries from two /test calls, got ${#event_headers[@]} (cross-subscription leak?)"
+fi
+
+begin_test "Webhook A delivery list returns only A's events"
+if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_A_ID}/deliveries" 2>/dev/null); then
+  bad=$(echo "$resp" | jq -r '
+    if type == "array" then .
+    elif .deliveries then .deliveries
+    else [] end
+    | map(select(.event_name == "repository.created" or .event == "repository.created"))
+    | length' 2>/dev/null || echo 0)
+  if [ "$bad" = "0" ]; then
+    pass
+  else
+    fail "webhook A delivery list returned ${bad} repository.created rows"
+  fi
+else
+  skip "delivery listing not available"
+fi
+
+end_suite

--- a/tests/webhooks/test-webhook-multi-event-filter.sh
+++ b/tests/webhooks/test-webhook-multi-event-filter.sh
@@ -7,28 +7,47 @@
 # "artifact.uploaded" must NOT receive a delivery for "repository.created"
 # fired against an unrelated repo, and vice versa.
 #
-# This test creates two webhooks pointing at the SAME mock receiver but
-# subscribed to disjoint event sets, then triggers a synchronous test
-# delivery on each one. We assert by X-ArtifactKeeper-Event that each
-# delivery only carries the expected event name, and that listing
-# deliveries per webhook returns only that webhook's events.
+# Approach: create two webhooks pointing at the same mock receiver but
+# subscribed to disjoint event sets, then drive REAL domain events
+# (artifact upload + repository create), and assert via the per-webhook
+# /deliveries endpoint that each webhook's row set contains only its own
+# event. The previous revision of this test used POST /webhooks/{id}/test
+# as a trigger and asserted total receiver count <= 3, which is a counting
+# heuristic, not a routing check; that approach is replaced here.
 #
-# The webhook /test endpoint is intentionally used instead of driving a
-# real artifact upload because we want to keep the test self-contained
-# and avoid the v1.1.x producer-feature-flag gate.
+# Gating: the producer that turns EventBus events into webhook_deliveries
+# rows ships in v1.2.0 (webhook_event_producer feature flag). On older
+# backends this whole suite is skipped at the suite level; partial
+# assertions don't silently degrade.
 #
 # Requires: curl, jq, python3
 
 source "$(dirname "$0")/../lib/common.sh"
 
 begin_suite "webhook-multi-event-filter"
+auth_admin
+setup_workdir
+
+# Suite-level gate: producer wire-up landed in v1.2.0. Without it, real
+# EventBus events do not enqueue webhook_deliveries rows, so the routing
+# assertion below cannot run. Skipping at the suite level avoids the
+# false-green pattern where individual assertions skip on missing rows.
+backend_ver=$(get_backend_version)
+if [ "$backend_ver" != "unknown" ]; then
+  min_ver=$(_feature_min_version "webhook_event_producer")
+  if ! version_ge "$backend_ver" "$min_ver"; then
+    skip_suite "webhook_event_producer requires backend >= ${min_ver}, running ${backend_ver}"
+  fi
+fi
 
 WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18773}"
 WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
-WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-multievt-${RUN_ID}.log}"
+WEBHOOK_RECEIVER_LOG="${WORK_DIR}/mock-webhook-receiver-multievt.log"
+WEBHOOK_RECEIVER_STDERR="${WORK_DIR}/mock-webhook-receiver-multievt.stderr"
 RECEIVER_PID=""
 WEBHOOK_A_ID=""
 WEBHOOK_B_ID=""
+TRIGGER_REPO_KEY="multievt-trigger-${RUN_ID}"
 
 cleanup_and_finalize() {
   local code=$?
@@ -41,12 +60,12 @@ cleanup_and_finalize() {
       api_delete "/api/v1/webhooks/${id}" >/dev/null 2>&1 || true
     fi
   done
-  rm -f "${WEBHOOK_RECEIVER_LOG}"
+  api_delete "/api/v1/repositories/${TRIGGER_REPO_KEY}" >/dev/null 2>&1 || true
+  # WORK_DIR (and the logs inside it) are cleaned by setup_workdir's
+  # registered exit handler. No /tmp leakage.
   exit "$code"
 }
 trap cleanup_and_finalize EXIT
-
-auth_admin
 
 # -------------------------------------------------------------------------
 # Pre-flight + receiver.
@@ -62,12 +81,22 @@ if [ -n "$miss" ]; then
 fi
 pass
 
+# Port-collision pre-flight: if something is already listening on
+# WEBHOOK_RECEIVER_PORT, fail loudly with a clear message rather than
+# silently attaching to a foreign receiver from another concurrent run.
+begin_test "Receiver port ${WEBHOOK_RECEIVER_PORT} is free"
+if curl -sf --max-time 1 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__health" >/dev/null 2>&1; then
+  fail "127.0.0.1:${WEBHOOK_RECEIVER_PORT} already serves /__health (concurrent run? stale receiver?); set WEBHOOK_RECEIVER_PORT to a free port"
+  end_suite
+fi
+pass
+
 begin_test "Start mock receiver"
 WEBHOOK_RECEIVER_PORT="$WEBHOOK_RECEIVER_PORT" \
   WEBHOOK_FAIL_FIRST_N=0 \
   WEBHOOK_RECEIVER_LOG="$WEBHOOK_RECEIVER_LOG" \
   python3 "$(dirname "$0")/../lib/mock-webhook-receiver.py" \
-  >/tmp/mock-webhook-receiver-multievt-${RUN_ID}.stderr 2>&1 &
+  >"$WEBHOOK_RECEIVER_STDERR" 2>&1 &
 RECEIVER_PID=$!
 
 ready=false
@@ -87,141 +116,206 @@ fi
 
 # -------------------------------------------------------------------------
 # Create two webhooks with disjoint event subscriptions.
+#
+# The wire event name uses underscores in the producer mapping
+# (see test-webhook-delivery.sh): repository_created and
+# artifact_uploaded. Some backend revisions accept the dot form as an
+# alias on the way in; we use underscores since that matches what the
+# producer emits onto the wire.
 # -------------------------------------------------------------------------
 
 WEBHOOK_A_NAME="multievt-a-${RUN_ID}"
 WEBHOOK_B_NAME="multievt-b-${RUN_ID}"
 
-begin_test "Create webhook A subscribed to artifact.uploaded only"
+begin_test "Create webhook A subscribed to artifact_uploaded only"
 payload_a=$(jq -nc \
   --arg name "$WEBHOOK_A_NAME" \
   --arg url  "$WEBHOOK_RECEIVER_URL" \
-  '{name: $name, url: $url, events: ["artifact.uploaded"], enabled: true}')
+  '{name: $name, url: $url, events: ["artifact_uploaded"], enabled: true}')
 if resp=$(api_post "/api/v1/webhooks" "$payload_a" 2>/dev/null); then
   WEBHOOK_A_ID=$(echo "$resp" | jq -r '.id // empty')
   if [ -n "$WEBHOOK_A_ID" ] && [ "$WEBHOOK_A_ID" != "null" ]; then
     pass
   else
-    skip "webhook A create returned no id"
+    fail "webhook A create returned no id: ${resp:0:200}"
     end_suite
   fi
 else
-  skip "webhook create endpoint not available"
+  fail "webhook A create request failed"
   end_suite
 fi
 
-begin_test "Create webhook B subscribed to repository.created only"
+begin_test "Create webhook B subscribed to repository_created only"
 payload_b=$(jq -nc \
   --arg name "$WEBHOOK_B_NAME" \
   --arg url  "$WEBHOOK_RECEIVER_URL" \
-  '{name: $name, url: $url, events: ["repository.created"], enabled: true}')
+  '{name: $name, url: $url, events: ["repository_created"], enabled: true}')
 if resp=$(api_post "/api/v1/webhooks" "$payload_b" 2>/dev/null); then
   WEBHOOK_B_ID=$(echo "$resp" | jq -r '.id // empty')
   if [ -n "$WEBHOOK_B_ID" ] && [ "$WEBHOOK_B_ID" != "null" ]; then
     pass
   else
-    skip "webhook B create returned no id (backend may not support repository.created subscriptions)"
+    fail "webhook B create returned no id: ${resp:0:200}"
     end_suite
   fi
 else
-  skip "webhook B create rejected"
+  fail "webhook B create request failed"
   end_suite
 fi
 
 # -------------------------------------------------------------------------
-# Fire a synchronous test delivery on each webhook and inspect the
-# X-ArtifactKeeper-Event header to confirm each row carries its own event
-# name, not a cross-contaminated one.
+# Drive a real repository_created event by creating a repo. This must
+# enqueue exactly one row on webhook B's delivery list and zero on A's.
 # -------------------------------------------------------------------------
 
-begin_test "Trigger test delivery on webhook A"
-if api_post "/api/v1/webhooks/${WEBHOOK_A_ID}/test" "" >/dev/null 2>&1; then
+begin_test "Create repo to fire repository_created"
+REPO_CREATE_PAYLOAD=$(jq -nc --arg k "$TRIGGER_REPO_KEY" \
+  '{key:$k, name:$k, format:"generic", repo_type:"local", is_public:true}')
+if api_post "/api/v1/repositories" "$REPO_CREATE_PAYLOAD" >/dev/null 2>&1; then
   pass
 else
-  skip "test delivery endpoint not available"
+  fail "repo create failed; cannot fire repository_created"
   end_suite
 fi
 
-begin_test "Trigger test delivery on webhook B"
-if api_post "/api/v1/webhooks/${WEBHOOK_B_ID}/test" "" >/dev/null 2>&1; then
+# -------------------------------------------------------------------------
+# Drive a real artifact_uploaded event by uploading a file into the new
+# repo. This must enqueue at least one row on webhook A's delivery list
+# and zero on B's.
+# -------------------------------------------------------------------------
+
+begin_test "Upload artifact to fire artifact_uploaded"
+echo "multievt-payload-${RUN_ID}" > "${WORK_DIR}/payload.txt"
+if api_upload "/api/v1/repositories/${TRIGGER_REPO_KEY}/artifacts/payload/${RUN_ID}.txt" \
+    "${WORK_DIR}/payload.txt" >/dev/null 2>&1; then
   pass
 else
-  skip "test delivery endpoint not available for webhook B"
+  fail "artifact upload failed; cannot fire artifact_uploaded"
   end_suite
 fi
 
-# Wait for receiver to record two deliveries.
-seen=0
-for _ in $(seq 1 30); do
-  seen=$(curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__count" 2>/dev/null || echo 0)
-  if [ "$seen" -ge 2 ]; then
-    break
+# -------------------------------------------------------------------------
+# Poll the per-webhook /deliveries endpoint. This is the load-bearing
+# contract: if it's not exposed, the routing assertion cannot be made,
+# and the test MUST FAIL (not skip) so the gap is visible. The endpoint
+# has shipped since the webhooks v2 wire contract landed; absence on a
+# v1.2.0+ backend is a regression we want to catch.
+# -------------------------------------------------------------------------
+
+DELIVERIES_A=""
+DELIVERIES_B=""
+
+begin_test "Webhook A /deliveries reachable"
+for _ in $(seq 1 15); do
+  if DELIVERIES_A=$(api_get "/api/v1/webhooks/${WEBHOOK_A_ID}/deliveries" 2>/dev/null); then
+    if [ -n "$DELIVERIES_A" ] && [ "$DELIVERIES_A" != "null" ]; then
+      break
+    fi
   fi
-  sleep 0.5
+  sleep 2
 done
-
-begin_test "Receiver observed both deliveries"
-if [ "$seen" -ge 2 ]; then
+if [ -n "$DELIVERIES_A" ] && [ "$DELIVERIES_A" != "null" ]; then
   pass
 else
-  fail "receiver count=${seen}, expected >=2"
+  fail "/api/v1/webhooks/${WEBHOOK_A_ID}/deliveries returned empty after 30s; routing cannot be asserted"
   end_suite
 fi
 
-# -------------------------------------------------------------------------
-# Parse the log and verify each delivery's event header matches the
-# subscribed event. The /test endpoint commonly emits a "webhook.test"
-# event rather than the subscribed event in some backend versions, so
-# we accept either the subscribed name or "webhook.test" as the wire
-# value, but require both webhooks to NOT see each other's domain event.
-# -------------------------------------------------------------------------
-
-mapfile -t event_headers < <(
-  jq -r '(.headers["X-ArtifactKeeper-Event"] //
-          .headers["x-artifactkeeper-event"] //
-          "")' "$WEBHOOK_RECEIVER_LOG" 2>/dev/null || true
-)
-
-begin_test "All deliveries carry a non-empty X-ArtifactKeeper-Event header"
-missing=0
-for ev in "${event_headers[@]}"; do
-  if [ -z "$ev" ]; then
-    missing=$(( missing + 1 ))
+begin_test "Webhook B /deliveries reachable"
+for _ in $(seq 1 15); do
+  if DELIVERIES_B=$(api_get "/api/v1/webhooks/${WEBHOOK_B_ID}/deliveries" 2>/dev/null); then
+    if [ -n "$DELIVERIES_B" ] && [ "$DELIVERIES_B" != "null" ]; then
+      break
+    fi
   fi
+  sleep 2
 done
-if [ "$missing" -eq 0 ] && [ "${#event_headers[@]}" -ge 2 ]; then
+if [ -n "$DELIVERIES_B" ] && [ "$DELIVERIES_B" != "null" ]; then
   pass
 else
-  fail "missing event header on ${missing}/${#event_headers[@]} deliveries"
+  fail "/api/v1/webhooks/${WEBHOOK_B_ID}/deliveries returned empty after 30s; routing cannot be asserted"
+  end_suite
 fi
 
-begin_test "At most one delivery per subscribed event reached the receiver"
-# We can't separate A's vs B's deliveries from the shared receiver log
-# without the X-ArtifactKeeper-Delivery -> webhook_id mapping the
-# producer doesn't expose on the wire. What we can verify is that two
-# /test calls produced exactly two deliveries (not 4, which would imply
-# cross-subscription leakage where webhook A also received B's event).
-if [ "${#event_headers[@]}" -le 3 ]; then
-  pass
-else
-  fail "expected <=3 deliveries from two /test calls, got ${#event_headers[@]} (cross-subscription leak?)"
-fi
-
-begin_test "Webhook A delivery list returns only A's events"
-if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_A_ID}/deliveries" 2>/dev/null); then
-  bad=$(echo "$resp" | jq -r '
+# Normalise the delivery payload to a flat array. Different backend
+# revisions wrap rows in {items:[...]}, {deliveries:[...]}, or return a
+# bare array; the jq filter handles all three.
+_normalize() {
+  echo "$1" | jq -c '
     if type == "array" then .
+    elif .items then .items
     elif .deliveries then .deliveries
-    else [] end
-    | map(select(.event_name == "repository.created" or .event == "repository.created"))
-    | length' 2>/dev/null || echo 0)
-  if [ "$bad" = "0" ]; then
-    pass
-  else
-    fail "webhook A delivery list returned ${bad} repository.created rows"
-  fi
+    else [] end' 2>/dev/null || echo '[]'
+}
+
+DELIVERIES_A_ARR=$(_normalize "$DELIVERIES_A")
+DELIVERIES_B_ARR=$(_normalize "$DELIVERIES_B")
+
+# -------------------------------------------------------------------------
+# Cross-routing assertion: webhook A (subscribed only to artifact_uploaded)
+# must have ZERO rows whose event is repository_created. This is the real
+# routing check, replacing the old "<=3 total deliveries" heuristic.
+# -------------------------------------------------------------------------
+
+begin_test "Webhook A has zero repository_created rows"
+bad_a=$(echo "$DELIVERIES_A_ARR" | jq '
+  map(select(
+    (.event == "repository_created") or
+    (.event == "repository.created") or
+    (.event_name == "repository_created") or
+    (.event_name == "repository.created")
+  )) | length' 2>/dev/null || echo 0)
+if [ "$bad_a" = "0" ]; then
+  pass
 else
-  skip "delivery listing not available"
+  fail "webhook A leaked ${bad_a} repository_created rows (cross-subscription routing failure)"
+fi
+
+# -------------------------------------------------------------------------
+# Mirror assertion: webhook B (subscribed only to repository_created) must
+# have ZERO rows whose event is artifact_uploaded.
+# -------------------------------------------------------------------------
+
+begin_test "Webhook B has zero artifact_uploaded rows"
+bad_b=$(echo "$DELIVERIES_B_ARR" | jq '
+  map(select(
+    (.event == "artifact_uploaded") or
+    (.event == "artifact.uploaded") or
+    (.event_name == "artifact_uploaded") or
+    (.event_name == "artifact.uploaded")
+  )) | length' 2>/dev/null || echo 0)
+if [ "$bad_b" = "0" ]; then
+  pass
+else
+  fail "webhook B leaked ${bad_b} artifact_uploaded rows (cross-subscription routing failure)"
+fi
+
+# -------------------------------------------------------------------------
+# Positive-side sanity: at least one of the two webhooks should have a
+# matching row for its subscribed event. If both are empty, the producer
+# isn't running and the cross-leak assertions above were vacuously true;
+# that's a regression we still want to surface.
+# -------------------------------------------------------------------------
+
+begin_test "At least one webhook recorded its own subscribed event"
+ok_a=$(echo "$DELIVERIES_A_ARR" | jq '
+  map(select(
+    (.event == "artifact_uploaded") or
+    (.event == "artifact.uploaded") or
+    (.event_name == "artifact_uploaded") or
+    (.event_name == "artifact.uploaded")
+  )) | length' 2>/dev/null || echo 0)
+ok_b=$(echo "$DELIVERIES_B_ARR" | jq '
+  map(select(
+    (.event == "repository_created") or
+    (.event == "repository.created") or
+    (.event_name == "repository_created") or
+    (.event_name == "repository.created")
+  )) | length' 2>/dev/null || echo 0)
+if [ "$ok_a" -gt 0 ] || [ "$ok_b" -gt 0 ]; then
+  pass
+else
+  fail "neither webhook recorded its subscribed event (A=${ok_a} artifact_uploaded, B=${ok_b} repository_created); producer may not be enqueuing rows"
 fi
 
 end_suite


### PR DESCRIPTION
## Summary

Three new webhook/event tests and three new search/browse tests covering the residual gaps in epic 7 (#75), epic 8 (#73), and the leftover sub-tasks in #85 that PR #139 did not address.

PR #139 already rewrote 7 of the 8 webhook tests against the v2 wire contract. This PR ships the two remaining sub-tasks from #85 (custom headers and multi-event filtering), plus thin proof-of-concept tests for each epic so the epics have concrete prior art rather than just a sub-issue list.

## What was already done

PR #139 (merged 2026-05-10) covered the bulk of issue #85:
- `test-webhook-hmac-signature.sh` -- v2 multi-value `v1=` token + legacy header coexistence
- `test-webhook-retry-recover.sh` -- 12-attempt jittered schedule, retry-attempt header
- `test-webhook-deadletter.sh` -- auto-disable on exhaustion
- `test-webhook-delivery.sh` -- wire-header assertions on real deliveries
- `test-webhook-event-versioning.sh` -- `event_schema_version` default + validation
- `test-webhook-replay-window.sh` -- offline t-window verifier
- `test-webhook-rotation-overlap.sh` -- dual-secret rotation window

Issue #85 will be closed referencing #139 and this PR.

## New tests (this PR)

Webhooks/events (Epic 7, #75):

- `tests/webhooks/test-webhook-custom-headers.sh` -- sub-task 7.7. Asserts custom header injection survives the delivery worker verbatim, alongside standard `X-ArtifactKeeper-Delivery`.
- `tests/webhooks/test-webhook-multi-event-filter.sh` -- sub-task 7.11. Pins per-webhook event routing: two webhooks subscribed to disjoint event sets pointing at the same receiver must not leak each other's events.
- `tests/webhooks/test-events-sse-stream.sh` -- sub-task 7.15. SSE event stream smoke: opens `/api/v1/events/stream`, triggers `repository.created`, asserts `text/event-stream` content-type and a parseable `data:` frame.

Search/browse (Epic 8, #73):

- `tests/search/test-search-advanced-filters.sh` -- sub-tasks 8.1, 8.2, 8.5. Pins `min_size` / `max_size` / `created_after` / `repository_key` on `/api/v1/search/advanced` using a known three-sentinel corpus with a decoy repo.
- `tests/search/test-search-tree-browse.sh` -- sub-task 8.10. Smoke-tests the 709-line tree browse handler at root, repo, and path levels.
- `tests/search/test-search-pagination.sh` -- sub-task 8.11. Pins pagination edge cases: `page=0`, `page=-1`, `per_page=0`, plus the normal-case sanity hit.

## Epic breakdown

Issues #75 and #73 receive separate comments enumerating the remaining sub-tasks that should each become their own sub-issue. These epics stay open after this PR merges; the comments are the authoritative next-step list.

## Test plan

- [ ] CI release-gate runs the new tests via `scripts/run-suite.sh --suite webhooks` and `--suite search` (auto-discovery, no workflow changes needed).
- [ ] On a 1.2-dev backend with `WEBHOOKS_V2_PRODUCER_ENABLED=1`, each new webhook test passes against a local mock receiver.
- [ ] On any 1.1.x or 1.2.x backend with search wired, each new search test passes or cleanly skips on missing endpoints.
- [ ] `bash -n` and `shellcheck --severity=warning` are clean on all six new scripts.

## Notes

- No release-gate YAML changes: `scripts/run-suite.sh` auto-discovers `test-*.sh` files, and both `webhooks` and `search` are already in the matrix.
- Mock-receiver port allocations: 18772 (custom-headers), 18773 (multi-event). Existing tests use 18765-18771.
- SSE test intentionally skips rather than fails on absent frames; the producer wire-up is gated by the `webhook_event_producer` flag (min version 1.2.0).