### PR TITLE
test(gate): scan-completion + SBOM silent-success class coverage (#46, #47, #56, #57, #61, #62, #64)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1578,7 +1578,7 @@ jobs:
           path: /tmp/all-results/
           if-no-files-found: ignore
 
-      - name: Gate check - fail if any required suite failed
+      - name: Gate check - fail if any required suite did not succeed
         # stress-tests and security-tests are intentionally excluded from
         # this rollup. Both have continue-on-error: true (see the comments
         # above each job) so their outcome can be 'failure' on
@@ -1589,15 +1589,27 @@ jobs:
         #   - security-tests: Grype DB not pre-seeded in v1.1.x backend
         #     image; quality gate is last-scanner-wins so Trivy covers
         #     the policy gate (artifact-keeper#1001).
-        # clean-install-smoke-with-deps is opt-in (gated on the
-        # `run_smoke_with_deps` workflow input, default false; see #53).
-        # When the input is false the job's result is 'skipped', which
-        # is neither 'failure' nor 'cancelled', so the rule below
-        # tolerates that case automatically. When the input is true,
-        # a failure DOES block the release: the line is included in
-        # the check below.
+        #
+        # The three new silent-success gates (scan-completion-gate,
+        # sbom-correctness-gate, pinned-cve-gate) use the STRICTER
+        # `result != 'success'` predicate. The looser
+        # `result == 'failure' || result == 'cancelled'` form lets a
+        # 'skipped' outcome (matrix-leg eval failure, future conditional
+        # `if:` gate, or a transitive `needs:` skip when `deploy` is
+        # skipped) through as green. For the silent-success gates that
+        # is precisely the regression class we are guarding against, so
+        # we close it explicitly.
+        #
+        # clean-install-smoke-with-deps is the one legitimate 'skipped'
+        # case: it is opt-in (gated on the `run_smoke_with_deps` workflow
+        # input, default false; see #53). When the input is false the
+        # job's result is 'skipped' by design. We continue to use the
+        # looser predicate for it so the default-off path stays green.
+        # When the input is true, a failure or cancellation DOES block
+        # the release.
+        #
         # The wildcard form contains(needs.*.result, 'failure') still
-        # observes those failures because needs.<job>.result reflects the
+        # observes failures because needs.<job>.result reflects the
         # job's outcome, not its continue-on-error-adjusted conclusion.
         # So we list the required suites explicitly here. If you add a
         # new required suite, add it to this list. Soft-failing suites
@@ -1608,9 +1620,9 @@ jobs:
           needs.clean-install-smoke-with-deps.result == 'failure' || needs.clean-install-smoke-with-deps.result == 'cancelled' ||
           needs.chart-upgrade-smoke.result == 'failure' || needs.chart-upgrade-smoke.result == 'cancelled' ||
           needs.real-flow-smoke.result == 'failure' || needs.real-flow-smoke.result == 'cancelled' ||
-          needs.scan-completion-gate.result == 'failure' || needs.scan-completion-gate.result == 'cancelled' ||
-          needs.sbom-correctness-gate.result == 'failure' || needs.sbom-correctness-gate.result == 'cancelled' ||
-          needs.pinned-cve-gate.result == 'failure' || needs.pinned-cve-gate.result == 'cancelled' ||
+          needs.scan-completion-gate.result != 'success' ||
+          needs.sbom-correctness-gate.result != 'success' ||
+          needs.pinned-cve-gate.result != 'success' ||
           needs.deploy.result == 'failure' || needs.deploy.result == 'cancelled' ||
           needs.format-tests.result == 'failure' || needs.format-tests.result == 'cancelled' ||
           needs.compatibility-tests.result == 'failure' || needs.compatibility-tests.result == 'cancelled' ||

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -680,10 +680,91 @@ jobs:
       # under the oci matrix entry once the oci fixture-builder lands
       # (#62 + #64 extension).
       EXPECTED_VULN_CVE: CVE-2019-10744
+      # Trivy DB age threshold for the freshness pre-flight. The DB is
+      # rebuilt every 6 hours upstream; we accept anything <= 14 days
+      # so weekend gaps and slow mirror sync do not generate false
+      # failures, while still catching DBs old enough that
+      # CVE-2019-10744 (published 2019) could fall out of recent index
+      # shards. Override at workflow_dispatch via repo variable
+      # TRIVY_DB_MAX_AGE_DAYS if needed.
+      TRIVY_DB_MAX_AGE_DAYS: ${{ vars.TRIVY_DB_MAX_AGE_DAYS || '14' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: artifact-keeper/artifact-keeper-test
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
+
+      - name: Trivy DB freshness pre-flight
+        # Distinguish "CVE database is stale" from "CVE-2019-10744 not
+        # surfaced". Without this step, a stale Trivy DB on the runner
+        # image causes the assertion to silently pass (no CVE found ==
+        # 0 findings == "did Trivy run at all?"). The misleading failure
+        # message blames the gate; the actual root cause is upstream.
+        #
+        # Exit codes:
+        #   0  - DB reachable, age within TRIVY_DB_MAX_AGE_DAYS
+        #   42 - DB too old (distinct so the rollup operator can tell
+        #        scanner DB drift apart from a real CVE-detection bug)
+        #   43 - Trivy pod unreachable or trivy --version failed
+        run: |
+          set -uo pipefail
+          NS="test-${{ needs.deploy.outputs.run_id }}"
+          MAX_AGE_DAYS="${TRIVY_DB_MAX_AGE_DAYS}"
+          MAX_AGE_SECONDS=$(( MAX_AGE_DAYS * 86400 ))
+
+          # Locate the Trivy pod. The Helm chart names the deployment
+          # artifact-keeper-trivy; we kubectl-exec into the first ready
+          # pod backed by that deployment.
+          POD=$(kubectl -n "$NS" get pods \
+            -l app.kubernetes.io/name=trivy \
+            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+          if [ -z "$POD" ]; then
+            echo "::error::Trivy pod not found in namespace ${NS} (pre-flight cannot run)"
+            exit 43
+          fi
+
+          # trivy --version emits "Vulnerability DB: ... UpdatedAt: 2026-04-30 ..."
+          # in older versions and a YAML-ish block in newer versions.
+          # Parse both shapes.
+          VER_OUT=$(kubectl -n "$NS" exec "$POD" -c trivy -- trivy --version 2>/dev/null \
+            || kubectl -n "$NS" exec "$POD" -- trivy --version 2>/dev/null \
+            || true)
+          if [ -z "$VER_OUT" ]; then
+            echo "::error::trivy --version returned empty output from pod ${POD}"
+            exit 43
+          fi
+          echo "trivy --version output:"
+          echo "$VER_OUT"
+          echo ""
+
+          # Extract UpdatedAt timestamp. Format varies:
+          #   "  UpdatedAt: 2026-04-30 12:34:56.789 +0000 UTC"
+          #   "    UpdatedAt 2026-04-30 12:34:56.789 +0000 UTC"
+          DB_DATE=$(echo "$VER_OUT" | grep -iE 'UpdatedAt' | head -n1 \
+            | sed -E 's/.*UpdatedAt[: ]+([0-9-]+ [0-9:.]+).*/\1/' \
+            | awk '{print $1" "$2}')
+          if [ -z "$DB_DATE" ] || ! date -d "$DB_DATE" +%s >/dev/null 2>&1; then
+            echo "::error::Could not parse Trivy DB UpdatedAt from --version output"
+            exit 43
+          fi
+
+          DB_EPOCH=$(date -d "$DB_DATE" -u +%s)
+          NOW_EPOCH=$(date -u +%s)
+          AGE_SECONDS=$(( NOW_EPOCH - DB_EPOCH ))
+          AGE_DAYS=$(( AGE_SECONDS / 86400 ))
+
+          echo "Trivy DB UpdatedAt: ${DB_DATE} (age: ${AGE_DAYS} days, threshold: ${MAX_AGE_DAYS} days)"
+
+          if [ "$AGE_SECONDS" -gt "$MAX_AGE_SECONDS" ]; then
+            echo "::error::Trivy DB is ${AGE_DAYS} days old, exceeds threshold of ${MAX_AGE_DAYS} days."
+            echo "::error::The pinned-CVE assertion below would surface a misleading 'CVE-2019-10744 not found' failure;"
+            echo "::error::the actual root cause is upstream DB staleness. Refresh Trivy DB or bump the runner image."
+            exit 42
+          fi
+
+          echo "Trivy DB freshness OK."
 
       - name: Run pinned-CVE gate
         run: |

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -491,6 +491,177 @@ jobs:
           if-no-files-found: ignore
 
   # -------------------------------------------------------------------
+  # Scan-completion gate (matrix across representative formats).
+  #
+  # Closes the gap surfaced by artifact-keeper#888 ("works for npm,
+  # silently fails for docker"). Each matrix entry runs the gate
+  # primitive in its own job (parallel) so a regression in any one
+  # format's scanner pipeline fails the release-gate loud.
+  #
+  # The wired formats (currently: npm) run the lite primitive at
+  # tests/security/test-scan-completes.sh via the release-gate wrapper.
+  # The scaffolded formats (oci, maven, pypi, cargo, helm) exit 0 with
+  # a clear log entry until their fixture-builders land (#62).
+  #
+  # Why a matrix rather than a single sequential driver:
+  #   - Each format scan can take 30-60s; sequential 6-format runs
+  #     blow the 5-min release-gate budget.
+  #   - The workflow-level matrix surfaces per-format outcomes in the
+  #     GitHub Actions UI so an operator can see "oci failed, npm
+  #     passed" at a glance.
+  # -------------------------------------------------------------------
+  scan-completion-gate:
+    needs: deploy
+    runs-on: ak-e2e-runners
+    timeout-minutes: 8
+    strategy:
+      fail-fast: false
+      matrix:
+        format: [npm, oci, maven, pypi, cargo, helm]
+    env:
+      BASE_URL: ${{ needs.deploy.outputs.backend_url }}
+      RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
+      JUNIT_OUTPUT_DIR: /tmp/test-results
+      # RELEASE_GATE=1 turns common.sh's skip_suite() into a hard fail.
+      # ALLOW_SCANNER_SKIP=0 is enforced inside the gate primitive --
+      # a scanner-pod-down skip in release-gate context is exactly the
+      # silent-success class this gate exists to catch.
+      RELEASE_GATE: '1'
+      ALLOW_SCANNER_SKIP: '0'
+      FIXTURE_FORMAT: ${{ matrix.format }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: artifact-keeper/artifact-keeper-test
+
+      - name: Run scan-completion gate for ${{ matrix.format }}
+        run: |
+          mkdir -p "$JUNIT_OUTPUT_DIR"
+          chmod +x tests/release-gate/scan-completion-gate.sh
+          # Per-format RUN_ID suffix so concurrent matrix jobs do not
+          # collide on the repo key (scan-complete-<RUN_ID>).
+          RUN_ID="${RUN_ID}-${{ matrix.format }}" \
+            ./tests/release-gate/scan-completion-gate.sh
+
+      - name: Capture scanner pod logs on failure
+        if: failure()
+        run: |
+          # The deploy job exports the test namespace; resolve it via
+          # the standard naming pattern. We use kubectl best-effort:
+          # if the runner pod has no kubeconfig, this step's failure
+          # is benign (we still surface the JUnit XML).
+          NS="test-${{ needs.deploy.outputs.run_id }}"
+          mkdir -p /tmp/test-logs
+          kubectl -n "$NS" logs -l app.kubernetes.io/component=scanner \
+            --tail=2000 > /tmp/test-logs/scanner-${{ matrix.format }}.log 2>&1 || true
+          kubectl -n "$NS" logs -l app.kubernetes.io/name=trivy \
+            --tail=2000 > /tmp/test-logs/trivy-${{ matrix.format }}.log 2>&1 || true
+          kubectl -n "$NS" logs -l app=artifact-keeper-backend \
+            --tail=1000 > /tmp/test-logs/backend-${{ matrix.format }}.log 2>&1 || true
+
+      - name: Upload scan-completion gate results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: junit-scan-completion-${{ matrix.format }}
+          path: |
+            /tmp/test-results/
+            /tmp/test-logs/
+          if-no-files-found: ignore
+
+  # -------------------------------------------------------------------
+  # SBOM correctness gate (scaffold).
+  #
+  # Pins the SBOM endpoint contract (POST /api/v1/sbom returns 200
+  # with the documented SbomResponse shape) so an endpoint deletion
+  # or 5xx regression fails the release loud. The component_count > 0
+  # assertion is deferred to artifact-keeper#903 (--list-all-pkgs)
+  # per the #57 epic.
+  # -------------------------------------------------------------------
+  sbom-correctness-gate:
+    needs: deploy
+    runs-on: ak-e2e-runners
+    timeout-minutes: 6
+    env:
+      BASE_URL: ${{ needs.deploy.outputs.backend_url }}
+      RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
+      JUNIT_OUTPUT_DIR: /tmp/test-results
+      RELEASE_GATE: '1'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: artifact-keeper/artifact-keeper-test
+
+      - name: Run SBOM correctness gate
+        run: |
+          mkdir -p "$JUNIT_OUTPUT_DIR"
+          chmod +x tests/release-gate/sbom-correctness-gate.sh
+          ./tests/release-gate/sbom-correctness-gate.sh
+
+      - name: Capture scanner pod logs on failure
+        if: failure()
+        run: |
+          NS="test-${{ needs.deploy.outputs.run_id }}"
+          mkdir -p /tmp/test-logs
+          kubectl -n "$NS" logs -l app.kubernetes.io/component=scanner \
+            --tail=2000 > /tmp/test-logs/sbom-scanner.log 2>&1 || true
+          kubectl -n "$NS" logs -l app=artifact-keeper-backend \
+            --tail=1000 > /tmp/test-logs/sbom-backend.log 2>&1 || true
+
+      - name: Upload SBOM gate results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: junit-sbom-correctness
+          path: |
+            /tmp/test-results/
+            /tmp/test-logs/
+          if-no-files-found: ignore
+
+  # -------------------------------------------------------------------
+  # Pinned-CVE assertion (#64).
+  #
+  # Tightens the gate beyond "findings_count >= 1" to a specific CVE
+  # id. Catches scanner-DB drift and parser-correctness regressions
+  # that the findings-count check alone would let through.
+  # -------------------------------------------------------------------
+  pinned-cve-gate:
+    needs: deploy
+    runs-on: ak-e2e-runners
+    timeout-minutes: 8
+    env:
+      BASE_URL: ${{ needs.deploy.outputs.backend_url }}
+      RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
+      JUNIT_OUTPUT_DIR: /tmp/test-results
+      RELEASE_GATE: '1'
+      # CVE-2019-10744 (lodash 4.17.4 prototype pollution) is what the
+      # lite fixture pins. log4j 2.14.0 / CVE-2021-44228 will move
+      # under the oci matrix entry once the oci fixture-builder lands
+      # (#62 + #64 extension).
+      EXPECTED_VULN_CVE: CVE-2019-10744
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: artifact-keeper/artifact-keeper-test
+
+      - name: Run pinned-CVE gate
+        run: |
+          mkdir -p "$JUNIT_OUTPUT_DIR"
+          chmod +x tests/release-gate/test-pinned-cve.sh
+          ./tests/release-gate/test-pinned-cve.sh
+
+      - name: Upload pinned-CVE gate results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: junit-pinned-cve
+          path: /tmp/test-results/
+          if-no-files-found: ignore
+
+  # -------------------------------------------------------------------
   # Format tests (8 parallel batches)
   # -------------------------------------------------------------------
   format-tests:
@@ -1308,7 +1479,7 @@ jobs:
   # Collect results and publish summary
   # -------------------------------------------------------------------
   collect-results:
-    needs: [version-set-integrity, clean-install-smoke, clean-install-smoke-with-deps, chart-upgrade-smoke, deploy, real-flow-smoke, format-tests, security-tests, compatibility-tests, repo-tests, promotion-tests, rbac-tests, lifecycle-tests, webhook-tests, search-tests, platform-tests, auth-tests, stress-tests, resilience-tests, mesh-tests]
+    needs: [version-set-integrity, clean-install-smoke, clean-install-smoke-with-deps, chart-upgrade-smoke, deploy, real-flow-smoke, scan-completion-gate, sbom-correctness-gate, pinned-cve-gate, format-tests, security-tests, compatibility-tests, repo-tests, promotion-tests, rbac-tests, lifecycle-tests, webhook-tests, search-tests, platform-tests, auth-tests, stress-tests, resilience-tests, mesh-tests]
     if: always()
     runs-on: ak-e2e-runners
     steps:
@@ -1327,7 +1498,7 @@ jobs:
           echo "| Suite | Status |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-------|--------|" >> "$GITHUB_STEP_SUMMARY"
 
-          for job in version-set-integrity clean-install-smoke clean-install-smoke-with-deps chart-upgrade-smoke real-flow-smoke format-tests repo-tests promotion-tests rbac-tests lifecycle-tests webhook-tests search-tests platform-tests auth-tests security-tests compatibility-tests stress-tests resilience-tests mesh-tests; do
+          for job in version-set-integrity clean-install-smoke clean-install-smoke-with-deps chart-upgrade-smoke real-flow-smoke scan-completion-gate sbom-correctness-gate pinned-cve-gate format-tests repo-tests promotion-tests rbac-tests lifecycle-tests webhook-tests search-tests platform-tests auth-tests security-tests compatibility-tests stress-tests resilience-tests mesh-tests; do
             status="skipped"
             case "$job" in
               version-set-integrity) status="${{ needs.version-set-integrity.result }}" ;;
@@ -1335,6 +1506,9 @@ jobs:
               clean-install-smoke-with-deps) status="${{ needs.clean-install-smoke-with-deps.result }}" ;;
               chart-upgrade-smoke) status="${{ needs.chart-upgrade-smoke.result }}" ;;
               real-flow-smoke) status="${{ needs.real-flow-smoke.result }}" ;;
+              scan-completion-gate) status="${{ needs.scan-completion-gate.result }}" ;;
+              sbom-correctness-gate) status="${{ needs.sbom-correctness-gate.result }}" ;;
+              pinned-cve-gate) status="${{ needs.pinned-cve-gate.result }}" ;;
               format-tests) status="${{ needs.format-tests.result }}" ;;
               repo-tests) status="${{ needs.repo-tests.result }}" ;;
               promotion-tests) status="${{ needs.promotion-tests.result }}" ;;
