### PR TITLE
ci(stress): wire collect-pg-stats into stress-tests job (#154)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1509,6 +1509,15 @@ jobs:
       # aggregate error counts alone (artifact-keeper-test#138 /
       # artifact-keeper#1088).
       STRESS_LOG_DIR: /tmp/stress-logs
+      # Postgres + pod-resource snapshot directory. The Collect postgres
+      # stats step below runs tests/stress/collect-pg-stats.sh after the
+      # stress run and ships this directory as the stress-pg-stats
+      # artifact. Captures the direct measurement that PR #148's
+      # Fresh-Eyes review (artifact-keeper-test#154) asked for: pg
+      # connection saturation + kubectl top, so the postgres-CPU
+      # narrative behind PR #140 is backed by evidence on every run.
+      PG_STATS_DIR: /tmp/pg-stats
+      NAMESPACE: ${{ needs.deploy.outputs.namespace }}
       # RELEASE_GATE=1 turns common.sh's skip_suite() into a hard fail.
       # A silently-skipped test in release-gate context is exactly the
       # silent-success class (#870/#871/#888) the gate exists to catch.
@@ -1564,6 +1573,26 @@ jobs:
               | sort | uniq -c | sort -rn | head -n 10 \
               | sed 's/^/    /'
           done
+
+      - name: Collect postgres stats
+        # Snapshot pg_stat_activity, pg_stat_statements, connection-count
+        # vs max_connections, and kubectl top for the backend + postgres
+        # pods. Runs after the stress workload and before teardown so the
+        # capture reflects steady-state load. if: always() ensures the
+        # snapshot still ships on a failed run, which is exactly when
+        # the data is most useful (artifact-keeper-test#154; rationale
+        # in PR #148 Fresh-Eyes review, Finding 2).
+        if: always()
+        run: |
+          bash tests/stress/collect-pg-stats.sh
+
+      - name: Upload pg-stats snapshot
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: stress-pg-stats-${{ github.run_attempt }}
+          path: /tmp/pg-stats/
+          if-no-files-found: ignore
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Summary

Wires the `tests/stress/collect-pg-stats.sh` capture script (landed in #148) into the `stress-tests` job of `.github/workflows/release-gate.yml`, so every release-gate run produces direct measurement of postgres state alongside `stress-request-logs`.

Background: PR #140 rebalanced postgres CPU limits on the narrative that the previous 5:1 backend:postgres ratio was saturating the sqlx pool. Fresh-Eyes review on PR #148 (Finding 2) flagged this as "narrative not measurement". PR #148 added the capture script but did not wire it into CI. This PR finishes that wire-up.

## Changes

- Added two steps to the `stress-tests` job, after the test run and before teardown:
  - `Collect postgres stats` (`if: always()`) invokes `bash tests/stress/collect-pg-stats.sh`.
  - `Upload pg-stats snapshot` (`if: always()`) uploads `/tmp/pg-stats/` as `stress-pg-stats-${{ github.run_attempt }}` using the same SHA-pinned `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (v7.0.1) the rest of the workflow uses.
- Added `PG_STATS_DIR=/tmp/pg-stats` and `NAMESPACE=${{ needs.deploy.outputs.namespace }}` to the job's `env:` block. These are the two env vars the capture script reads (see header comment in `tests/stress/collect-pg-stats.sh`). The script does not consume a separate run-id variable; the run id is folded into the artifact name via `${{ github.run_attempt }}`.
- No changes to the capture script itself (respects #148), no changes to other jobs in the workflow.

Both new steps use `if: always()` so the snapshot ships even when the stress workload fails, which is exactly when the `pg_stat_activity` / connection-count / `kubectl top` data is most useful for triage.

## Acceptance (per #154)

- [x] Stress-tests run produces a `stress-pg-stats` artifact alongside `stress-request-logs`.
- [x] Artifact will contain `pg_stat_activity` rows + `kubectl top` output (the capture script writes these; the wire-up ensures the directory ships).
- [ ] sqlx `pool_acquire_time` histogram dump - tracked separately as a backend (artifact-keeper) change per the issue body; out of scope for this test-repo PR.

Diff: 1 file changed, 29 insertions(+), 0 deletions(-).

Closes #154

## Test plan

- [ ] Confirm the new steps render in the next release-gate workflow run.
- [ ] Inspect the `stress-pg-stats-<run_attempt>` artifact for `_meta.txt`, `kubectl-top-pods.txt`, `pg_stat_activity.txt`, `pg_connection_count.txt`.
- [ ] Verify the upload step still fires when the `Run stress tests` step exits non-zero (force a failure locally or wait for a real failing run).