@@ -1396,6 +1570,9 @@ jobs:
           needs.clean-install-smoke-with-deps.result == 'failure' || needs.clean-install-smoke-with-deps.result == 'cancelled' ||
           needs.chart-upgrade-smoke.result == 'failure' || needs.chart-upgrade-smoke.result == 'cancelled' ||
           needs.real-flow-smoke.result == 'failure' || needs.real-flow-smoke.result == 'cancelled' ||
+          needs.scan-completion-gate.result == 'failure' || needs.scan-completion-gate.result == 'cancelled' ||
+          needs.sbom-correctness-gate.result == 'failure' || needs.sbom-correctness-gate.result == 'cancelled' ||
+          needs.pinned-cve-gate.result == 'failure' || needs.pinned-cve-gate.result == 'cancelled' ||
           needs.deploy.result == 'failure' || needs.deploy.result == 'cancelled' ||
           needs.format-tests.result == 'failure' || needs.format-tests.result == 'cancelled' ||
           needs.compatibility-tests.result == 'failure' || needs.compatibility-tests.result == 'cancelled' ||

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -500,8 +500,16 @@ jobs:
   #
   # The wired formats (currently: npm) run the lite primitive at
   # tests/security/test-scan-completes.sh via the release-gate wrapper.
-  # The scaffolded formats (oci, maven, pypi, cargo, helm) exit 0 with
-  # a clear log entry until their fixture-builders land (#62).
+  #
+  # The matrix is intentionally restricted to formats whose fixtures
+  # exist. Scaffolded formats (oci, maven, pypi, cargo, helm) are NOT
+  # in the matrix because a green checkmark on an `exit 0` scaffold
+  # is the same silent-success class the gate exists to prevent. The
+  # scan-completion-gate-scaffolds-pending job below surfaces the
+  # deferred formats as ::warning:: annotations so the gap is visible
+  # without painting the dashboard with fake passes. When a fixture-
+  # builder for a deferred format lands (#62), add the format to this
+  # matrix in the same PR.
   #
   # Why a matrix rather than a single sequential driver:
   #   - Each format scan can take 30-60s; sequential 6-format runs
@@ -517,7 +525,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        format: [npm, oci, maven, pypi, cargo, helm]
+        format: [npm]
     env:
       BASE_URL: ${{ needs.deploy.outputs.backend_url }}
       RUN_ID: ${{ needs.deploy.outputs.run_id }}
@@ -569,6 +577,36 @@ jobs:
             /tmp/test-results/
             /tmp/test-logs/
           if-no-files-found: ignore
+
+  # -------------------------------------------------------------------
+  # Scaffolds-pending sentinel (#62).
+  #
+  # This job exists ONLY to surface the deferred formats as a
+  # ::warning:: annotation on every release-gate run so the gap is
+  # visible. It does NOT run any test. It is NOT a required gate.
+  # Deliberately a separate job (not a matrix step) so the GitHub
+  # Actions UI shows ONE warning row rather than five green
+  # checkmarks that imply broader format coverage than exists.
+  #
+  # When a fixture-builder for one of the listed formats lands,
+  # remove the format from this list and add it to the matrix above.
+  # -------------------------------------------------------------------
+  scan-completion-gate-scaffolds-pending:
+    needs: deploy
+    runs-on: ak-e2e-runners
+    timeout-minutes: 2
+    steps:
+      - name: Emit scaffolds-pending warnings
+        run: |
+          for fmt in oci maven pypi cargo helm; do
+            echo "::warning title=scan-completion gate: ${fmt} fixture missing::No scan-completion fixture exists for ${fmt}; the silent-success class (#888) is NOT covered for this format. Tracked under artifact-keeper-test#62."
+          done
+          # Echo to the runner log too so the operator sees this even
+          # without expanding the annotations pane.
+          echo ""
+          echo "Scan-completion format coverage:"
+          echo "  wired:    npm"
+          echo "  deferred: oci, maven, pypi, cargo, helm (artifact-keeper-test#62)"
 
   # -------------------------------------------------------------------
   # SBOM correctness gate (scaffold).

--- a/.github/workflows/scan-completes-self-test.yml
+++ b/.github/workflows/scan-completes-self-test.yml
@@ -1,0 +1,226 @@
+name: Scan-Completes Self-Test
+
+# Meta-test for the scan-completion gate per the #883 contract.
+#
+# Covers artifact-keeper-test#61.
+#
+# Why this exists
+# ---------------
+# The lite scan-completion gate at tests/security/test-scan-completes.sh
+# (and the release-gate wrapper at tests/release-gate/scan-completion-gate.sh)
+# is the load-bearing assertion against the #871 (stuck queued) and #888
+# (silent completed-but-not-scanned) regression classes.
+#
+# Without a paired pass/fail meta-test, a future PR can silently weaken
+# the gate -- drop the findings_count >= 1 check, raise the timeout
+# until SCAN_TIMEOUT is useless, swallow the assertion in a tolerant
+# ALLOW_SCANNER_SKIP path -- and the gate goes green forever on a
+# broken backend. That is the same silent-success failure class the
+# gate exists to prevent. The #883 contract requires explicit paired
+# evidence.
+#
+# We pin TWO distinct failure shapes because each exercises a different
+# code path in the gate:
+#
+#   A. Trivy scaled to zero (scanner pod unreachable).
+#      The lite gate's scanner_unavailable() helper MUST fail loud
+#      (RELEASE_GATE=1 + ALLOW_SCANNER_SKIP=0). If a refactor accidentally
+#      makes scanner-down silently exit 0, this fixture catches it.
+#
+#   B. Findings forgery (backend stub completes scans with findings_count=0).
+#      The lite gate's findings_count >= 1 assertion is the only
+#      thing standing between "scan ran" and "scan ran AND inspected
+#      the bytes". If a refactor removes that check (or replaces it
+#      with `>= 0`), this fixture catches it.
+#
+# Triggers
+# --------
+# Run on every PR that touches the gate primitive, the wrapper, the
+# common library, the release-gate workflow, or this self-test.
+# Without this, a PR could weaken the gate and the self-test would
+# not run, defeating the meta-test entirely.
+
+on:
+  pull_request:
+    paths:
+      - 'tests/security/test-scan-completes.sh'
+      - 'tests/release-gate/scan-completion-gate.sh'
+      - 'tests/release-gate/test-pinned-cve.sh'
+      - 'tests/lib/common.sh'
+      - '.github/workflows/release-gate.yml'
+      - '.github/workflows/scan-completes-self-test.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'tests/security/test-scan-completes.sh'
+      - 'tests/release-gate/scan-completion-gate.sh'
+      - 'tests/release-gate/test-pinned-cve.sh'
+      - 'tests/lib/common.sh'
+      - '.github/workflows/release-gate.yml'
+      - '.github/workflows/scan-completes-self-test.yml'
+
+# Cancel stale runs of the same workflow on a branch when a new push
+# arrives. Keeps PR feedback fast.
+concurrency:
+  group: scan-completes-self-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # -------------------------------------------------------------------
+  # Fixture A: Trivy scaled to zero.
+  #
+  # Deploy a test stack with `trivy.replicaCount=0` (or the chart's
+  # equivalent). With no scanner pod reachable, every scan trigger
+  # surfaces as 503 from the backend's scanner-service stub, OR the
+  # scan transitions to `failed` with error_message set. Either way
+  # the gate primitive MUST fail (RELEASE_GATE=1 + ALLOW_SCANNER_SKIP=0).
+  # EXPECT_FAILURE=1 inverts the exit code so this job reports green
+  # when the gate correctly rejects the broken backend.
+  # -------------------------------------------------------------------
+  pin-gate-fails-on-trivy-zero:
+    name: Gate must reject Trivy scaled to zero (fixture A)
+    runs-on: ak-e2e-runners
+    timeout-minutes: 12
+    env:
+      ADMIN_PASS: TestRunner!2026secure
+      JUNIT_OUTPUT_DIR: /tmp/test-results
+      RELEASE_GATE: '1'
+      ALLOW_SCANNER_SKIP: '0'
+      # EXPECT_FAILURE inverts common.sh's end_suite exit code: a fail
+      # (the gate working correctly on a broken backend) becomes exit 0;
+      # a pass (the gate weakened to a no-op) becomes exit 1.
+      EXPECT_FAILURE: '1'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+
+      - name: Deploy backend with trivy.replicaCount=0
+        id: deploy
+        run: |
+          RUN_ID="self-trivy-zero-${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+          chmod +x scripts/create-test-namespace.sh
+          # --full-stack normally enables Trivy. Override the replica
+          # count to zero via a fixture-only values file so the chart
+          # still installs but the scanner pod is unschedulable. The
+          # backend's scan-trigger path then surfaces scanner-unavailable.
+          #
+          # The values file path is relative-to-repo-root because
+          # create-test-namespace.sh prepends REPO_ROOT to --values.
+          mkdir -p helm/.self-test-fixtures
+          cat > helm/.self-test-fixtures/values-trivy-zero.yaml <<'YAML'
+          trivy:
+            enabled: true
+            replicaCount: 0
+          YAML
+          # Target the rolling dev tag on PRs / main. The self-test is
+          # checking gate semantics, not release-image integrity; using
+          # :dev means we exercise the latest backend behavior. If a
+          # specific tag's gate semantics need pinning later, this can
+          # become a workflow_dispatch input.
+          ./scripts/create-test-namespace.sh \
+            --run-id "${RUN_ID}" \
+            --backend-tag "dev" \
+            --web-tag "dev" \
+            --full-stack \
+            --values helm/.self-test-fixtures/values-trivy-zero.yaml
+          echo "namespace=test-${RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "backend_url=http://artifact-keeper-backend.test-${RUN_ID}.svc.cluster.local:8080" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for backend ready (Trivy is intentionally absent)
+        run: |
+          chmod +x tests/lib/wait-for-ready.sh
+          ./tests/lib/wait-for-ready.sh "${{ steps.deploy.outputs.backend_url }}" 300
+
+      - name: Run gate against Trivy-zero fixture; expect failure
+        env:
+          BASE_URL: ${{ steps.deploy.outputs.backend_url }}
+          RUN_ID: ${{ steps.deploy.outputs.run_id }}
+        run: |
+          mkdir -p "$JUNIT_OUTPUT_DIR"
+          chmod +x tests/release-gate/scan-completion-gate.sh
+          # EXPECT_FAILURE=1 in env. end_suite() reads it and inverts
+          # the exit code. If the gate's findings_count assertion or
+          # the scanner_unavailable hard-fail is intact, this script
+          # exits 0 (because the gate exited 1 -- expected). If the
+          # gate has been weakened, the script exits 1 here.
+          ./tests/release-gate/scan-completion-gate.sh
+
+      - name: Capture scanner diagnostics
+        if: always()
+        run: |
+          NS="${{ steps.deploy.outputs.namespace }}"
+          mkdir -p /tmp/test-logs
+          kubectl -n "$NS" get pods > /tmp/test-logs/pods-trivy-zero.txt 2>&1 || true
+          kubectl -n "$NS" describe deploy trivy > /tmp/test-logs/describe-trivy-zero.txt 2>&1 || true
+          kubectl -n "$NS" logs -l app=artifact-keeper-backend \
+            --tail=500 > /tmp/test-logs/backend-trivy-zero.log 2>&1 || true
+
+      - name: Teardown
+        if: always()
+        run: |
+          NS="${{ steps.deploy.outputs.namespace }}"
+          kubectl delete namespace "$NS" --wait=false --ignore-not-found || true
+
+      - name: Upload self-test diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: scan-self-test-trivy-zero-${{ github.run_attempt }}
+          path: |
+            /tmp/test-results/
+            /tmp/test-logs/
+          if-no-files-found: ignore
+
+  # -------------------------------------------------------------------
+  # Fixture B: Findings forgery.
+  #
+  # Run the gate against a backend with the SCANNER_FORCE_EMPTY_FINDINGS
+  # env override (or equivalent debug-only knob). The override makes
+  # the scanner_service.rs path return Ok(vec![]) for every artifact
+  # regardless of content, which becomes `findings_count=0, status=completed,
+  # error_message=null` -- the exact #888 silent-success shape.
+  #
+  # The lite gate's load-bearing assertion (findings_count >= 1 on the
+  # known-vulnerable lodash fixture) MUST fail against this backend.
+  # If a refactor weakens that check, this fixture surfaces it.
+  #
+  # NOTE: this fixture requires the backend to honor a debug-only env
+  # knob. Until that lands (tracked as artifact-keeper#NNN -- TODO file
+  # once #61 merges), we scaffold the job with a clearly-marked TODO
+  # and exit 0. That keeps the workflow visible in the Actions UI but
+  # does not yet provide paired evidence for the findings_count
+  # assertion specifically.
+  # -------------------------------------------------------------------
+  pin-gate-fails-on-findings-forgery:
+    name: Gate must reject findings forgery (fixture B, scaffold)
+    runs-on: ak-e2e-runners
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Scaffold note
+        run: |
+          echo "::warning::Fixture B (findings forgery) is currently a scaffold."
+          echo "::warning::Requires backend to honor SCANNER_FORCE_EMPTY_FINDINGS=1"
+          echo "::warning::(or equivalent debug-only knob) to deterministically emit"
+          echo "::warning::status=completed + findings_count=0 + error_message=null."
+          echo "::warning::Filed as a follow-up against artifact-keeper. Fixture A"
+          echo "::warning::(Trivy scaled to zero) already provides paired-failure"
+          echo "::warning::evidence for the scanner_unavailable path, which is the"
+          echo "::warning::other half of the #888 silent-success class."
+          echo ""
+          echo "When the backend gains the debug knob, replace this step with:"
+          echo "  1. Deploy stack with backend env SCANNER_FORCE_EMPTY_FINDINGS=1"
+          echo "  2. Run scan-completion-gate.sh with EXPECT_FAILURE=1"
+          echo "  3. Assert gate exits 0 (gate correctly rejected the forgery)"
+          # Exit 0 so the workflow itself is green; we surface the
+          # scaffold status via the ::warning:: annotations above so
+          # an operator browsing the PR sees the gap without the
+          # workflow falsely turning green-as-passed.
+          exit 0

--- a/.github/workflows/scan-completes-self-test.yml
+++ b/.github/workflows/scan-completes-self-test.yml
@@ -41,21 +41,27 @@ name: Scan-Completes Self-Test
 # not run, defeating the meta-test entirely.
 
 on:
+  # Path filter is intentionally broad. The self-test must re-run on any
+  # change to the gate primitives, their helpers, or the workflow plumbing
+  # so a PR cannot weaken the gate without tripping the meta-test. Listing
+  # only the named gate scripts misses helper-weakening changes (e.g. a
+  # tolerant edit to tests/lib/common.sh that turns fail() into a warning),
+  # which is exactly the silent-success class the meta-test guards
+  # against. Hitting on a wider set of paths costs at most one runner job
+  # per unrelated PR; missing the trigger costs us the entire meta-test.
   pull_request:
     paths:
+      - 'tests/release-gate/**'
       - 'tests/security/test-scan-completes.sh'
-      - 'tests/release-gate/scan-completion-gate.sh'
-      - 'tests/release-gate/test-pinned-cve.sh'
-      - 'tests/lib/common.sh'
+      - 'tests/lib/**'
       - '.github/workflows/release-gate.yml'
       - '.github/workflows/scan-completes-self-test.yml'
   push:
     branches: [main]
     paths:
+      - 'tests/release-gate/**'
       - 'tests/security/test-scan-completes.sh'
-      - 'tests/release-gate/scan-completion-gate.sh'
-      - 'tests/release-gate/test-pinned-cve.sh'
-      - 'tests/lib/common.sh'
+      - 'tests/lib/**'
       - '.github/workflows/release-gate.yml'
       - '.github/workflows/scan-completes-self-test.yml'
 

--- a/.github/workflows/scan-completes-self-test.yml
+++ b/.github/workflows/scan-completes-self-test.yml
@@ -184,49 +184,117 @@ jobs:
           if-no-files-found: ignore
 
   # -------------------------------------------------------------------
-  # Fixture B: Findings forgery.
+  # Fixture B: Non-vulnerable fixture must trip the findings_count check.
   #
-  # Run the gate against a backend with the SCANNER_FORCE_EMPTY_FINDINGS
-  # env override (or equivalent debug-only knob). The override makes
-  # the scanner_service.rs path return Ok(vec![]) for every artifact
-  # regardless of content, which becomes `findings_count=0, status=completed,
-  # error_message=null` -- the exact #888 silent-success shape.
+  # The lite gate's load-bearing assertion is `findings_count >= 1` on
+  # a known-vulnerable lodash fixture. If a refactor weakens that check
+  # (drops it, replaces it with `>= 0`, swallows it in a tolerant
+  # branch), the gate goes green forever on a broken backend. Fixture A
+  # covers the scanner_unavailable half; Fixture B covers the
+  # findings-emitted half.
   #
-  # The lite gate's load-bearing assertion (findings_count >= 1 on the
-  # known-vulnerable lodash fixture) MUST fail against this backend.
-  # If a refactor weakens that check, this fixture surfaces it.
+  # Approach (no backend debug knob required):
+  #   - Override FIXTURE_LODASH_VERSION=4.17.21 (a non-vulnerable
+  #     release of lodash). Trivy's npm parser still parses the
+  #     lockfile but emits zero findings because the version carries
+  #     no published CVE.
+  #   - findings_count=0 on a non-vulnerable fixture is the CORRECT
+  #     scanner behavior. The gate's `findings_count >= 1` assertion
+  #     must therefore FAIL (the fixture proves the assertion is
+  #     load-bearing). EXPECT_FAILURE=1 inverts the exit code so a
+  #     gate failure becomes a self-test pass.
   #
-  # NOTE: this fixture requires the backend to honor a debug-only env
-  # knob. Until that lands (tracked as artifact-keeper#NNN -- TODO file
-  # once #61 merges), we scaffold the job with a clearly-marked TODO
-  # and exit 0. That keeps the workflow visible in the Actions UI but
-  # does not yet provide paired evidence for the findings_count
-  # assertion specifically.
+  # This fixture pairs with Fixture A to provide the full #883
+  # paired-evidence contract: A proves scanner-unavailable fails loud,
+  # B proves the findings_count >= 1 assertion bites.
   # -------------------------------------------------------------------
-  pin-gate-fails-on-findings-forgery:
-    name: Gate must reject findings forgery (fixture B, scaffold)
+  pin-gate-fails-on-non-vulnerable-fixture:
+    name: Gate must reject non-vulnerable fixture (fixture B)
     runs-on: ak-e2e-runners
-    timeout-minutes: 10
+    timeout-minutes: 12
+    env:
+      ADMIN_PASS: TestRunner!2026secure
+      JUNIT_OUTPUT_DIR: /tmp/test-results
+      RELEASE_GATE: '1'
+      ALLOW_SCANNER_SKIP: '0'
+      # EXPECT_FAILURE inverts common.sh's end_suite exit code: the gate
+      # must fail on the non-vulnerable fixture (correct scanner
+      # behavior: zero findings on a clean lockfile), and that failure
+      # becomes exit 0 here.
+      EXPECT_FAILURE: '1'
+      # Override the fixture to a clean lodash version. test-scan-completes.sh
+      # reads FIXTURE_LODASH_VERSION and builds the lockfile from it.
+      # 4.17.21 is the latest patch; no CVE rows for it.
+      FIXTURE_LODASH_VERSION: '4.17.21'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Scaffold note
+      - name: Install kubectl
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+
+      - name: Deploy backend with Trivy enabled (full stack)
+        id: deploy
         run: |
-          echo "::warning::Fixture B (findings forgery) is currently a scaffold."
-          echo "::warning::Requires backend to honor SCANNER_FORCE_EMPTY_FINDINGS=1"
-          echo "::warning::(or equivalent debug-only knob) to deterministically emit"
-          echo "::warning::status=completed + findings_count=0 + error_message=null."
-          echo "::warning::Filed as a follow-up against artifact-keeper. Fixture A"
-          echo "::warning::(Trivy scaled to zero) already provides paired-failure"
-          echo "::warning::evidence for the scanner_unavailable path, which is the"
-          echo "::warning::other half of the #888 silent-success class."
-          echo ""
-          echo "When the backend gains the debug knob, replace this step with:"
-          echo "  1. Deploy stack with backend env SCANNER_FORCE_EMPTY_FINDINGS=1"
-          echo "  2. Run scan-completion-gate.sh with EXPECT_FAILURE=1"
-          echo "  3. Assert gate exits 0 (gate correctly rejected the forgery)"
-          # Exit 0 so the workflow itself is green; we surface the
-          # scaffold status via the ::warning:: annotations above so
-          # an operator browsing the PR sees the gap without the
-          # workflow falsely turning green-as-passed.
-          exit 0
+          RUN_ID="self-clean-fixture-${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+          chmod +x scripts/create-test-namespace.sh
+          ./scripts/create-test-namespace.sh \
+            --run-id "${RUN_ID}" \
+            --backend-tag "dev" \
+            --web-tag "dev" \
+            --full-stack
+          echo "namespace=test-${RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "backend_url=http://artifact-keeper-backend.test-${RUN_ID}.svc.cluster.local:8080" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for backend + Trivy ready
+        run: |
+          chmod +x tests/lib/wait-for-ready.sh
+          ./tests/lib/wait-for-ready.sh "${{ steps.deploy.outputs.backend_url }}" 300
+          # Confirm Trivy is up; if it is not, fixture A's failure mode
+          # would mask fixture B's signal.
+          kubectl -n "${{ steps.deploy.outputs.namespace }}" wait \
+            --for=condition=Available deployment/artifact-keeper-trivy \
+            --timeout=120s
+
+      - name: Run gate against clean-lodash fixture; expect failure
+        env:
+          BASE_URL: ${{ steps.deploy.outputs.backend_url }}
+          RUN_ID: ${{ steps.deploy.outputs.run_id }}
+        run: |
+          mkdir -p "$JUNIT_OUTPUT_DIR"
+          chmod +x tests/release-gate/scan-completion-gate.sh
+          # FIXTURE_LODASH_VERSION=4.17.21 (set at job env). The fixture
+          # builds a clean lockfile, Trivy scans it, findings_count=0,
+          # the gate's `findings_count >= 1` assertion fires, end_suite
+          # exits non-zero. EXPECT_FAILURE=1 inverts to exit 0.
+          ./tests/release-gate/scan-completion-gate.sh
+
+      - name: Capture scanner diagnostics
+        if: always()
+        run: |
+          NS="${{ steps.deploy.outputs.namespace }}"
+          mkdir -p /tmp/test-logs
+          kubectl -n "$NS" get pods > /tmp/test-logs/pods-clean-fixture.txt 2>&1 || true
+          kubectl -n "$NS" logs -l app.kubernetes.io/name=trivy \
+            --tail=2000 > /tmp/test-logs/trivy-clean-fixture.log 2>&1 || true
+          kubectl -n "$NS" logs -l app=artifact-keeper-backend \
+            --tail=500 > /tmp/test-logs/backend-clean-fixture.log 2>&1 || true
+
+      - name: Teardown
+        if: always()
+        run: |
+          NS="${{ steps.deploy.outputs.namespace }}"
+          kubectl delete namespace "$NS" --wait=false --ignore-not-found || true
+
+      - name: Upload self-test diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: scan-self-test-clean-fixture-${{ github.run_attempt }}
+          path: |
+            /tmp/test-results/
+            /tmp/test-logs/
+          if-no-files-found: ignore

--- a/tests/release-gate/sbom-correctness-gate.sh
+++ b/tests/release-gate/sbom-correctness-gate.sh
@@ -6,38 +6,25 @@
 #   - #47 E2E SBOM correctness
 #   - #57 Epic: SBOM correctness silent-success gate
 #
-# Status: SCAFFOLD.
+# Status: ACTIVE.
 #
-# Per artifact-keeper-test#57, PR #51's review surfaced architectural
-# blockers that this gate cannot resolve without a backend change:
+# artifact-keeper#903 (--list-all-pkgs + name normalization, scan_packages
+# inventory) merged via PR #1150 on 2026-05-11. With #903 live, this gate
+# asserts the full silent-empty bug: lockfile-bearing fixture must produce
+# component_count >= 1. The assertion is gated on backend feature detection
+# (probe /api/v1/openapi.json for the get_sbom_components path that #903
+# introduced) so the gate stays portable across release tags that may lag
+# #903 -- pre-#903 deploy targets skip the load-bearing check rather than
+# flap, and the skip is surfaced loudly.
 #
-#   1. Trivy is invoked WITHOUT --list-all-pkgs (artifact-keeper#903).
-#      Without that flag, scan_findings only stores CVE-bearing rows,
-#      so SBOMs derived from scan_findings are "CVEs in deps" rather
-#      than "deps". The empty-SBOM symptom is structural, not a bug
-#      we can assert around.
-#   2. Component names are persisted as "name (target)" (e.g.
-#      "body-parser (package-lock.json)"), so substring-matching on
-#      known component names needs care.
-#   3. The cve/history endpoint previously used as a "scan complete"
-#      probe returns [] for any unknown artifact and was a silent
-#      no-op (#57 round-2 finding).
-#
-# The full gate per #57 requires:
-#   - Backend: artifact-keeper#903 (--list-all-pkgs + name normalization)
-#   - Test: enable scan_on_upload BEFORE the upload
-#   - Test: poll via GET /api/v1/scans?artifact_id=... not cve/history
-#   - Test: force_regenerate=true on every poll iteration
-#   - Test: negative-control fixture (garbage tarball -> component_count == 0)
-#   - Test: Trivy DB version pinning
-#   - Workflow: scanner pod log capture on failure
-#   - Meta-test: paired pass/fail evidence
-#
-# Until #903 ships, this scaffold runs the *contract pin* portion: it
-# asserts the endpoints exist and respond with the right shape, but
-# it does NOT yet assert on component count. That keeps the gate
-# present in CI (so a 404 on /api/v1/sbom would fail the gate loud)
-# without falsely passing on the actual silent-empty bug.
+# Earlier scaffold rationale (now resolved):
+#   - Trivy invoked WITHOUT --list-all-pkgs: resolved by #903 (both
+#     trivy_fs_scanner.rs and image_scanner.rs now pass the flag).
+#   - Component names persisted as "name (target)": resolved by #903's
+#     name normalization in convert_trivy_packages.
+#   - cve/history probe returning [] silently: replaced upstream by the
+#     /api/v1/scans?artifact_id polling shape; we read .component_count
+#     directly from the SBOM response, not the probe.
 #
 # Environment:
 #   BASE_URL    backend URL
@@ -149,10 +136,9 @@ fi
 
 # ---------------------------------------------------------------------------
 # Contract pin: POST /api/v1/sbom must return 200 with a SbomResponse
-# shape. This is the minimum pin until #903 lands. It catches the gross
-# regression where the SBOM endpoint disappears or starts returning 5xx,
-# but it does NOT yet catch the silent-empty bug (#870) -- that requires
-# #903 + the scaffold-completion sub-tasks in #57.
+# shape. Catches the gross regression where the SBOM endpoint disappears
+# or starts returning 5xx. The component_count > 0 assertion below
+# catches the actual silent-empty bug (#870) on backends carrying #903.
 # ---------------------------------------------------------------------------
 
 begin_test "POST /api/v1/sbom returns 200 with SBOM response shape"
@@ -178,7 +164,7 @@ case "$sbom_status" in
           and (.dependency_count | type) == "number"
         ' < "${WORK_DIR}/sbom-resp.json" >/dev/null 2>&1; then
       sbom_component_count=$(jq -r '.component_count' < "${WORK_DIR}/sbom-resp.json")
-      echo "  component_count=${sbom_component_count} (NOT asserted >0 until artifact-keeper#903)"
+      echo "  component_count=${sbom_component_count} (asserted >= 1 below if #903 detected)"
       pass
     else
       body=$(head -c 400 "${WORK_DIR}/sbom-resp.json" 2>/dev/null || true)
@@ -201,19 +187,59 @@ case "$sbom_status" in
 esac
 
 # ---------------------------------------------------------------------------
-# Component-count assertion (scaffold).
-# Per #57, this must NOT be wired up until artifact-keeper#903 ships
-# (--list-all-pkgs + name normalization). Without #903, the SBOM is
-# legitimately empty for non-CVE deps and an assertion here would
-# flap or, worse, drive contributors to add `|| true` workarounds
-# that mask the real bug.
+# Component-count assertion.
+#
+# artifact-keeper#903 (--list-all-pkgs + name normalization, scan_packages
+# inventory) merged via PR #1150 on 2026-05-11. Once a backend carrying
+# migration 085 (scan_packages table) is deployed, the SBOM endpoint must
+# return component_count >= 1 for our lockfile-bearing npm fixture. The
+# assertion is gated on backend feature detection (probe the OpenAPI spec
+# for the scan_packages-derived response shape) so the gate stays portable
+# across release tags that lag #903.
 # ---------------------------------------------------------------------------
 
-begin_test "SBOM component_count > 0 (deferred to artifact-keeper#903)"
-# TODO(artifact-keeper-test#57, artifact-keeper#903): once --list-all-pkgs
-# is enabled and names are normalized, replace the skip with:
-#   component_count=$(jq -r '.component_count' < "${WORK_DIR}/sbom-resp.json")
-#   if [ "$component_count" -gt 0 ]; then pass; else fail "..."; fi
-skip "deferred to artifact-keeper#903 (--list-all-pkgs + name normalization)"
+begin_test "Detect backend support for #903 (scan_packages inventory)"
+# Probe approach: inspect the OpenAPI spec for the get_sbom_components
+# operation, which #903 introduced alongside the inventory pipeline. The
+# spec is served at /api/v1/openapi.json (utoipa). A backend predating
+# #903 either lacks the path entirely or exposes only the legacy
+# components-from-findings shape. We treat the path presence as the
+# feature signal.
+HAS_LIST_ALL_PKGS=0
+# shellcheck disable=SC2086
+spec_status=$(curl -s -o "${WORK_DIR}/openapi.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/openapi.json") || spec_status="000"
+if [ "$spec_status" = "200" ]; then
+  if jq -e '.paths | keys[] | select(test("/sbom/.*/components$"))' \
+       < "${WORK_DIR}/openapi.json" >/dev/null 2>&1; then
+    HAS_LIST_ALL_PKGS=1
+  fi
+fi
+echo "  HAS_LIST_ALL_PKGS=${HAS_LIST_ALL_PKGS} (openapi status=${spec_status})"
+pass
+
+begin_test "SBOM component_count > 0 for lockfile-bearing fixture"
+if [ "$HAS_LIST_ALL_PKGS" = "1" ]; then
+  component_count=$(jq -r '.component_count // 0' < "${WORK_DIR}/sbom-resp.json")
+  if [ "${component_count:-0}" -ge 1 ]; then
+    echo "  component_count=${component_count} (>= 1 confirms #903 inventory pipeline live)"
+    pass
+  else
+    # This is exactly the #870 silent-success class: backend advertises
+    # the #903 inventory shape but returns 0 components for a lockfile
+    # that names lodash. That means either the scan didn't run, the
+    # scan_packages table didn't receive rows, or the SBOM service is
+    # still reading from scan_findings only.
+    body=$(head -c 400 "${WORK_DIR}/sbom-resp.json" 2>/dev/null || true)
+    fail "SBOM component_count=${component_count} on lockfile-bearing fixture (#870 silent-empty class)" "$body"
+  fi
+else
+  # Pre-#903 backend (e.g. v1.1.x release-image rebuild against a tag
+  # that predates PR #1150). The empty-SBOM symptom is structural on
+  # those builds; asserting > 0 would flap. Surface the gap loudly via
+  # skip so the gate's scope on this deploy target is honest.
+  skip "backend predates artifact-keeper#903 (no get_sbom_components path in OpenAPI spec)"
+fi
 
 end_suite

--- a/tests/release-gate/sbom-correctness-gate.sh
+++ b/tests/release-gate/sbom-correctness-gate.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# sbom-correctness-gate.sh -- Release-gate primitive for the SBOM correctness
+# silent-success class (#870: SBOM endpoint returned 200 with empty/fake data).
+#
+# Covers artifact-keeper-test issues:
+#   - #47 E2E SBOM correctness
+#   - #57 Epic: SBOM correctness silent-success gate
+#
+# Status: SCAFFOLD.
+#
+# Per artifact-keeper-test#57, PR #51's review surfaced architectural
+# blockers that this gate cannot resolve without a backend change:
+#
+#   1. Trivy is invoked WITHOUT --list-all-pkgs (artifact-keeper#903).
+#      Without that flag, scan_findings only stores CVE-bearing rows,
+#      so SBOMs derived from scan_findings are "CVEs in deps" rather
+#      than "deps". The empty-SBOM symptom is structural, not a bug
+#      we can assert around.
+#   2. Component names are persisted as "name (target)" (e.g.
+#      "body-parser (package-lock.json)"), so substring-matching on
+#      known component names needs care.
+#   3. The cve/history endpoint previously used as a "scan complete"
+#      probe returns [] for any unknown artifact and was a silent
+#      no-op (#57 round-2 finding).
+#
+# The full gate per #57 requires:
+#   - Backend: artifact-keeper#903 (--list-all-pkgs + name normalization)
+#   - Test: enable scan_on_upload BEFORE the upload
+#   - Test: poll via GET /api/v1/scans?artifact_id=... not cve/history
+#   - Test: force_regenerate=true on every poll iteration
+#   - Test: negative-control fixture (garbage tarball -> component_count == 0)
+#   - Test: Trivy DB version pinning
+#   - Workflow: scanner pod log capture on failure
+#   - Meta-test: paired pass/fail evidence
+#
+# Until #903 ships, this scaffold runs the *contract pin* portion: it
+# asserts the endpoints exist and respond with the right shape, but
+# it does NOT yet assert on component count. That keeps the gate
+# present in CI (so a 404 on /api/v1/sbom would fail the gate loud)
+# without falsely passing on the actual silent-empty bug.
+#
+# Environment:
+#   BASE_URL    backend URL
+#   ADMIN_PASS  admin password
+#   RUN_ID      resource-name suffix
+
+# shellcheck source=../lib/common.sh disable=SC1091
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "sbom-correctness-gate"
+auth_admin
+setup_workdir
+
+REPO_KEY="sbom-gate-${RUN_ID}"
+PACKAGE_NAME="sbom-fixture"
+PACKAGE_VERSION="1.0.0"
+TARBALL_NAME="${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz"
+ARTIFACT_PATH="${PACKAGE_NAME}/${PACKAGE_VERSION}/${TARBALL_NAME}"
+
+cleanup_sbom() {
+  # shellcheck disable=SC2086  # CURL_TIMEOUT must word-split
+  curl -sf $CURL_TIMEOUT -X DELETE -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/repositories/${REPO_KEY}" >/dev/null 2>&1 || true
+  [ -n "${WORK_DIR:-}" ] && rm -rf "$WORK_DIR" 2>/dev/null || true
+}
+trap cleanup_sbom EXIT
+
+# ---------------------------------------------------------------------------
+# Build a minimal npm-shaped fixture so the artifact has an SBOM-extractable
+# manifest. Same lockfile shape as test-scan-completes.sh because the SBOM
+# pipeline currently derives components from scan_findings (until #903).
+# ---------------------------------------------------------------------------
+
+begin_test "Build SBOM fixture"
+mkdir -p "${WORK_DIR}/package"
+cat > "${WORK_DIR}/package/package.json" <<EOF
+{
+  "name": "${PACKAGE_NAME}",
+  "version": "${PACKAGE_VERSION}",
+  "dependencies": { "lodash": "4.17.4" }
+}
+EOF
+cat > "${WORK_DIR}/package/package-lock.json" <<EOF
+{
+  "name": "${PACKAGE_NAME}",
+  "version": "${PACKAGE_VERSION}",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": { "name": "${PACKAGE_NAME}", "version": "${PACKAGE_VERSION}",
+          "dependencies": { "lodash": "4.17.4" } },
+    "node_modules/lodash": { "version": "4.17.4" }
+  }
+}
+EOF
+if tar -czf "${WORK_DIR}/${TARBALL_NAME}" -C "${WORK_DIR}" package 2>/dev/null; then
+  pass
+else
+  fail "could not build SBOM fixture tarball"
+fi
+
+# ---------------------------------------------------------------------------
+# Create repo + upload fixture.
+# ---------------------------------------------------------------------------
+
+begin_test "Create generic local repository"
+if create_local_repo "$REPO_KEY" "generic"; then
+  pass
+else
+  fail "could not create generic repository ${REPO_KEY}"
+fi
+
+begin_test "Upload SBOM fixture"
+# shellcheck disable=SC2086
+upload_status=$(curl -s -o "${WORK_DIR}/upload-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -X PUT \
+  -H "$(auth_header)" \
+  -H "Content-Type: application/gzip" \
+  --data-binary "@${WORK_DIR}/${TARBALL_NAME}" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/${ARTIFACT_PATH}") || upload_status="000"
+if [ "$upload_status" = "200" ] || [ "$upload_status" = "201" ]; then
+  pass
+else
+  fail "upload returned HTTP ${upload_status}"
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve artifact_id.
+# ---------------------------------------------------------------------------
+
+begin_test "Resolve artifact_id"
+# shellcheck disable=SC2086
+list_status=$(curl -s -o "${WORK_DIR}/list-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts") || list_status="000"
+ARTIFACT_ID=""
+if [ "$list_status" = "200" ]; then
+  ARTIFACT_ID=$(jq -er --arg p "$ARTIFACT_PATH" \
+    '.items | map(select(.path == $p or .name == $p)) | first | .id // empty' \
+    < "${WORK_DIR}/list-resp.json" 2>/dev/null || true)
+fi
+if [ -n "$ARTIFACT_ID" ]; then
+  pass
+else
+  fail "could not resolve artifact_id (list HTTP ${list_status})"
+  end_suite
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Contract pin: POST /api/v1/sbom must return 200 with a SbomResponse
+# shape. This is the minimum pin until #903 lands. It catches the gross
+# regression where the SBOM endpoint disappears or starts returning 5xx,
+# but it does NOT yet catch the silent-empty bug (#870) -- that requires
+# #903 + the scaffold-completion sub-tasks in #57.
+# ---------------------------------------------------------------------------
+
+begin_test "POST /api/v1/sbom returns 200 with SBOM response shape"
+sbom_payload=$(jq -n --arg id "$ARTIFACT_ID" \
+  '{artifact_id: $id, format: "cyclonedx", force_regenerate: true}')
+# shellcheck disable=SC2086
+sbom_status=$(curl -s -o "${WORK_DIR}/sbom-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -X POST \
+  -H "$(auth_header)" \
+  -H "Content-Type: application/json" \
+  -d "$sbom_payload" \
+  "${BASE_URL}/api/v1/sbom") || sbom_status="000"
+
+case "$sbom_status" in
+  200)
+    # Confirm response shape. SbomResponse fields per
+    # backend/src/api/handlers/sbom.rs:91-107
+    if jq -e '
+          (.id | type) == "string"
+          and (.artifact_id | type) == "string"
+          and (.format | type) == "string"
+          and (.component_count | type) == "number"
+          and (.dependency_count | type) == "number"
+        ' < "${WORK_DIR}/sbom-resp.json" >/dev/null 2>&1; then
+      sbom_component_count=$(jq -r '.component_count' < "${WORK_DIR}/sbom-resp.json")
+      echo "  component_count=${sbom_component_count} (NOT asserted >0 until artifact-keeper#903)"
+      pass
+    else
+      body=$(head -c 400 "${WORK_DIR}/sbom-resp.json" 2>/dev/null || true)
+      fail "SBOM response shape mismatch" "$body"
+    fi
+    ;;
+  404)
+    fail "POST /api/v1/sbom returned 404 (endpoint missing in this backend version)"
+    ;;
+  503|504)
+    # Scanner-pod unavailability classifies the SAME as scan-completion-gate.sh:
+    # release-gate context must fail loud. The silent-success class this gate
+    # exists to catch is exactly "report success when scanner could not run".
+    fail "POST /api/v1/sbom returned ${sbom_status}; scanner pod unavailable, release-gate must fail loud (#870 class)"
+    ;;
+  *)
+    body=$(head -c 400 "${WORK_DIR}/sbom-resp.json" 2>/dev/null || true)
+    fail "POST /api/v1/sbom returned HTTP ${sbom_status}" "$body"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Component-count assertion (scaffold).
+# Per #57, this must NOT be wired up until artifact-keeper#903 ships
+# (--list-all-pkgs + name normalization). Without #903, the SBOM is
+# legitimately empty for non-CVE deps and an assertion here would
+# flap or, worse, drive contributors to add `|| true` workarounds
+# that mask the real bug.
+# ---------------------------------------------------------------------------
+
+begin_test "SBOM component_count > 0 (deferred to artifact-keeper#903)"
+# TODO(artifact-keeper-test#57, artifact-keeper#903): once --list-all-pkgs
+# is enabled and names are normalized, replace the skip with:
+#   component_count=$(jq -r '.component_count' < "${WORK_DIR}/sbom-resp.json")
+#   if [ "$component_count" -gt 0 ]; then pass; else fail "..."; fi
+skip "deferred to artifact-keeper#903 (--list-all-pkgs + name normalization)"
+
+end_suite

--- a/tests/release-gate/scan-completion-gate.sh
+++ b/tests/release-gate/scan-completion-gate.sh
@@ -6,43 +6,42 @@
 #   - #46  E2E scan flow completion
 #   - #56  Epic: scan-completion silent-success gate
 #
-# This is the format-parameterized wrapper around the lite primitive at
-# tests/security/test-scan-completes.sh. It hard-codes the release-gate
-# semantics:
+# This is the release-gate-specific entry point around the lite primitive
+# at tests/security/test-scan-completes.sh. It exists for ONE reason: to
+# hard-code release-gate semantics so neither the workflow author nor a
+# future contributor can dial them back without editing this file:
 #   - ALLOW_SCANNER_SKIP=0 (a missing scanner in release-gate IS the bug)
 #   - RELEASE_GATE=1 (skip_suite => hard fail)
-#   - SCAN_TIMEOUT defaults to 180s (same as the lite primitive)
+#   - SCAN_TIMEOUT defaults to 180s
 #
-# It is parameterized via FIXTURE_FORMAT so test-scan-completion-format-matrix.sh
-# can iterate over npm / pypi / oci / maven without copy-pasting the
-# trigger + poll + assert plumbing.
-#
-# Currently implemented fixture formats:
-#   - npm (default, lodash 4.17.4 / CVE-2019-10744)
-#   - generic-payload (for the SBOM gate scaffold; no findings assertion)
-#
-# Scaffolded but not yet wired (require a fixture-builder per format):
-#   - oci, maven, pypi, cargo, helm
-#   For these we exit 0 with a clear log line. The format-matrix script's
-#   matrix entries record this as a skip; when the fixture-builder lands
-#   the matrix flips that entry to a real gate without touching the
-#   workflow file.
+# Format support: only npm. Other formats (oci, maven, pypi, cargo, helm)
+# need format-specific fixture builders that do not exist yet. The earlier
+# scaffold branches in this file were dead code -- the workflow matrix is
+# restricted to [npm] (see the scan-completion-gate-scaffolds-pending
+# sentinel job in release-gate.yml for visibility on deferred formats).
+# FIXTURE_FORMAT is accepted only for forward compatibility with the
+# matrix; an unsupported value fails the gate loudly rather than silently
+# exiting 0.
 #
 # Why this lives in tests/release-gate/ rather than tests/security/:
 #   - tests/security/ is picked up automatically by run-suite.sh --suite
 #     security. The existing test-scan-completes.sh stays there for the
 #     security suite. This wrapper exists specifically so the release-gate
-#     workflow can call ONE script per matrix entry without spinning up
-#     the whole security suite, and without coupling the matrix wiring
-#     to run-suite.sh's directory layout.
+#     workflow can call ONE script per matrix entry with the release-gate
+#     env forced on regardless of the caller's env, without coupling to
+#     run-suite.sh's directory layout.
 #
 # Environment:
 #   BASE_URL              backend URL (default http://localhost:8080)
 #   ADMIN_USER            admin username (default admin)
 #   ADMIN_PASS            admin password
 #   RUN_ID                resource-name suffix
-#   FIXTURE_FORMAT        npm | oci | maven | pypi | cargo | helm | generic-payload
-#                         (default: npm)
+#   FIXTURE_FORMAT        npm (default; only supported value today)
+#   FIXTURE_LODASH_VERSION  override the lodash version baked into the
+#                         fixture lockfile. Used by the self-test
+#                         fixture B path to swap to a non-vulnerable
+#                         version (4.17.21) and prove the gate's
+#                         findings_count assertion bites. Default 4.17.4.
 #   SCAN_TIMEOUT          max seconds to wait (default 180)
 #   EXPECT_FAILURE        set to 1 by the meta-test workflow (#883 contract)
 #   ALLOW_SCANNER_SKIP    forced to 0 here; release-gate must fail loud
@@ -50,6 +49,7 @@
 # Exit codes (delegated to the embedded suite):
 #   0 - all assertions passed
 #   1 - any assertion failed
+#   2 - configuration error (unknown FIXTURE_FORMAT, etc.)
 #   4 - EXPECT_FAILURE=1 but gate passed (self-test detected weakening)
 
 set -uo pipefail
@@ -70,37 +70,17 @@ export ALLOW_SCANNER_SKIP=0
 export RELEASE_GATE=1
 export SCAN_TIMEOUT="${SCAN_TIMEOUT:-180}"
 
-case "$FIXTURE_FORMAT" in
-  npm)
-    # Delegate to the lite primitive. It already builds the lodash 4.17.4
-    # fixture, uploads via PUT to a generic repo, triggers a scan, polls,
-    # and asserts the load-bearing findings_count >= 1.
-    exec "$(dirname "$0")/../security/test-scan-completes.sh"
-    ;;
-  oci|maven|pypi|cargo|helm)
-    # Scaffolds. Each of these needs a known-vulnerable fixture builder
-    # (Trivy image scan for oci, jar+pom for maven, .whl for pypi, .crate
-    # for cargo, .tgz with vulnerable subchart for helm). The format-matrix
-    # script currently runs these as scaffolds: exit 0 with a clear log
-    # entry so the matrix surfaces "not yet covered" without blocking.
-    # TODO(artifact-keeper-test#62): land the per-format fixture builders.
-    echo "scan-completion-gate.sh: FIXTURE_FORMAT=${FIXTURE_FORMAT} is a scaffold (#62)"
-    echo "  No assertion run. To wire this format up:"
-    echo "    1. Build a known-vulnerable fixture for ${FIXTURE_FORMAT} in the format's native path"
-    echo "    2. Drop into the matrix slot in test-scan-completion-format-matrix.sh"
-    exit 0
-    ;;
-  generic-payload)
-    # Used by the SBOM gate scaffold. Just upload a tarball, trigger a
-    # scan, assert it reaches a terminal state. No findings_count
-    # assertion (the payload is not a recognized package format).
-    # TODO(artifact-keeper-test#57): expand once #903 lands.
-    echo "scan-completion-gate.sh: FIXTURE_FORMAT=generic-payload is a scaffold (#57)"
-    exit 0
-    ;;
-  *)
-    echo "ERROR: unknown FIXTURE_FORMAT='${FIXTURE_FORMAT}'" >&2
-    echo "  Supported: npm, oci, maven, pypi, cargo, helm, generic-payload" >&2
-    exit 2
-    ;;
-esac
+if [ "$FIXTURE_FORMAT" != "npm" ]; then
+  echo "ERROR: scan-completion-gate.sh: FIXTURE_FORMAT='${FIXTURE_FORMAT}' has no fixture builder yet." >&2
+  echo "  Only 'npm' is supported. Deferred formats (oci, maven, pypi, cargo, helm)" >&2
+  echo "  are tracked under artifact-keeper-test#62. When a fixture builder for a" >&2
+  echo "  deferred format lands, add the case here AND add the format to the" >&2
+  echo "  release-gate.yml workflow matrix in the same PR." >&2
+  exit 2
+fi
+
+# Delegate to the lite primitive. It builds the lodash fixture
+# (FIXTURE_LODASH_VERSION-controlled, default 4.17.4 / CVE-2019-10744),
+# uploads via PUT to a generic repo, triggers a scan, polls, and asserts
+# the load-bearing findings_count >= 1.
+exec "$(dirname "$0")/../security/test-scan-completes.sh"

--- a/tests/release-gate/scan-completion-gate.sh
+++ b/tests/release-gate/scan-completion-gate.sh
@@ -47,10 +47,11 @@
 #   ALLOW_SCANNER_SKIP    forced to 0 here; release-gate must fail loud
 #
 # Exit codes (delegated to the embedded suite):
-#   0 - all assertions passed
-#   1 - any assertion failed
+#   0 - all assertions passed (or EXPECT_FAILURE=1 and at least one failed)
+#   1 - any assertion failed (or EXPECT_FAILURE=1 and every assertion passed,
+#       which means the gate has been weakened -- self-test detected it)
 #   2 - configuration error (unknown FIXTURE_FORMAT, etc.)
-#   4 - EXPECT_FAILURE=1 but gate passed (self-test detected weakening)
+#   5 - EXPECT_FAILURE=1 and ALLOW_SCANNER_SKIP=1 (mutually exclusive)
 
 set -uo pipefail
 

--- a/tests/release-gate/scan-completion-gate.sh
+++ b/tests/release-gate/scan-completion-gate.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# scan-completion-gate.sh -- Release-gate primitive for the scan-completion
+# silent-success class (#871 stuck-queued, #888 silently completed-but-not-scanned).
+#
+# Covers artifact-keeper-test issues:
+#   - #46  E2E scan flow completion
+#   - #56  Epic: scan-completion silent-success gate
+#
+# This is the format-parameterized wrapper around the lite primitive at
+# tests/security/test-scan-completes.sh. It hard-codes the release-gate
+# semantics:
+#   - ALLOW_SCANNER_SKIP=0 (a missing scanner in release-gate IS the bug)
+#   - RELEASE_GATE=1 (skip_suite => hard fail)
+#   - SCAN_TIMEOUT defaults to 180s (same as the lite primitive)
+#
+# It is parameterized via FIXTURE_FORMAT so test-scan-completion-format-matrix.sh
+# can iterate over npm / pypi / oci / maven without copy-pasting the
+# trigger + poll + assert plumbing.
+#
+# Currently implemented fixture formats:
+#   - npm (default, lodash 4.17.4 / CVE-2019-10744)
+#   - generic-payload (for the SBOM gate scaffold; no findings assertion)
+#
+# Scaffolded but not yet wired (require a fixture-builder per format):
+#   - oci, maven, pypi, cargo, helm
+#   For these we exit 0 with a clear log line. The format-matrix script's
+#   matrix entries record this as a skip; when the fixture-builder lands
+#   the matrix flips that entry to a real gate without touching the
+#   workflow file.
+#
+# Why this lives in tests/release-gate/ rather than tests/security/:
+#   - tests/security/ is picked up automatically by run-suite.sh --suite
+#     security. The existing test-scan-completes.sh stays there for the
+#     security suite. This wrapper exists specifically so the release-gate
+#     workflow can call ONE script per matrix entry without spinning up
+#     the whole security suite, and without coupling the matrix wiring
+#     to run-suite.sh's directory layout.
+#
+# Environment:
+#   BASE_URL              backend URL (default http://localhost:8080)
+#   ADMIN_USER            admin username (default admin)
+#   ADMIN_PASS            admin password
+#   RUN_ID                resource-name suffix
+#   FIXTURE_FORMAT        npm | oci | maven | pypi | cargo | helm | generic-payload
+#                         (default: npm)
+#   SCAN_TIMEOUT          max seconds to wait (default 180)
+#   EXPECT_FAILURE        set to 1 by the meta-test workflow (#883 contract)
+#   ALLOW_SCANNER_SKIP    forced to 0 here; release-gate must fail loud
+#
+# Exit codes (delegated to the embedded suite):
+#   0 - all assertions passed
+#   1 - any assertion failed
+#   4 - EXPECT_FAILURE=1 but gate passed (self-test detected weakening)
+
+set -uo pipefail
+
+# shellcheck source=../lib/common.sh disable=SC1091
+source "$(dirname "$0")/../lib/common.sh"
+
+FIXTURE_FORMAT="${FIXTURE_FORMAT:-npm}"
+
+# Release-gate semantics. Refuse to honor ALLOW_SCANNER_SKIP=1 here; a
+# release-gate that gracefully skips when the scanner pod is down is the
+# exact silent-success class this gate exists to catch.
+if [ "${ALLOW_SCANNER_SKIP:-0}" = "1" ]; then
+  echo "ERROR: scan-completion-gate.sh refuses ALLOW_SCANNER_SKIP=1 (release-gate must fail loud on scanner unavailability; that is the #888 silent-success class)" >&2
+  exit 2
+fi
+export ALLOW_SCANNER_SKIP=0
+export RELEASE_GATE=1
+export SCAN_TIMEOUT="${SCAN_TIMEOUT:-180}"
+
+case "$FIXTURE_FORMAT" in
+  npm)
+    # Delegate to the lite primitive. It already builds the lodash 4.17.4
+    # fixture, uploads via PUT to a generic repo, triggers a scan, polls,
+    # and asserts the load-bearing findings_count >= 1.
+    exec "$(dirname "$0")/../security/test-scan-completes.sh"
+    ;;
+  oci|maven|pypi|cargo|helm)
+    # Scaffolds. Each of these needs a known-vulnerable fixture builder
+    # (Trivy image scan for oci, jar+pom for maven, .whl for pypi, .crate
+    # for cargo, .tgz with vulnerable subchart for helm). The format-matrix
+    # script currently runs these as scaffolds: exit 0 with a clear log
+    # entry so the matrix surfaces "not yet covered" without blocking.
+    # TODO(artifact-keeper-test#62): land the per-format fixture builders.
+    echo "scan-completion-gate.sh: FIXTURE_FORMAT=${FIXTURE_FORMAT} is a scaffold (#62)"
+    echo "  No assertion run. To wire this format up:"
+    echo "    1. Build a known-vulnerable fixture for ${FIXTURE_FORMAT} in the format's native path"
+    echo "    2. Drop into the matrix slot in test-scan-completion-format-matrix.sh"
+    exit 0
+    ;;
+  generic-payload)
+    # Used by the SBOM gate scaffold. Just upload a tarball, trigger a
+    # scan, assert it reaches a terminal state. No findings_count
+    # assertion (the payload is not a recognized package format).
+    # TODO(artifact-keeper-test#57): expand once #903 lands.
+    echo "scan-completion-gate.sh: FIXTURE_FORMAT=generic-payload is a scaffold (#57)"
+    exit 0
+    ;;
+  *)
+    echo "ERROR: unknown FIXTURE_FORMAT='${FIXTURE_FORMAT}'" >&2
+    echo "  Supported: npm, oci, maven, pypi, cargo, helm, generic-payload" >&2
+    exit 2
+    ;;
+esac

--- a/tests/release-gate/test-pinned-cve.sh
+++ b/tests/release-gate/test-pinned-cve.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# test-pinned-cve.sh -- Pinned-CVE assertion against /scans/{id}/findings.
+#
+# Covers artifact-keeper-test#64.
+#
+# Why this exists, on top of the lite gate's findings_count >= 1 check:
+#   - findings_count >= 1 catches "scanner emitted at least one finding".
+#     That defeats the gross silent-success class (#888) but it does NOT
+#     catch scanner *correctness* drift:
+#       a) If a future scanner version mis-parses payload.txt and emits
+#          100 spurious findings, findings_count >= 1 still passes.
+#       b) If the CVE database is stale and Trivy can no longer detect
+#          CVE-2019-10744 but emits other (unrelated) findings,
+#          findings_count >= 1 still passes.
+#   - The fix is to bind the gate to a specific CVE id. The lite fixture
+#     pins lodash 4.17.4, which has CVE-2019-10744 (Prototype Pollution,
+#     CVSS 9.1). We assert that EXACT CVE shows up in the findings list
+#     for the scan.
+#
+# Fixture choice: per the task brief, log4j 2.14.0 / CVE-2021-44228 is
+# also a candidate. lodash is what test-scan-completes.sh already builds,
+# and #64 explicitly references CVE-2019-10744 as the pinned value, so
+# we follow that path. log4j coverage belongs in the format-matrix (oci
+# manifest path) once that scaffold is wired up (#62 + #64 extension).
+#
+# Backend contract (verified against
+#   artifact-keeper/backend/src/api/handlers/security.rs:287-311):
+#     GET /api/v1/security/scans/{id}/findings
+#     -> { items: [FindingResponse], total: i64 }
+#     FindingResponse.cve_id is Option<String> (may be null for
+#     non-CVE findings). We match on cve_id == "CVE-2019-10744".
+#
+# Environment:
+#   BASE_URL              backend URL (default http://localhost:8080)
+#   ADMIN_PASS            admin password
+#   RUN_ID                resource-name suffix
+#   EXPECTED_VULN_CVE     CVE id to assert (default: CVE-2019-10744)
+#   SCAN_TIMEOUT          poll-until-completed budget (default 180)
+
+# shellcheck source=../lib/common.sh disable=SC1091
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "pinned-cve"
+auth_admin
+setup_workdir
+
+REPO_KEY="pinned-cve-${RUN_ID}"
+PACKAGE_NAME="lodash-vuln-fixture"
+PACKAGE_VERSION="1.0.0"
+TARBALL_NAME="${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz"
+ARTIFACT_PATH="${PACKAGE_NAME}/${PACKAGE_VERSION}/${TARBALL_NAME}"
+SCAN_TIMEOUT="${SCAN_TIMEOUT:-180}"
+EXPECTED_VULN_CVE="${EXPECTED_VULN_CVE:-CVE-2019-10744}"
+
+cleanup_pin() {
+  # shellcheck disable=SC2086
+  curl -sf $CURL_TIMEOUT -X DELETE -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/repositories/${REPO_KEY}" >/dev/null 2>&1 || true
+  [ -n "${WORK_DIR:-}" ] && rm -rf "$WORK_DIR" 2>/dev/null || true
+}
+trap cleanup_pin EXIT
+
+# ---------------------------------------------------------------------------
+# Build the known-vulnerable lodash 4.17.4 fixture (same payload shape as
+# test-scan-completes.sh; deliberately duplicated rather than sourced so
+# this test stays self-contained for the release-gate workflow).
+# ---------------------------------------------------------------------------
+
+begin_test "Build lodash 4.17.4 fixture (CVE-2019-10744)"
+mkdir -p "${WORK_DIR}/package"
+cat > "${WORK_DIR}/package/package.json" <<EOF
+{
+  "name": "${PACKAGE_NAME}",
+  "version": "${PACKAGE_VERSION}",
+  "dependencies": { "lodash": "4.17.4" }
+}
+EOF
+cat > "${WORK_DIR}/package/package-lock.json" <<EOF
+{
+  "name": "${PACKAGE_NAME}",
+  "version": "${PACKAGE_VERSION}",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": { "name": "${PACKAGE_NAME}", "version": "${PACKAGE_VERSION}",
+          "dependencies": { "lodash": "4.17.4" } },
+    "node_modules/lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyLuHBHJgwGu1myF0sR4U="
+    }
+  },
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyLuHBHJgwGu1myF0sR4U="
+    }
+  }
+}
+EOF
+if tar -czf "${WORK_DIR}/${TARBALL_NAME}" -C "${WORK_DIR}" package 2>/dev/null; then
+  pass
+else
+  fail "could not build fixture tarball"
+fi
+
+# ---------------------------------------------------------------------------
+# Repo + upload.
+# ---------------------------------------------------------------------------
+
+begin_test "Create generic local repository"
+if create_local_repo "$REPO_KEY" "generic"; then
+  pass
+else
+  fail "could not create generic repository ${REPO_KEY}"
+fi
+
+begin_test "Upload fixture"
+# shellcheck disable=SC2086
+upload_status=$(curl -s -o "${WORK_DIR}/upload-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -X PUT \
+  -H "$(auth_header)" \
+  -H "Content-Type: application/gzip" \
+  --data-binary "@${WORK_DIR}/${TARBALL_NAME}" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/${ARTIFACT_PATH}") || upload_status="000"
+if [ "$upload_status" = "200" ] || [ "$upload_status" = "201" ]; then
+  pass
+else
+  fail "upload returned HTTP ${upload_status}"
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve artifact_id.
+# ---------------------------------------------------------------------------
+
+begin_test "Resolve artifact_id"
+ARTIFACT_ID=""
+# shellcheck disable=SC2086
+list_status=$(curl -s -o "${WORK_DIR}/list-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts") || list_status="000"
+if [ "$list_status" = "200" ]; then
+  ARTIFACT_ID=$(jq -er --arg p "$ARTIFACT_PATH" \
+    '.items | map(select(.path == $p or .name == $p)) | first | .id // empty' \
+    < "${WORK_DIR}/list-resp.json" 2>/dev/null || true)
+fi
+if [ -n "$ARTIFACT_ID" ]; then
+  pass
+else
+  fail "could not resolve artifact_id (list HTTP ${list_status})"
+  end_suite
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Trigger scan and poll until terminal.
+# ---------------------------------------------------------------------------
+
+begin_test "Trigger scan"
+trigger_body=$(jq -n --arg id "$ARTIFACT_ID" '{artifact_id: $id, force: true}')
+# shellcheck disable=SC2086
+trig_status=$(curl -s -o "${WORK_DIR}/trig-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -X POST \
+  -H "$(auth_header)" \
+  -H "Content-Type: application/json" \
+  -d "$trigger_body" \
+  "${BASE_URL}/api/v1/security/scan") || trig_status="000"
+case "$trig_status" in
+  2*) pass ;;
+  *) fail "scan trigger returned HTTP ${trig_status}" ;;
+esac
+
+begin_test "Scan reaches completed within ${SCAN_TIMEOUT}s"
+elapsed=0
+SCAN_ID=""
+final_status=""
+while [ "$elapsed" -lt "$SCAN_TIMEOUT" ]; do
+  # shellcheck disable=SC2086
+  poll_status=$(curl -s -o "${WORK_DIR}/scans-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/security/artifacts/${ARTIFACT_ID}/scans") || poll_status="000"
+  if [ "$poll_status" = "200" ]; then
+    scan_obj=$(jq -c '.items[0] // empty' < "${WORK_DIR}/scans-resp.json" 2>/dev/null || echo "")
+    if [ -n "$scan_obj" ]; then
+      state=$(echo "$scan_obj" | jq -r '.status | ascii_downcase' 2>/dev/null || echo "unknown")
+      case "$state" in
+        completed|failed|error|timeout)
+          final_status="$state"
+          SCAN_ID=$(echo "$scan_obj" | jq -r '.id // empty')
+          break
+          ;;
+      esac
+    fi
+  fi
+  sleep 5
+  elapsed=$(( elapsed + 5 ))
+done
+
+if [ "$final_status" = "completed" ]; then
+  echo "  scan_id=${SCAN_ID}"
+  pass
+elif [ -n "$final_status" ]; then
+  fail "scan reached terminal state '${final_status}', expected 'completed'"
+  end_suite
+  exit 1
+else
+  fail "scan did not reach a terminal state within ${SCAN_TIMEOUT}s"
+  end_suite
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Load-bearing assertion: fetch findings for the scan and confirm the
+# pinned CVE appears.
+#
+# Backend handler list_findings returns FindingListResponse {items, total}.
+# Each FindingResponse has cve_id: Option<String>; we match on
+# .cve_id == EXPECTED_VULN_CVE. If cve_id is null for all rows but the
+# scan claims findings_count > 0, that is a backend contract regression
+# (separate failure mode -- we surface it loudly with the actual CVE
+# values observed).
+# ---------------------------------------------------------------------------
+
+begin_test "GET /scans/${SCAN_ID}/findings includes ${EXPECTED_VULN_CVE}"
+# shellcheck disable=SC2086
+findings_status=$(curl -s -o "${WORK_DIR}/findings-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/security/scans/${SCAN_ID}/findings?per_page=200") \
+  || findings_status="000"
+
+case "$findings_status" in
+  200)
+    # Confirm response shape first so a "200 with HTML" misroute fails loud.
+    if ! jq -e '(.items | type) == "array" and (.total | type) == "number"' \
+         < "${WORK_DIR}/findings-resp.json" >/dev/null 2>&1; then
+      body=$(head -c 400 "${WORK_DIR}/findings-resp.json" 2>/dev/null || true)
+      fail "findings endpoint 200 but body shape mismatch (expected {items: [], total: N})" "$body"
+      end_suite
+      exit 1
+    fi
+
+    total_findings=$(jq -r '.total' < "${WORK_DIR}/findings-resp.json")
+    matched=$(jq --arg cve "$EXPECTED_VULN_CVE" \
+      '[.items[] | select(.cve_id == $cve)] | length' \
+      < "${WORK_DIR}/findings-resp.json")
+
+    if [ "${matched:-0}" -ge 1 ]; then
+      echo "  matched ${matched} finding(s) for ${EXPECTED_VULN_CVE} (total findings: ${total_findings})"
+      pass
+    else
+      # Surface what we DID see so the operator can decide whether the
+      # CVE database has drifted or the scanner mis-parsed the fixture.
+      observed_cves=$(jq -r '[.items[].cve_id // "<null>"] | unique | join(", ")' \
+        < "${WORK_DIR}/findings-resp.json" 2>/dev/null || echo "<jq-error>")
+      preview=$(jq -c '.items[0:3]' < "${WORK_DIR}/findings-resp.json" 2>/dev/null | cut -c 1-500)
+      fail "scan ${SCAN_ID} on lodash 4.17.4 did not surface ${EXPECTED_VULN_CVE} in findings (total=${total_findings})" \
+"observed cve_ids: ${observed_cves}
+first 3 findings: ${preview}
+endpoint: GET ${BASE_URL}/api/v1/security/scans/${SCAN_ID}/findings
+diagnosis:
+  - If observed_cves is empty/<null> and total > 0, FindingResponse.cve_id stopped being populated.
+  - If observed_cves are present but none is ${EXPECTED_VULN_CVE}, scanner DB drift or fixture rot.
+  - If total == 0, scanner did not inspect the fixture; see test-scan-completes.sh diagnosis."
+    fi
+    ;;
+  404)
+    fail "findings endpoint returned 404; scan_id=${SCAN_ID} may be wrong or endpoint missing"
+    ;;
+  *)
+    body=$(head -c 400 "${WORK_DIR}/findings-resp.json" 2>/dev/null || true)
+    fail "findings endpoint returned HTTP ${findings_status}" "$body"
+    ;;
+esac
+
+end_suite

--- a/tests/release-gate/test-scan-completion-format-matrix.sh
+++ b/tests/release-gate/test-scan-completion-format-matrix.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# test-scan-completion-format-matrix.sh -- iterate scan-completion-gate.sh
+# across representative package formats so a regression in any one format's
+# scanner pipeline fails the release gate.
+#
+# Covers artifact-keeper-test#62: the lite gate (PR #60) tests one fixture
+# (npm tarball with package-lock.json). The customer's #888 complaint was
+# precisely the format-coverage gap ("works for npm, silently fails for
+# docker"). Matrixing across formats turns that gap into a loud failure.
+#
+# Matrix entries:
+#   - npm:    wired (delegates to test-scan-completes.sh via the gate primitive)
+#   - oci:    scaffold (TODO #62)
+#   - maven:  scaffold (TODO #62)
+#   - pypi:   scaffold (TODO #62)
+#   - cargo:  scaffold (TODO #62)
+#   - helm:   scaffold (TODO #62)
+#
+# When a fixture-builder for a scaffolded format lands, the matrix entry
+# flips from "scaffold" to "wired" without touching this file -- the
+# gate primitive's case statement is the single source of truth.
+#
+# Why one driver script rather than per-format siblings in tests/security/:
+#   - Pacing: each format's scan can take 30-60s. Sequential 6-format
+#     pass would blow the release-gate 5-min budget. We let each matrix
+#     entry run in its own workflow job (parallel) by passing the format
+#     name via env. This script can also be invoked locally to run a
+#     subset (e.g. FORMATS=npm,oci ./test-scan-completion-format-matrix.sh).
+#   - Single source of truth: the gate primitive lives in one file. A
+#     fix to the polling logic propagates to every format automatically.
+#
+# Environment:
+#   FORMATS    comma-separated list of formats to run (default: all)
+#              e.g. FORMATS=npm,oci ./test-scan-completion-format-matrix.sh
+#   BASE_URL, ADMIN_PASS, RUN_ID -- per usual
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Default matrix: all representative formats from artifact-keeper-test#62.
+FORMATS="${FORMATS:-npm,oci,maven,pypi,cargo,helm}"
+
+# Track per-format outcomes for the final summary.
+declare -a PASSED=()
+declare -a FAILED=()
+declare -a SCAFFOLDED=()
+
+# Per-format RUN_ID suffixes so concurrent runs don't clobber each other's
+# repos. Each format gets its own repo key derived from the base RUN_ID.
+BASE_RUN_ID="${RUN_ID:-matrix-$(date +%s)}"
+
+echo "========================================"
+echo "  scan-completion format matrix"
+echo "  formats: ${FORMATS}"
+echo "  base run_id: ${BASE_RUN_ID}"
+echo "========================================"
+
+# We deliberately keep going on failure so the operator sees ALL format
+# regressions in one workflow run, not just the first. The aggregate
+# exit code at the end fails the gate if any format failed.
+overall_exit=0
+
+IFS=',' read -ra FORMAT_LIST <<< "$FORMATS"
+for fmt in "${FORMAT_LIST[@]}"; do
+  fmt_trim=$(echo "$fmt" | tr -d '[:space:]')
+  [ -z "$fmt_trim" ] && continue
+  echo ""
+  echo "--- format=${fmt_trim} ---"
+
+  # Per-format RUN_ID so the repo key (e.g. scan-complete-<RUN_ID>) is unique.
+  fmt_run_id="${BASE_RUN_ID}-${fmt_trim}"
+
+  # Capture the gate primitive's stdout+stderr so its log shows up
+  # inline in the matrix log. Cannot use `exec` because we need control
+  # back to record the format's outcome.
+  if FIXTURE_FORMAT="$fmt_trim" RUN_ID="$fmt_run_id" \
+       "${SCRIPT_DIR}/scan-completion-gate.sh"; then
+    # The gate exits 0 on success OR on scaffolded formats. Distinguish
+    # by inspecting whether the gate emitted the scaffold marker.
+    # (cheap: re-run with a probe? no -- the scaffold path's exit 0 is
+    # accompanied by the marker on stdout, but we already consumed it.
+    # Solution: write a sentinel file from the gate. Until that exists,
+    # we conservatively classify wired-formats by name.)
+    case "$fmt_trim" in
+      npm|generic-payload)
+        PASSED+=("$fmt_trim")
+        ;;
+      *)
+        SCAFFOLDED+=("$fmt_trim")
+        ;;
+    esac
+  else
+    rc=$?
+    FAILED+=("${fmt_trim}(exit=${rc})")
+    overall_exit=1
+  fi
+done
+
+echo ""
+echo "========================================"
+echo "  scan-completion matrix summary"
+echo "----------------------------------------"
+echo "  passed:     ${PASSED[*]:-<none>}"
+echo "  scaffolded: ${SCAFFOLDED[*]:-<none>}  (TODO artifact-keeper-test#62)"
+echo "  failed:     ${FAILED[*]:-<none>}"
+echo "========================================"
+
+if [ "$overall_exit" -ne 0 ]; then
+  echo ""
+  echo "FAIL: one or more formats failed the scan-completion gate."
+  echo "This indicates the scan-completion silent-success class (#888)"
+  echo "is reproducing for at least one package format."
+  exit 1
+fi
+
+if [ "${#PASSED[@]}" -eq 0 ]; then
+  echo ""
+  echo "FAIL: no formats actually ran the wired gate; matrix degenerated to all-scaffolds."
+  echo "At minimum the npm fixture must be exercised."
+  exit 1
+fi
+
+echo ""
+echo "PASS: scan-completion gate passed for all wired formats."
+exit 0

--- a/tests/release-gate/test-scan-completion-format-matrix.sh
+++ b/tests/release-gate/test-scan-completion-format-matrix.sh
@@ -8,43 +8,44 @@
 # precisely the format-coverage gap ("works for npm, silently fails for
 # docker"). Matrixing across formats turns that gap into a loud failure.
 #
-# Matrix entries:
-#   - npm:    wired (delegates to test-scan-completes.sh via the gate primitive)
-#   - oci:    scaffold (TODO #62)
-#   - maven:  scaffold (TODO #62)
-#   - pypi:   scaffold (TODO #62)
-#   - cargo:  scaffold (TODO #62)
-#   - helm:   scaffold (TODO #62)
+# This script is for LOCAL developer use. CI uses the workflow-level
+# matrix in release-gate.yml directly (parallel runner jobs surface
+# per-format outcomes in the Actions UI).
 #
-# When a fixture-builder for a scaffolded format lands, the matrix entry
-# flips from "scaffold" to "wired" without touching this file -- the
-# gate primitive's case statement is the single source of truth.
+# Matrix entries (current):
+#   - npm: wired (delegates to test-scan-completes.sh via the gate primitive)
+#
+# Deferred formats (no fixture yet, NOT in the matrix; tracked under #62):
+#   oci, maven, pypi, cargo, helm. Adding any of these requires landing
+#   a format-specific fixture builder AND adding the format to BOTH:
+#     1. release-gate.yml workflow matrix (so CI runs it)
+#     2. SUPPORTED_FORMATS below (so local runs accept it)
 #
 # Why one driver script rather than per-format siblings in tests/security/:
-#   - Pacing: each format's scan can take 30-60s. Sequential 6-format
-#     pass would blow the release-gate 5-min budget. We let each matrix
-#     entry run in its own workflow job (parallel) by passing the format
-#     name via env. This script can also be invoked locally to run a
-#     subset (e.g. FORMATS=npm,oci ./test-scan-completion-format-matrix.sh).
+#   - Pacing: each format's scan can take 30-60s. Sequential pass over
+#     all formats would blow the release-gate 5-min budget. CI runs each
+#     matrix entry in its own workflow job (parallel).
 #   - Single source of truth: the gate primitive lives in one file. A
 #     fix to the polling logic propagates to every format automatically.
 #
 # Environment:
-#   FORMATS    comma-separated list of formats to run (default: all)
-#              e.g. FORMATS=npm,oci ./test-scan-completion-format-matrix.sh
+#   FORMATS    comma-separated list of formats to run (default: npm)
+#              e.g. FORMATS=npm ./test-scan-completion-format-matrix.sh
 #   BASE_URL, ADMIN_PASS, RUN_ID -- per usual
 
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Default matrix: all representative formats from artifact-keeper-test#62.
-FORMATS="${FORMATS:-npm,oci,maven,pypi,cargo,helm}"
+# Default matrix: only formats whose fixtures exist. Keep this in sync
+# with the workflow matrix in .github/workflows/release-gate.yml.
+SUPPORTED_FORMATS="npm"
+FORMATS="${FORMATS:-${SUPPORTED_FORMATS}}"
 
 # Track per-format outcomes for the final summary.
 declare -a PASSED=()
 declare -a FAILED=()
-declare -a SCAFFOLDED=()
+declare -a REJECTED=()
 
 # Per-format RUN_ID suffixes so concurrent runs don't clobber each other's
 # repos. Each format gets its own repo key derived from the base RUN_ID.
@@ -57,8 +58,8 @@ echo "  base run_id: ${BASE_RUN_ID}"
 echo "========================================"
 
 # We deliberately keep going on failure so the operator sees ALL format
-# regressions in one workflow run, not just the first. The aggregate
-# exit code at the end fails the gate if any format failed.
+# regressions in one run, not just the first. The aggregate exit code
+# at the end fails the gate if any format failed or was rejected.
 overall_exit=0
 
 IFS=',' read -ra FORMAT_LIST <<< "$FORMATS"
@@ -71,28 +72,20 @@ for fmt in "${FORMAT_LIST[@]}"; do
   # Per-format RUN_ID so the repo key (e.g. scan-complete-<RUN_ID>) is unique.
   fmt_run_id="${BASE_RUN_ID}-${fmt_trim}"
 
-  # Capture the gate primitive's stdout+stderr so its log shows up
-  # inline in the matrix log. Cannot use `exec` because we need control
-  # back to record the format's outcome.
+  # The gate primitive now exits 2 for unknown FIXTURE_FORMAT values
+  # rather than silently exiting 0. That removes the previous ambiguity
+  # between "format passed" and "format scaffolded": we no longer need
+  # a sentinel file, the exit code distinguishes the three outcomes.
   if FIXTURE_FORMAT="$fmt_trim" RUN_ID="$fmt_run_id" \
        "${SCRIPT_DIR}/scan-completion-gate.sh"; then
-    # The gate exits 0 on success OR on scaffolded formats. Distinguish
-    # by inspecting whether the gate emitted the scaffold marker.
-    # (cheap: re-run with a probe? no -- the scaffold path's exit 0 is
-    # accompanied by the marker on stdout, but we already consumed it.
-    # Solution: write a sentinel file from the gate. Until that exists,
-    # we conservatively classify wired-formats by name.)
-    case "$fmt_trim" in
-      npm|generic-payload)
-        PASSED+=("$fmt_trim")
-        ;;
-      *)
-        SCAFFOLDED+=("$fmt_trim")
-        ;;
-    esac
+    PASSED+=("$fmt_trim")
   else
     rc=$?
-    FAILED+=("${fmt_trim}(exit=${rc})")
+    if [ "$rc" = "2" ]; then
+      REJECTED+=("${fmt_trim}(no fixture; see #62)")
+    else
+      FAILED+=("${fmt_trim}(exit=${rc})")
+    fi
     overall_exit=1
   fi
 done
@@ -101,26 +94,27 @@ echo ""
 echo "========================================"
 echo "  scan-completion matrix summary"
 echo "----------------------------------------"
-echo "  passed:     ${PASSED[*]:-<none>}"
-echo "  scaffolded: ${SCAFFOLDED[*]:-<none>}  (TODO artifact-keeper-test#62)"
-echo "  failed:     ${FAILED[*]:-<none>}"
+echo "  passed:   ${PASSED[*]:-<none>}"
+echo "  rejected: ${REJECTED[*]:-<none>}  (no fixture builder; artifact-keeper-test#62)"
+echo "  failed:   ${FAILED[*]:-<none>}"
 echo "========================================"
 
 if [ "$overall_exit" -ne 0 ]; then
   echo ""
-  echo "FAIL: one or more formats failed the scan-completion gate."
-  echo "This indicates the scan-completion silent-success class (#888)"
-  echo "is reproducing for at least one package format."
+  echo "FAIL: one or more formats failed or were rejected."
+  if [ "${#REJECTED[@]}" -gt 0 ]; then
+    echo "  Rejected formats lack a fixture builder. To run only wired"
+    echo "  formats locally: FORMATS=${SUPPORTED_FORMATS} \$0"
+  fi
   exit 1
 fi
 
 if [ "${#PASSED[@]}" -eq 0 ]; then
   echo ""
-  echo "FAIL: no formats actually ran the wired gate; matrix degenerated to all-scaffolds."
-  echo "At minimum the npm fixture must be exercised."
+  echo "FAIL: no formats ran. At minimum the npm fixture must be exercised."
   exit 1
 fi
 
 echo ""
-echo "PASS: scan-completion gate passed for all wired formats."
+echo "PASS: scan-completion gate passed for all formats."
 exit 0

--- a/tests/security/test-scan-completes.sh
+++ b/tests/security/test-scan-completes.sh
@@ -67,8 +67,16 @@ EXPECT_FAILURE="${EXPECT_FAILURE:-0}"
 # actually produce findings -- if findings_count == 0 on a healthy
 # backend, the scanner never inspected the bytes (Reality Checker /
 # Security Engineer reviews of PR #60).
+#
+# FIXTURE_LODASH_VERSION env override exists for the paired-evidence
+# self-test (scan-completes-self-test.yml fixture B): setting it to a
+# non-vulnerable version like 4.17.21 produces a fixture that Trivy
+# scans cleanly. With findings_count=0 on a healthy backend, the
+# load-bearing assertion below correctly FAILS, which paired with
+# EXPECT_FAILURE=1 proves the assertion is doing real work. Do NOT
+# set this env var outside the self-test fixture B job.
 EXPECTED_VULN_PACKAGE="lodash"
-EXPECTED_VULN_VERSION="4.17.4"
+EXPECTED_VULN_VERSION="${FIXTURE_LODASH_VERSION:-4.17.4}"
 EXPECTED_VULN_CVE_HINT="CVE-2019-10744"
 
 # ---------------------------------------------------------------------------
@@ -162,16 +170,29 @@ is_nonneg_int() {
 # the lockfile exactly.
 # ---------------------------------------------------------------------------
 
-begin_test "Build known-vulnerable fixture (lodash 4.17.4 / CVE-2019-10744)"
+begin_test "Build fixture (lodash ${EXPECTED_VULN_VERSION})"
 mkdir -p "${WORK_DIR}/package"
+
+# Trivy parses package-lock.json on the version field; the integrity
+# SHA does not gate detection. We use the published-npm SHA for 4.17.4
+# (the default vulnerable case) so the lockfile is realistic. For
+# overridden versions (FIXTURE_LODASH_VERSION set by the self-test
+# fixture B path) we use a known-fixture placeholder rather than a
+# real-but-wrong SHA, since no real consumer ever resolves this
+# tarball.
+if [ "$EXPECTED_VULN_VERSION" = "4.17.4" ]; then
+  LODASH_INTEGRITY="sha1-eCA6TRwyLuHBHJgwGu1myF0sR4U="
+else
+  LODASH_INTEGRITY="sha1-FIXTURE-NOT-FOR-NPM-RESOLUTION-PLACEHOLDER="
+fi
 
 cat > "${WORK_DIR}/package/package.json" <<EOF
 {
   "name": "scan-completes-fixture",
   "version": "1.0.0",
-  "description": "Release-gate fixture pinned to a known-vulnerable lodash for CVE-2019-10744 detection",
+  "description": "Release-gate fixture pinned to lodash ${EXPECTED_VULN_VERSION}",
   "dependencies": {
-    "lodash": "4.17.4"
+    "lodash": "${EXPECTED_VULN_VERSION}"
   }
 }
 EOF
@@ -187,20 +208,20 @@ cat > "${WORK_DIR}/package/package-lock.json" <<EOF
       "name": "scan-completes-fixture",
       "version": "1.0.0",
       "dependencies": {
-        "lodash": "4.17.4"
+        "lodash": "${EXPECTED_VULN_VERSION}"
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyLuHBHJgwGu1myF0sR4U="
+      "version": "${EXPECTED_VULN_VERSION}",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-${EXPECTED_VULN_VERSION}.tgz",
+      "integrity": "${LODASH_INTEGRITY}"
     }
   },
   "dependencies": {
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyLuHBHJgwGu1myF0sR4U="
+      "version": "${EXPECTED_VULN_VERSION}",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-${EXPECTED_VULN_VERSION}.tgz",
+      "integrity": "${LODASH_INTEGRITY}"
     }
   }
 }

--- a/tests/security/test-scan-completes.sh
+++ b/tests/security/test-scan-completes.sh
@@ -88,36 +88,6 @@ EXPECTED_VULN_CVE_HINT="CVE-2019-10744"
 cleanup() {
   local exit_code=$?
 
-  # Mutual exclusion: EXPECT_FAILURE=1 inverts exit codes for self-test;
-  # ALLOW_SCANNER_SKIP=1 makes scanner_unavailable() return success. If
-  # both are set, the self-test would falsely report "gate caught a bad
-  # backend" when in fact it just gracefully skipped. This bug class
-  # would silently turn the self-test into a no-op -- the exact failure
-  # mode #883 is meant to prevent.
-  if [ "$EXPECT_FAILURE" = "1" ] && [ "$ALLOW_SCANNER_SKIP" = "1" ]; then
-    echo "" >&2
-    echo "ERROR: EXPECT_FAILURE=1 and ALLOW_SCANNER_SKIP=1 are mutually exclusive." >&2
-    echo "  EXPECT_FAILURE inverts exit codes; ALLOW_SCANNER_SKIP coerces failure to success." >&2
-    echo "  Together they corrupt the self-test signal. Pick one." >&2
-    exit 5
-  fi
-
-  # Self-test mode: invert the meaning of exit code so a *real* failure
-  # is reported as success (the gate is correctly catching a bad
-  # backend), and exit 0 is reported as exit 4 (the gate falsely passed
-  # on a bad backend).
-  if [ "$EXPECT_FAILURE" = "1" ]; then
-    if [ "$exit_code" -eq 0 ]; then
-      echo "" >&2
-      echo "ERROR: EXPECT_FAILURE=1 was set but the gate passed. Gate is broken or fixture is wrong." >&2
-      exit_code=4
-    else
-      echo ""
-      echo "Self-test PASSED: gate exited with code ${exit_code} as expected."
-      exit_code=0
-    fi
-  fi
-
   # shellcheck disable=SC2086  # CURL_TIMEOUT must word-split, per common.sh
   curl -sf $CURL_TIMEOUT -X DELETE -H "$(auth_header)" \
     "${BASE_URL}/api/v1/repositories/${REPO_KEY}" >/dev/null 2>&1 || true
@@ -126,6 +96,18 @@ cleanup() {
   exit "$exit_code"
 }
 trap cleanup EXIT
+
+# Mutual exclusion guard. EXPECT_FAILURE=1 inverts the suite exit code (via
+# end_suite() in common.sh); ALLOW_SCANNER_SKIP=1 makes scanner_unavailable()
+# coerce failure into success. Together they would falsely report "gate caught
+# a bad backend" when the gate just gracefully skipped, silently turning the
+# self-test into a no-op -- the failure class #883 is meant to prevent.
+if [ "$EXPECT_FAILURE" = "1" ] && [ "$ALLOW_SCANNER_SKIP" = "1" ]; then
+  echo "ERROR: EXPECT_FAILURE=1 and ALLOW_SCANNER_SKIP=1 are mutually exclusive." >&2
+  echo "  EXPECT_FAILURE inverts exit codes; ALLOW_SCANNER_SKIP coerces failure to success." >&2
+  echo "  Together they corrupt the self-test signal. Pick one." >&2
+  exit 5
+fi
 
 # ---------------------------------------------------------------------------
 # Fail-or-skip helper. Scanner unreachability is a legitimate failure


### PR DESCRIPTION
## Summary

Adds release-gate primitives for the scan-completion (#871, #888) and SBOM correctness (#870) silent-success classes, plus a paired pass/fail meta-test per the #883 contract.

Closes #46, #47, #56, #57, #61, #62, #64 from this repo.

## Files added

- `tests/release-gate/scan-completion-gate.sh`: format-parameterized release-gate wrapper around the lite primitive at `tests/security/test-scan-completes.sh`. Hard-codes `RELEASE_GATE=1` and refuses `ALLOW_SCANNER_SKIP=1` so a scanner-pod-down condition in release-gate context fails loud (the exact #888 class).
- `tests/release-gate/sbom-correctness-gate.sh`: pins the `POST /api/v1/sbom` contract (200 with `SbomResponse` shape). Component-count assertion deferred to artifact-keeper#903 per the #57 epic.
- `tests/release-gate/test-scan-completion-format-matrix.sh`: driver that iterates the gate across npm, oci, maven, pypi, cargo, helm. npm is wired (lodash 4.17.4 / CVE-2019-10744); the other five are scaffolded with `TODO(#62)` log lines.
- `tests/release-gate/test-pinned-cve.sh`: tightens the gate beyond `findings_count >= 1` to a pinned CVE id via `GET /api/v1/security/scans/{id}/findings`. Defaults to CVE-2019-10744; configurable via `EXPECTED_VULN_CVE` env var.
- `.github/workflows/release-gate.yml`: three new jobs (`scan-completion-gate` as a 6-format matrix, `sbom-correctness-gate`, `pinned-cve-gate`), wired into the rollup gate-check and the summary report. Includes `kubectl logs` capture on failure (#56 diagnostics sub-task).
- `.github/workflows/scan-completes-self-test.yml`: paired-evidence meta-test (#61, #883 contract). Fixture A (Trivy scaled to zero) is fully wired; fixture B (findings forgery) is a scaffold pending a backend debug knob.

## Scope honesty

Per the time-box, these are wired and exercise the silent-success contract end to end:

- npm scan-completion gate (delegates to the existing lite primitive)
- Pinned-CVE assertion against `/scans/{id}/findings`
- SBOM endpoint contract pin
- Self-test fixture A (Trivy scaled to zero)
- Workflow integration + diagnostics capture

These are scaffolds with explicit `TODO` markers:

- oci, maven, pypi, cargo, helm format-matrix entries (need fixture builders per #62)
- SBOM `component_count > 0` assertion (needs artifact-keeper#903 `--list-all-pkgs`)
- Self-test fixture B (findings forgery) (needs backend debug knob)

Each scaffold exits 0 with a clearly-marked log line so the gate stays honest about what it currently catches.

## Backend contracts verified

All endpoint shapes verified against the backend at this branch:

- `POST /api/v1/security/scan` -> `TriggerScanResponse {message, artifacts_queued}` (`backend/src/api/handlers/security.rs:96-99`)
- `GET /api/v1/security/artifacts/{id}/scans` -> `ScanListResponse {items: ScanResponse[], total}` with `findings_count: i32`, `error_message: Option<String>`, `completed_at: Option<DateTime>` (`security.rs:110-136`)
- `GET /api/v1/security/scans/{id}/findings` -> `FindingListResponse {items: FindingResponse[], total}` with `cve_id: Option<String>` (`security.rs:287-311`)
- `POST /api/v1/sbom` -> `SbomResponse {id, artifact_id, component_count: i32, ...}` (`backend/src/api/handlers/sbom.rs:91-107`)

## Verification

- `bash -n` clean on all four scripts
- `shellcheck -x` clean on all four scripts
- `python3 yaml.safe_load` clean on both workflows
- End-to-end run against the local backend not possible (no local backend in this worktree); the gate's plumbing reuses the existing `tests/security/test-scan-completes.sh` primitive that PR #60 already verified.

## Test plan

- [ ] CI: release-gate workflow's three new jobs run on a deploy and pass against a healthy backend
- [ ] CI: scan-completes-self-test workflow's fixture A correctly fails the gate (Trivy scaled to zero) and the meta-test reports green via `EXPECT_FAILURE=1` inversion
- [ ] CI: collect-results rollup includes the three new jobs in the summary table
- [ ] CI: gate-check fails the workflow if any of the three new jobs fail or are cancelled