### PR TITLE
test(webhooks): HMAC signing + SSRF + dry-run + enable/disable toggle (#75)

### DIFF
--- a/tests/webhooks/test-event-delivery-status-filter.sh
+++ b/tests/webhooks/test-event-delivery-status-filter.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# test-event-delivery-status-filter.sh
+#
+# Issue #75 sub-task 7.14: GET /api/v1/webhooks/{id}/deliveries supports
+# a `status` query parameter (openapi.yaml: parameter `status`, type
+# nullable string). No existing test exercises the filter; the delivery
+# and dead-letter suites read the list without a filter and inspect every
+# row.
+#
+# The .status field is what the operator UI uses to surface "all
+# failures" / "all retries" / "all successes". A regression where the
+# query parameter is silently ignored returns the unfiltered list, the
+# UI shows the wrong rows, and on-call triages the wrong delivery.
+#
+# Strategy:
+#   1. Drive a SUCCESS delivery via /test against a 200-always receiver.
+#   2. Read the unfiltered deliveries list to learn the actual status
+#      vocabulary the backend uses (it varies across builds:
+#      "success" | "succeeded" | "delivered" are all in the wild).
+#   3. Filter by that observed status. The returned set MUST be
+#      non-empty AND every row's .status MUST equal the queried value.
+#   4. Filter by a status vocabulary that does not match any row
+#      ("xfail-${RUN_ID}") -- the returned set MUST be empty. This is
+#      the load-bearing assertion: if the backend ignores the param,
+#      this query returns the full list and the test fails loudly.
+#
+# Requires: curl, jq, python3
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "event-delivery-status-filter"
+
+WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18783}"
+WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
+WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-statusfilter-${RUN_ID}.log}"
+RECEIVER_PID=""
+WEBHOOK_ID=""
+
+cleanup_and_finalize() {
+  local code=$?
+  if [ -n "${WEBHOOK_ID}" ] && [ "${WEBHOOK_ID}" != "null" ]; then
+    api_delete "/api/v1/webhooks/${WEBHOOK_ID}" >/dev/null 2>&1 || true
+  fi
+  if [ -n "${RECEIVER_PID}" ] && kill -0 "${RECEIVER_PID}" 2>/dev/null; then
+    kill "${RECEIVER_PID}" 2>/dev/null || true
+    wait "${RECEIVER_PID}" 2>/dev/null || true
+  fi
+  rm -f "${WEBHOOK_RECEIVER_LOG}"
+  exit "$code"
+}
+trap cleanup_and_finalize EXIT
+
+auth_admin
+
+# -------------------------------------------------------------------------
+# extract_rows JSON
+#
+# The list endpoint returns one of three documented shapes:
+#   - bare array
+#   - { items: [...] }
+#   - { items: [...], total: N }   (DeliveryListResponse)
+# Normalize to a JSON array on stdout so downstream jq queries are
+# consistent. Empty input echoes "[]" so the count assertion sees zero.
+# -------------------------------------------------------------------------
+
+extract_rows() {
+  local json="$1"
+  echo "$json" | jq -c '
+    if type == "array" then .
+    elif .items then .items
+    elif .deliveries then .deliveries
+    else []
+    end
+  ' 2>/dev/null || echo "[]"
+}
+
+# -------------------------------------------------------------------------
+# Pre-flight.
+# -------------------------------------------------------------------------
+
+begin_test "python3 and jq available"
+miss=""
+command -v python3  >/dev/null 2>&1 || miss="${miss} python3"
+command -v jq       >/dev/null 2>&1 || miss="${miss} jq"
+if [ -n "$miss" ]; then
+  skip "missing tools:${miss}"
+  end_suite
+fi
+pass
+
+# -------------------------------------------------------------------------
+# Start receiver. Always-200 so the resulting delivery row lands in
+# whatever the success-state vocabulary is for this build.
+# -------------------------------------------------------------------------
+
+begin_test "Start mock receiver (always-200)"
+WEBHOOK_RECEIVER_PORT="$WEBHOOK_RECEIVER_PORT" \
+  WEBHOOK_FAIL_FIRST_N=0 \
+  WEBHOOK_RECEIVER_LOG="$WEBHOOK_RECEIVER_LOG" \
+  python3 "$(dirname "$0")/../lib/mock-webhook-receiver.py" \
+  >/tmp/mock-webhook-receiver-statusfilter-${RUN_ID}.stderr 2>&1 &
+RECEIVER_PID=$!
+
+ready=false
+for _ in $(seq 1 25); do
+  if curl -sf --max-time 1 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__health" >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 0.2
+done
+if [ "$ready" = true ]; then
+  pass
+else
+  fail "mock receiver did not come up on 127.0.0.1:${WEBHOOK_RECEIVER_PORT}"
+fi
+
+# -------------------------------------------------------------------------
+# Create webhook.
+# -------------------------------------------------------------------------
+
+WEBHOOK_NAME="statusfilter-${RUN_ID}"
+SUITE_BLOCKED=false
+
+begin_test "Create webhook"
+if [ "$ready" != "true" ]; then
+  skip "receiver not running"
+else
+  PAYLOAD=$(jq -n \
+    --arg name "$WEBHOOK_NAME" \
+    --arg url "$WEBHOOK_RECEIVER_URL" \
+    '{name: $name, url: $url, events: ["artifact.uploaded"], enabled: true}')
+  if resp=$(api_post "/api/v1/webhooks" "$PAYLOAD" 2>/dev/null); then
+    WEBHOOK_ID=$(echo "$resp" | jq -r '.id // empty')
+    if [ -z "$WEBHOOK_ID" ] || [ "$WEBHOOK_ID" = "null" ]; then
+      fail "create returned no id"
+    else
+      pass
+    fi
+  else
+    SUITE_BLOCKED=true
+    skip "webhook create rejected (URL likely blocked by SSRF allow-list)"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Drive at least one delivery and wait until it shows up in the list.
+# Use /test because it shares the producer pipeline with real events
+# (proven by test-webhook-dry-run.sh) and is the fastest way to get a
+# deterministic row inserted.
+# -------------------------------------------------------------------------
+
+begin_test "Trigger a delivery via /test"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "no webhook id"
+else
+  if api_post "/api/v1/webhooks/${WEBHOOK_ID}/test" "" >/dev/null 2>&1; then
+    pass
+  else
+    SUITE_BLOCKED=true
+    skip "/test endpoint unavailable"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Wait for the row to land in the list. Poll up to ~30s -- the producer
+# is async, and on cold start the first delivery can be slow to flush.
+# -------------------------------------------------------------------------
+
+UNFILTERED_JSON=""
+UNFILTERED_COUNT=0
+OBSERVED_STATUS=""
+
+begin_test "Unfiltered list contains at least one delivery"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "no webhook id"
+else
+  for _ in $(seq 1 15); do
+    if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}/deliveries" 2>/dev/null); then
+      UNFILTERED_JSON="$resp"
+      rows=$(extract_rows "$resp")
+      UNFILTERED_COUNT=$(echo "$rows" | jq 'length' 2>/dev/null || echo 0)
+      if [ "$UNFILTERED_COUNT" -gt 0 ]; then
+        OBSERVED_STATUS=$(echo "$rows" | jq -r '.[0].status // empty')
+        break
+      fi
+    fi
+    sleep 2
+  done
+  if [ "$UNFILTERED_COUNT" -gt 0 ]; then
+    pass
+  else
+    fail "no delivery row appeared within 30s for webhook ${WEBHOOK_ID}"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Discovered the actual status vocabulary. If the rows have no .status
+# field at all, the filter spec doesn't apply to this build; skip
+# rather than fail (would be a contract mismatch, not a regression).
+# -------------------------------------------------------------------------
+
+begin_test "Delivery rows expose a .status field"
+if [ "$SUITE_BLOCKED" = "true" ] || [ "$UNFILTERED_COUNT" -eq 0 ]; then
+  skip "no rows to inspect"
+elif [ -z "$OBSERVED_STATUS" ] || [ "$OBSERVED_STATUS" = "null" ]; then
+  SUITE_BLOCKED=true
+  skip "rows have no .status field; filter spec inapplicable"
+else
+  pass
+fi
+
+# -------------------------------------------------------------------------
+# Positive filter: status=<observed> returns the row(s) we know exist.
+# Every returned row's .status must equal the queried value. A regression
+# where the filter is silently ignored manifests as
+#   "filter returned rows whose .status != queried value"
+# (because the unfiltered list might contain mixed statuses on a busy
+# cluster, even if our /test produced just one success).
+# -------------------------------------------------------------------------
+
+begin_test "Filter status=${OBSERVED_STATUS:-?} returns only matching rows"
+if [ "$SUITE_BLOCKED" = "true" ]; then
+  skip "no observed status to filter by"
+else
+  # URL-encode the status conservatively. Observed values are alnum +
+  # underscores in every build we've seen; if a build returns something
+  # exotic, jq quoting in the assert below catches it.
+  if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}/deliveries?status=${OBSERVED_STATUS}" 2>/dev/null); then
+    rows=$(extract_rows "$resp")
+    cnt=$(echo "$rows" | jq 'length' 2>/dev/null || echo 0)
+    if [ "$cnt" -lt 1 ]; then
+      fail "filter status=${OBSERVED_STATUS} returned 0 rows, but unfiltered list had ${UNFILTERED_COUNT}"
+    else
+      mismatched=$(echo "$rows" | jq --arg s "$OBSERVED_STATUS" '
+        [.[] | select(.status != $s)] | length
+      ' 2>/dev/null || echo 0)
+      if [ "$mismatched" -eq 0 ]; then
+        pass
+      else
+        fail "filter returned ${mismatched}/${cnt} rows whose .status != '${OBSERVED_STATUS}' (filter likely ignored)" "${rows:0:500}"
+      fi
+    fi
+  else
+    fail "filter request failed"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Negative filter: a status value that cannot exist must return zero
+# rows. This is the assertion that catches "the backend ignores the
+# status param and returns the full list". We embed RUN_ID so two
+# parallel runs of this suite cannot collide on this synthetic value.
+# -------------------------------------------------------------------------
+
+begin_test "Filter status=xfail-${RUN_ID} returns zero rows"
+if [ "$SUITE_BLOCKED" = "true" ]; then
+  skip "no observed status to compare against"
+else
+  bogus="xfail-${RUN_ID}"
+  if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}/deliveries?status=${bogus}" 2>/dev/null); then
+    rows=$(extract_rows "$resp")
+    cnt=$(echo "$rows" | jq 'length' 2>/dev/null || echo 0)
+    if [ "$cnt" -eq 0 ]; then
+      pass
+    else
+      fail "filter status=${bogus} returned ${cnt} rows; expected 0 (filter likely ignored, returning unfiltered list of ${UNFILTERED_COUNT})" "${rows:0:500}"
+    fi
+  else
+    # Some implementations reject an unknown status with 4xx -- that is
+    # also acceptable behavior (strict enum). Accept the rejection.
+    pass
+  fi
+fi
+
+end_suite

--- a/tests/webhooks/test-event-delivery-status-filter.sh
+++ b/tests/webhooks/test-event-delivery-status-filter.sh
@@ -2,27 +2,34 @@
 # test-event-delivery-status-filter.sh
 #
 # Issue #75 sub-task 7.14: GET /api/v1/webhooks/{id}/deliveries supports
-# a `status` query parameter (openapi.yaml: parameter `status`, type
-# nullable string). No existing test exercises the filter; the delivery
-# and dead-letter suites read the list without a filter and inspect every
-# row.
+# a `status` query parameter (backend webhooks.rs:488-493). The handler
+# at webhooks.rs:541 normalizes the parameter to a boolean filter on the
+# DeliveryResponse.success column:
 #
-# The .status field is what the operator UI uses to surface "all
-# failures" / "all retries" / "all successes". A regression where the
-# query parameter is silently ignored returns the unfiltered list, the
-# UI shows the wrong rows, and on-call triages the wrong delivery.
+#     let success_filter = query.status.as_ref().map(|s| s == "success");
+#
+# So:
+#   status=success  -> WHERE success = TRUE
+#   status=anything -> WHERE success = FALSE
+#   status omitted  -> no filter
+#
+# DeliveryResponse exposes the verdict as a boolean .success field
+# (openapi.yaml:12703-12745, webhooks.rs:495-508). There is no string
+# .status field on the response row; an earlier draft of this test read
+# .status and would have produced "" for every row regardless of the
+# actual delivery verdict.
 #
 # Strategy:
 #   1. Drive a SUCCESS delivery via /test against a 200-always receiver.
-#   2. Read the unfiltered deliveries list to learn the actual status
-#      vocabulary the backend uses (it varies across builds:
-#      "success" | "succeeded" | "delivered" are all in the wild).
-#   3. Filter by that observed status. The returned set MUST be
-#      non-empty AND every row's .status MUST equal the queried value.
-#   4. Filter by a status vocabulary that does not match any row
-#      ("xfail-${RUN_ID}") -- the returned set MUST be empty. This is
-#      the load-bearing assertion: if the backend ignores the param,
-#      this query returns the full list and the test fails loudly.
+#   2. Read the unfiltered deliveries list. At least one row's .success
+#      must be true.
+#   3. Filter status=success. The returned set MUST be non-empty AND
+#      every row's .success MUST be true.
+#   4. Filter status=failure. Our /test row (success=true) MUST NOT be
+#      in the filtered set, and every returned row's .success MUST be
+#      false. This is the load-bearing assertion: if the backend
+#      ignores the param, this query returns the full list including
+#      our success row and the test fails loudly.
 #
 # Requires: curl, jq, python3
 
@@ -30,7 +37,11 @@ source "$(dirname "$0")/../lib/common.sh"
 
 begin_suite "event-delivery-status-filter"
 
-WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18783}"
+# Receiver port: derive from PID so parallel test runs do not collide on
+# the same listen socket. The base 18000 + ($$ % 1000) keeps us away
+# from common reserved ports and inside an unprivileged range. Callers
+# can still override with WEBHOOK_RECEIVER_PORT.
+WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-$(( 18000 + $$ % 1000 ))}"
 WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
 WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-statusfilter-${RUN_ID}.log}"
 RECEIVER_PID=""
@@ -129,7 +140,7 @@ else
   PAYLOAD=$(jq -n \
     --arg name "$WEBHOOK_NAME" \
     --arg url "$WEBHOOK_RECEIVER_URL" \
-    '{name: $name, url: $url, events: ["artifact.uploaded"], enabled: true}')
+    '{name: $name, url: $url, events: ["artifact_uploaded"]}')
   if resp=$(api_post "/api/v1/webhooks" "$PAYLOAD" 2>/dev/null); then
     WEBHOOK_ID=$(echo "$resp" | jq -r '.id // empty')
     if [ -z "$WEBHOOK_ID" ] || [ "$WEBHOOK_ID" = "null" ]; then
@@ -167,78 +178,63 @@ fi
 # is async, and on cold start the first delivery can be slow to flush.
 # -------------------------------------------------------------------------
 
-UNFILTERED_JSON=""
 UNFILTERED_COUNT=0
-OBSERVED_STATUS=""
+SUCCESS_ROW_COUNT=0
 
-begin_test "Unfiltered list contains at least one delivery"
+begin_test "Unfiltered list contains at least one success row"
 if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
   skip "no webhook id"
 else
   for _ in $(seq 1 15); do
     if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}/deliveries" 2>/dev/null); then
-      UNFILTERED_JSON="$resp"
       rows=$(extract_rows "$resp")
       UNFILTERED_COUNT=$(echo "$rows" | jq 'length' 2>/dev/null || echo 0)
-      if [ "$UNFILTERED_COUNT" -gt 0 ]; then
-        OBSERVED_STATUS=$(echo "$rows" | jq -r '.[0].status // empty')
+      SUCCESS_ROW_COUNT=$(echo "$rows" | jq '[.[] | select(.success == true)] | length' 2>/dev/null || echo 0)
+      if [ "$SUCCESS_ROW_COUNT" -gt 0 ]; then
         break
       fi
     fi
     sleep 2
   done
-  if [ "$UNFILTERED_COUNT" -gt 0 ]; then
+  if [ "$SUCCESS_ROW_COUNT" -gt 0 ]; then
     pass
+  elif [ "$UNFILTERED_COUNT" -gt 0 ]; then
+    # Rows landed but none of them succeeded. /test against our local
+    # always-200 receiver should produce success=true; if it did not,
+    # the suite's premise is broken and downstream assertions cannot
+    # tell "filter ignored" from "no success rows to filter for".
+    SUITE_BLOCKED=true
+    skip "delivery rows exist but none have .success=true; cannot exercise success-vs-failure filter"
   else
     fail "no delivery row appeared within 30s for webhook ${WEBHOOK_ID}"
   fi
 fi
 
 # -------------------------------------------------------------------------
-# Discovered the actual status vocabulary. If the rows have no .status
-# field at all, the filter spec doesn't apply to this build; skip
-# rather than fail (would be a contract mismatch, not a regression).
+# Positive filter: status=success returns rows whose .success == true.
+# Per handler logic at webhooks.rs:541, status=success maps to a
+# WHERE success = TRUE filter. The returned set MUST be non-empty
+# (we just drove a success delivery) AND every returned row MUST have
+# .success == true. A regression where the filter is silently dropped
+# would surface as "the filtered set still contains success=false rows"
+# on any cluster with prior failed deliveries.
 # -------------------------------------------------------------------------
 
-begin_test "Delivery rows expose a .status field"
-if [ "$SUITE_BLOCKED" = "true" ] || [ "$UNFILTERED_COUNT" -eq 0 ]; then
-  skip "no rows to inspect"
-elif [ -z "$OBSERVED_STATUS" ] || [ "$OBSERVED_STATUS" = "null" ]; then
-  SUITE_BLOCKED=true
-  skip "rows have no .status field; filter spec inapplicable"
-else
-  pass
-fi
-
-# -------------------------------------------------------------------------
-# Positive filter: status=<observed> returns the row(s) we know exist.
-# Every returned row's .status must equal the queried value. A regression
-# where the filter is silently ignored manifests as
-#   "filter returned rows whose .status != queried value"
-# (because the unfiltered list might contain mixed statuses on a busy
-# cluster, even if our /test produced just one success).
-# -------------------------------------------------------------------------
-
-begin_test "Filter status=${OBSERVED_STATUS:-?} returns only matching rows"
+begin_test "Filter status=success returns only success=true rows"
 if [ "$SUITE_BLOCKED" = "true" ]; then
-  skip "no observed status to filter by"
+  skip "no success row to filter for"
 else
-  # URL-encode the status conservatively. Observed values are alnum +
-  # underscores in every build we've seen; if a build returns something
-  # exotic, jq quoting in the assert below catches it.
-  if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}/deliveries?status=${OBSERVED_STATUS}" 2>/dev/null); then
+  if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}/deliveries?status=success" 2>/dev/null); then
     rows=$(extract_rows "$resp")
     cnt=$(echo "$rows" | jq 'length' 2>/dev/null || echo 0)
     if [ "$cnt" -lt 1 ]; then
-      fail "filter status=${OBSERVED_STATUS} returned 0 rows, but unfiltered list had ${UNFILTERED_COUNT}"
+      fail "filter status=success returned 0 rows, but unfiltered list had ${SUCCESS_ROW_COUNT} success row(s)"
     else
-      mismatched=$(echo "$rows" | jq --arg s "$OBSERVED_STATUS" '
-        [.[] | select(.status != $s)] | length
-      ' 2>/dev/null || echo 0)
+      mismatched=$(echo "$rows" | jq '[.[] | select(.success != true)] | length' 2>/dev/null || echo 0)
       if [ "$mismatched" -eq 0 ]; then
         pass
       else
-        fail "filter returned ${mismatched}/${cnt} rows whose .status != '${OBSERVED_STATUS}' (filter likely ignored)" "${rows:0:500}"
+        fail "filter status=success returned ${mismatched}/${cnt} rows whose .success != true (filter likely ignored)" "${rows:0:500}"
       fi
     fi
   else
@@ -247,28 +243,32 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# Negative filter: a status value that cannot exist must return zero
-# rows. This is the assertion that catches "the backend ignores the
-# status param and returns the full list". We embed RUN_ID so two
-# parallel runs of this suite cannot collide on this synthetic value.
+# Negative filter: status=failure must NOT return the success row we
+# just produced, and any rows it does return must have .success == false.
+# This is the assertion that catches "the backend ignores the status
+# param and returns the full list" -- if it did, the success row we
+# drove above would appear here.
+#
+# Per handler: status=anything-except-success maps to WHERE success=FALSE,
+# so "failure" is the documented spelling of the negative filter.
 # -------------------------------------------------------------------------
 
-begin_test "Filter status=xfail-${RUN_ID} returns zero rows"
+begin_test "Filter status=failure excludes success=true rows"
 if [ "$SUITE_BLOCKED" = "true" ]; then
-  skip "no observed status to compare against"
+  skip "no success row to compare against"
 else
-  bogus="xfail-${RUN_ID}"
-  if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}/deliveries?status=${bogus}" 2>/dev/null); then
+  if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}/deliveries?status=failure" 2>/dev/null); then
     rows=$(extract_rows "$resp")
     cnt=$(echo "$rows" | jq 'length' 2>/dev/null || echo 0)
-    if [ "$cnt" -eq 0 ]; then
+    success_leaked=$(echo "$rows" | jq '[.[] | select(.success == true)] | length' 2>/dev/null || echo 0)
+    if [ "$success_leaked" -eq 0 ]; then
       pass
     else
-      fail "filter status=${bogus} returned ${cnt} rows; expected 0 (filter likely ignored, returning unfiltered list of ${UNFILTERED_COUNT})" "${rows:0:500}"
+      fail "filter status=failure returned ${success_leaked}/${cnt} rows with .success=true; expected zero (filter likely ignored, returning unfiltered list)" "${rows:0:500}"
     fi
   else
-    # Some implementations reject an unknown status with 4xx -- that is
-    # also acceptable behavior (strict enum). Accept the rejection.
+    # Some implementations reject an unknown status with 4xx -- the
+    # handler today does not, but tolerate the stricter behavior.
     pass
   fi
 fi

--- a/tests/webhooks/test-webhook-dry-run.sh
+++ b/tests/webhooks/test-webhook-dry-run.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# test-webhook-dry-run.sh
+#
+# Issue #75 sub-task 7.12: POST /api/v1/webhooks/{id}/test (a.k.a. the
+# "dry-run" endpoint). The endpoint is referenced by test-webhook-crud.sh
+# in a degenerate form (does it return a 2xx?) and used as a delivery
+# trigger by the HMAC and rotation tests, but no existing suite asserts
+# the actual TestWebhookResponse contract or the round-trip semantics of
+# the call.
+#
+# Contract under test (from openapi.yaml):
+#   POST /api/v1/webhooks/{id}/test -> 200 TestWebhookResponse
+#
+#   The response carries the result of a synthetic delivery: the receiver
+#   was POSTed, the round-trip succeeded or failed, and the caller can
+#   distinguish "you configured a bad URL" from "the receiver is down".
+#
+# Assertions in this suite:
+#   1. /test returns a 2xx for a real, reachable webhook.
+#   2. The receiver actually got a POST -- the endpoint is not a no-op.
+#   3. The body that arrived at the receiver is JSON with an event field
+#      (the same shape a real delivery uses, so receivers can be tested
+#      with the same code path).
+#   4. /test on a deleted/unknown id returns 404 (negative path -- this
+#      catches the regression where /test silently succeeds against any
+#      string, which is a tenant-isolation bug).
+#
+# Requires: curl, jq, python3
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "webhook-dry-run"
+
+WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18782}"
+WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
+WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-dryrun-${RUN_ID}.log}"
+RECEIVER_PID=""
+WEBHOOK_ID=""
+
+cleanup_and_finalize() {
+  local code=$?
+  if [ -n "${WEBHOOK_ID}" ] && [ "${WEBHOOK_ID}" != "null" ]; then
+    api_delete "/api/v1/webhooks/${WEBHOOK_ID}" >/dev/null 2>&1 || true
+  fi
+  if [ -n "${RECEIVER_PID}" ] && kill -0 "${RECEIVER_PID}" 2>/dev/null; then
+    kill "${RECEIVER_PID}" 2>/dev/null || true
+    wait "${RECEIVER_PID}" 2>/dev/null || true
+  fi
+  rm -f "${WEBHOOK_RECEIVER_LOG}"
+  exit "$code"
+}
+trap cleanup_and_finalize EXIT
+
+auth_admin
+
+# -------------------------------------------------------------------------
+# Pre-flight.
+# -------------------------------------------------------------------------
+
+begin_test "python3 and jq available"
+miss=""
+command -v python3  >/dev/null 2>&1 || miss="${miss} python3"
+command -v jq       >/dev/null 2>&1 || miss="${miss} jq"
+if [ -n "$miss" ]; then
+  skip "missing tools:${miss}"
+  end_suite
+fi
+pass
+
+# -------------------------------------------------------------------------
+# Start receiver.
+# -------------------------------------------------------------------------
+
+begin_test "Start mock receiver"
+WEBHOOK_RECEIVER_PORT="$WEBHOOK_RECEIVER_PORT" \
+  WEBHOOK_FAIL_FIRST_N=0 \
+  WEBHOOK_RECEIVER_LOG="$WEBHOOK_RECEIVER_LOG" \
+  python3 "$(dirname "$0")/../lib/mock-webhook-receiver.py" \
+  >/tmp/mock-webhook-receiver-dryrun-${RUN_ID}.stderr 2>&1 &
+RECEIVER_PID=$!
+
+ready=false
+for _ in $(seq 1 25); do
+  if curl -sf --max-time 1 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__health" >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 0.2
+done
+if [ "$ready" = true ]; then
+  pass
+else
+  fail "mock receiver did not come up on 127.0.0.1:${WEBHOOK_RECEIVER_PORT}"
+fi
+
+# -------------------------------------------------------------------------
+# Create webhook.
+# -------------------------------------------------------------------------
+
+WEBHOOK_NAME="dryrun-${RUN_ID}"
+SUITE_BLOCKED=false
+
+begin_test "Create webhook"
+if [ "$ready" != "true" ]; then
+  skip "receiver not running"
+else
+  PAYLOAD=$(jq -n \
+    --arg name "$WEBHOOK_NAME" \
+    --arg url "$WEBHOOK_RECEIVER_URL" \
+    '{name: $name, url: $url, events: ["artifact.uploaded"], enabled: true}')
+  if resp=$(api_post "/api/v1/webhooks" "$PAYLOAD" 2>/dev/null); then
+    WEBHOOK_ID=$(echo "$resp" | jq -r '.id // empty')
+    if [ -z "$WEBHOOK_ID" ] || [ "$WEBHOOK_ID" = "null" ]; then
+      fail "create returned no id"
+    else
+      pass
+    fi
+  else
+    SUITE_BLOCKED=true
+    skip "webhook create rejected (URL '${WEBHOOK_RECEIVER_URL}' likely blocked by SSRF allow-list)"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Call /test, capture the response body, capture the HTTP status code.
+# Use curl directly (not api_post) so we can read both the body and the
+# status without an extra round-trip.
+# -------------------------------------------------------------------------
+
+TEST_RESP_BODY=""
+TEST_RESP_STATUS=""
+
+begin_test "POST /test returns 2xx with a response body"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "no webhook id"
+else
+  curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__reset" >/dev/null 2>&1 || true
+  tmp=$(mktemp)
+  TEST_RESP_STATUS=$(curl -s -o "$tmp" -w '%{http_code}' \
+    --max-time 15 \
+    -H "$(auth_header)" \
+    -X POST \
+    "${BASE_URL}/api/v1/webhooks/${WEBHOOK_ID}/test" 2>/dev/null) || TEST_RESP_STATUS="000"
+  TEST_RESP_BODY=$(cat "$tmp" 2>/dev/null || true)
+  rm -f "$tmp"
+
+  case "$TEST_RESP_STATUS" in
+    2??)
+      if [ -z "$TEST_RESP_BODY" ]; then
+        fail "/test returned ${TEST_RESP_STATUS} with empty body (expected TestWebhookResponse JSON)"
+      else
+        pass
+      fi
+      ;;
+    501)
+      SUITE_BLOCKED=true
+      skip "/test endpoint not implemented (HTTP 501)"
+      ;;
+    *)
+      fail "expected 2xx from /test, got HTTP ${TEST_RESP_STATUS}" "${TEST_RESP_BODY:0:400}"
+      ;;
+  esac
+fi
+
+# -------------------------------------------------------------------------
+# Receiver actually got a POST. This is the load-bearing assertion for
+# the dry-run endpoint: a /test that returns 200 without firing a real
+# delivery is a silent-success bug (the operator clicks "Test", sees
+# green, and trusts a configuration that has never actually delivered).
+# -------------------------------------------------------------------------
+
+LATEST_BODY=""
+LATEST_HEADERS=""
+
+begin_test "Receiver got a POST from the /test call"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "no webhook id or /test unavailable"
+else
+  seen=0
+  for _ in $(seq 1 20); do
+    seen=$(curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__count" 2>/dev/null || echo 0)
+    [ "$seen" -gt 0 ] && break
+    sleep 0.5
+  done
+  if [ "$seen" -ge 1 ] && [ -s "$WEBHOOK_RECEIVER_LOG" ]; then
+    LATEST=$(tail -n 1 "$WEBHOOK_RECEIVER_LOG")
+    LATEST_BODY=$(echo "$LATEST" | jq -r '.body')
+    LATEST_HEADERS=$(echo "$LATEST" | jq -r '.headers')
+    pass
+  else
+    fail "/test returned ${TEST_RESP_STATUS} but no POST landed at the receiver. This is a silent-success regression: operators clicking 'Test' would see green for a webhook that never fires."
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# The body the receiver got is the same shape a real delivery uses.
+# This matters because customers wire test deliveries into their CI to
+# validate receiver code: if /test sends a different envelope than the
+# real producer, the test passes and real deliveries fail.
+# -------------------------------------------------------------------------
+
+begin_test "Delivered body is JSON with an event field"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$LATEST_BODY" ]; then
+  skip "no receiver body to inspect"
+else
+  evt=$(echo "$LATEST_BODY" | jq -r '.event // empty' 2>/dev/null) || evt=""
+  if [ -n "$evt" ]; then
+    pass
+  else
+    fail "delivered body has no .event field" "${LATEST_BODY:0:300}"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# The delivery carries the standard wire-contract headers. We only
+# check presence here (the dedicated HMAC suite owns shape/value); the
+# point of this assertion is that /test goes through the same delivery
+# pipeline as a real event, not a special-cased shortcut.
+# -------------------------------------------------------------------------
+
+begin_test "Delivery carries X-ArtifactKeeper-Delivery header"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$LATEST_HEADERS" ]; then
+  skip "no receiver headers to inspect"
+else
+  delivery=$(echo "$LATEST_HEADERS" | jq -r '
+    (.["X-ArtifactKeeper-Delivery"] //
+     .["x-artifactkeeper-delivery"] //
+     .["X-ARTIFACTKEEPER-DELIVERY"] // empty)
+  ')
+  if [ -n "$delivery" ] && [ "$delivery" != "null" ]; then
+    pass
+  else
+    fail "X-ArtifactKeeper-Delivery missing from /test delivery (suggests /test bypasses the standard delivery pipeline)"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Negative path: /test against a webhook id that does not exist must
+# return 404. The unhappy spelling here is the regression where /test
+# returns 200 for any string and just no-ops -- the symptom of a route
+# that doesn't load the webhook before dispatching.
+#
+# Use a clearly-fabricated UUID so we don't accidentally collide with a
+# real row.
+# -------------------------------------------------------------------------
+
+begin_test "POST /test on unknown id returns 404"
+fake_id="00000000-0000-0000-0000-000000000000"
+status=$(curl -s -o /dev/null -w '%{http_code}' \
+  --max-time 10 \
+  -H "$(auth_header)" \
+  -X POST \
+  "${BASE_URL}/api/v1/webhooks/${fake_id}/test" 2>/dev/null) || status="000"
+
+case "$status" in
+  404)
+    pass
+    ;;
+  4??)
+    # Some implementations return 400 for malformed-id and 404 for
+    # not-found; both are acceptable for an obviously-synthetic id, but
+    # we tighten the assertion: must NOT be a success.
+    pass
+    ;;
+  501)
+    skip "/test endpoint not implemented (HTTP 501)"
+    ;;
+  2??)
+    fail "SECURITY/UX: POST /test against unknown id '${fake_id}' returned HTTP ${status}. A no-op success here masks misconfigured webhook ids."
+    ;;
+  000)
+    fail "network failure contacting ${BASE_URL} for unknown-id /test"
+    ;;
+  *)
+    fail "unexpected HTTP ${status} for /test on unknown id (expected 404)"
+    ;;
+esac
+
+end_suite

--- a/tests/webhooks/test-webhook-dry-run.sh
+++ b/tests/webhooks/test-webhook-dry-run.sh
@@ -31,7 +31,10 @@ source "$(dirname "$0")/../lib/common.sh"
 
 begin_suite "webhook-dry-run"
 
-WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18782}"
+# Receiver port: derive from PID so parallel test runs do not collide
+# on the same listen socket. Callers can still override with
+# WEBHOOK_RECEIVER_PORT.
+WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-$(( 18000 + $$ % 1000 ))}"
 WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
 WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-dryrun-${RUN_ID}.log}"
 RECEIVER_PID=""
@@ -104,10 +107,14 @@ begin_test "Create webhook"
 if [ "$ready" != "true" ]; then
   skip "receiver not running"
 else
+  # CreateWebhookRequest does not accept an enabled/is_enabled field
+  # (backend webhooks.rs:86-95); new webhooks default to enabled. Event
+  # names are the snake_case Display form of WebhookEvent (webhooks.rs:
+  # 50-74), e.g. "artifact_uploaded".
   PAYLOAD=$(jq -n \
     --arg name "$WEBHOOK_NAME" \
     --arg url "$WEBHOOK_RECEIVER_URL" \
-    '{name: $name, url: $url, events: ["artifact.uploaded"], enabled: true}')
+    '{name: $name, url: $url, events: ["artifact_uploaded"]}')
   if resp=$(api_post "/api/v1/webhooks" "$PAYLOAD" 2>/dev/null); then
     WEBHOOK_ID=$(echo "$resp" | jq -r '.id // empty')
     if [ -z "$WEBHOOK_ID" ] || [ "$WEBHOOK_ID" = "null" ]; then

--- a/tests/webhooks/test-webhook-enable-disable-toggle.sh
+++ b/tests/webhooks/test-webhook-enable-disable-toggle.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# test-webhook-enable-disable-toggle.sh
+#
+# Issue #75 sub-task 7.13: POST /api/v1/webhooks/{id}/enable and
+# /api/v1/webhooks/{id}/disable. test-webhook-crud.sh calls PUT
+# {"enabled":false} but never asserts the state actually flipped, and
+# never exercises the dedicated /enable + /disable verbs at all.
+#
+# The .enabled flag is the operator's circuit-breaker. If a receiver is
+# dropping deliveries on the floor and we need to pause fan-out, /disable
+# is what we POST. The behavior under test:
+#
+#   1. New webhook is enabled by default.
+#   2. POST /disable flips the flag; GET reflects enabled=false.
+#   3. POST /enable flips it back; GET reflects enabled=true.
+#   4. /disable and /enable are idempotent: calling them on a webhook
+#      already in the target state must still return 2xx (no 409
+#      conflicts -- the operator's tooling will retry, and a retry on
+#      an idempotent verb must not error).
+#   5. /enable on an unknown id returns 404 (parallels the dry-run
+#      negative path; same regression class).
+#
+# Requires: curl, jq, python3 (only for receiver -- optional path below)
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "webhook-enable-disable-toggle"
+
+WEBHOOK_ID=""
+
+cleanup_and_finalize() {
+  local code=$?
+  if [ -n "${WEBHOOK_ID}" ] && [ "${WEBHOOK_ID}" != "null" ]; then
+    api_delete "/api/v1/webhooks/${WEBHOOK_ID}" >/dev/null 2>&1 || true
+  fi
+  exit "$code"
+}
+trap cleanup_and_finalize EXIT
+
+auth_admin
+
+# -------------------------------------------------------------------------
+# Pre-flight.
+# -------------------------------------------------------------------------
+
+begin_test "jq available"
+if ! command -v jq >/dev/null 2>&1; then
+  skip "jq not available"
+  end_suite
+fi
+pass
+
+# -------------------------------------------------------------------------
+# Helpers: POST a verb and read the .enabled flag back.
+# -------------------------------------------------------------------------
+
+# post_verb <verb>   ->   echoes HTTP status
+post_verb() {
+  local verb="$1"
+  curl -s -o /dev/null -w '%{http_code}' \
+    --max-time 10 \
+    -H "$(auth_header)" \
+    -X POST \
+    "${BASE_URL}/api/v1/webhooks/${WEBHOOK_ID}/${verb}" 2>/dev/null || echo "000"
+}
+
+# read_enabled   ->   echoes "true" | "false" | ""
+read_enabled() {
+  if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}" 2>/dev/null); then
+    echo "$resp" | jq -r '.enabled // empty' 2>/dev/null || echo ""
+  else
+    echo ""
+  fi
+}
+
+# -------------------------------------------------------------------------
+# Create a webhook. Use a URL that the SSRF allow-list will accept --
+# httpbin.org is the convention used by test-webhook-crud.sh. We do not
+# actually fire any deliveries in this suite, so the URL only needs to
+# pass the create-time validator.
+# -------------------------------------------------------------------------
+
+WEBHOOK_NAME="toggle-${RUN_ID}"
+SUITE_BLOCKED=false
+
+begin_test "Create webhook (enabled by default)"
+PAYLOAD=$(jq -n \
+  --arg name "$WEBHOOK_NAME" \
+  --arg url "https://httpbin.org/post" \
+  '{name: $name, url: $url, events: ["artifact.uploaded"], enabled: true}')
+if resp=$(api_post "/api/v1/webhooks" "$PAYLOAD" 2>/dev/null); then
+  WEBHOOK_ID=$(echo "$resp" | jq -r '.id // empty')
+  initial=$(echo "$resp" | jq -r '.enabled // empty')
+  if [ -z "$WEBHOOK_ID" ] || [ "$WEBHOOK_ID" = "null" ]; then
+    fail "create returned no id"
+  elif [ "$initial" != "true" ]; then
+    fail "webhook created with enabled='${initial}', expected 'true'"
+  else
+    pass
+  fi
+else
+  SUITE_BLOCKED=true
+  skip "webhook create rejected (URL likely blocked or endpoint unavailable)"
+fi
+
+# -------------------------------------------------------------------------
+# /disable flips enabled to false.
+# -------------------------------------------------------------------------
+
+begin_test "POST /disable returns 2xx"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "no webhook id"
+else
+  status=$(post_verb "disable")
+  case "$status" in
+    2??) pass ;;
+    501) SUITE_BLOCKED=true; skip "/disable endpoint not implemented" ;;
+    *)   fail "expected 2xx from /disable, got HTTP ${status}" ;;
+  esac
+fi
+
+begin_test "GET shows enabled=false after /disable"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "/disable unavailable"
+else
+  state=$(read_enabled)
+  if [ "$state" = "false" ]; then
+    pass
+  else
+    fail "expected enabled=false after /disable, got '${state}'"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# /disable is idempotent. Calling it twice in a row must still return
+# 2xx, not 409 -- operator tooling will retry on a network hiccup and a
+# 409 would push the operator toward the bad workaround of "GET first,
+# branch on state".
+# -------------------------------------------------------------------------
+
+begin_test "POST /disable is idempotent (second call also 2xx)"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "/disable unavailable"
+else
+  status=$(post_verb "disable")
+  case "$status" in
+    2??) pass ;;
+    *)   fail "second /disable returned HTTP ${status} (expected 2xx, /disable must be idempotent)" ;;
+  esac
+fi
+
+# -------------------------------------------------------------------------
+# /enable flips it back.
+# -------------------------------------------------------------------------
+
+begin_test "POST /enable returns 2xx"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "no webhook id"
+else
+  status=$(post_verb "enable")
+  case "$status" in
+    2??) pass ;;
+    501) SUITE_BLOCKED=true; skip "/enable endpoint not implemented" ;;
+    *)   fail "expected 2xx from /enable, got HTTP ${status}" ;;
+  esac
+fi
+
+begin_test "GET shows enabled=true after /enable"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "/enable unavailable"
+else
+  state=$(read_enabled)
+  if [ "$state" = "true" ]; then
+    pass
+  else
+    fail "expected enabled=true after /enable, got '${state}'"
+  fi
+fi
+
+begin_test "POST /enable is idempotent (second call also 2xx)"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "/enable unavailable"
+else
+  status=$(post_verb "enable")
+  case "$status" in
+    2??) pass ;;
+    *)   fail "second /enable returned HTTP ${status} (expected 2xx, /enable must be idempotent)" ;;
+  esac
+fi
+
+# -------------------------------------------------------------------------
+# Final consistency check: round-trip enable -> disable -> enable lands
+# the webhook back in the enabled state. Cheap belt-and-braces against
+# a regression where /enable and /disable both report 2xx but only one
+# of them actually mutates state.
+# -------------------------------------------------------------------------
+
+begin_test "Round-trip toggle leaves the webhook enabled"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "toggle endpoints unavailable"
+else
+  post_verb "disable" >/dev/null
+  post_verb "enable"  >/dev/null
+  state=$(read_enabled)
+  if [ "$state" = "true" ]; then
+    pass
+  else
+    fail "after disable->enable round-trip, .enabled='${state}' (expected 'true')"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Negative path: /enable on a fabricated id is 404. Symmetric to the
+# /test negative case in test-webhook-dry-run.sh.
+# -------------------------------------------------------------------------
+
+begin_test "POST /enable on unknown id returns 404"
+if [ "$SUITE_BLOCKED" = "true" ]; then
+  skip "toggle endpoints unavailable"
+else
+  fake_id="00000000-0000-0000-0000-000000000000"
+  status=$(curl -s -o /dev/null -w '%{http_code}' \
+    --max-time 10 \
+    -H "$(auth_header)" \
+    -X POST \
+    "${BASE_URL}/api/v1/webhooks/${fake_id}/enable" 2>/dev/null) || status="000"
+  case "$status" in
+    404) pass ;;
+    4??) pass ;;  # 400 for malformed is fine; the assertion is "not 2xx"
+    2??) fail "POST /enable against unknown id '${fake_id}' returned HTTP ${status} (expected 404)" ;;
+    501) skip "/enable not implemented" ;;
+    *)   fail "unexpected HTTP ${status} for /enable on unknown id" ;;
+  esac
+fi
+
+end_suite

--- a/tests/webhooks/test-webhook-enable-disable-toggle.sh
+++ b/tests/webhooks/test-webhook-enable-disable-toggle.sh
@@ -3,16 +3,22 @@
 #
 # Issue #75 sub-task 7.13: POST /api/v1/webhooks/{id}/enable and
 # /api/v1/webhooks/{id}/disable. test-webhook-crud.sh calls PUT
-# {"enabled":false} but never asserts the state actually flipped, and
+# {"is_enabled":false} but never asserts the state actually flipped, and
 # never exercises the dedicated /enable + /disable verbs at all.
 #
-# The .enabled flag is the operator's circuit-breaker. If a receiver is
-# dropping deliveries on the floor and we need to pause fan-out, /disable
-# is what we POST. The behavior under test:
+# Schema note: WebhookResponse.is_enabled is the documented field
+# (openapi.yaml:18591, backend webhooks.rs:103). CreateWebhookRequest
+# does not accept an is_enabled/enabled field -- new webhooks are
+# enabled by default at the DB layer -- so the create body in this
+# suite intentionally omits it.
 #
-#   1. New webhook is enabled by default.
-#   2. POST /disable flips the flag; GET reflects enabled=false.
-#   3. POST /enable flips it back; GET reflects enabled=true.
+# The is_enabled flag is the operator's circuit-breaker. If a receiver
+# is dropping deliveries on the floor and we need to pause fan-out,
+# /disable is what we POST. The behavior under test:
+#
+#   1. New webhook is enabled by default (is_enabled=true).
+#   2. POST /disable flips the flag; GET reflects is_enabled=false.
+#   3. POST /enable flips it back; GET reflects is_enabled=true.
 #   4. /disable and /enable are idempotent: calling them on a webhook
 #      already in the target state must still return 2xx (no 409
 #      conflicts -- the operator's tooling will retry, and a retry on
@@ -51,7 +57,11 @@ fi
 pass
 
 # -------------------------------------------------------------------------
-# Helpers: POST a verb and read the .enabled flag back.
+# Helpers: POST a verb and read the .is_enabled flag back. The field is
+# .is_enabled per openapi.yaml:18591 and backend webhooks.rs:103. An
+# earlier draft read .enabled, which is silently absent on every
+# response and would have caused the assertions below to compare ""
+# against "true"/"false" forever.
 # -------------------------------------------------------------------------
 
 # post_verb <verb>   ->   echoes HTTP status
@@ -67,7 +77,7 @@ post_verb() {
 # read_enabled   ->   echoes "true" | "false" | ""
 read_enabled() {
   if resp=$(api_get "/api/v1/webhooks/${WEBHOOK_ID}" 2>/dev/null); then
-    echo "$resp" | jq -r '.enabled // empty' 2>/dev/null || echo ""
+    echo "$resp" | jq -r '.is_enabled // empty' 2>/dev/null || echo ""
   else
     echo ""
   fi
@@ -84,17 +94,20 @@ WEBHOOK_NAME="toggle-${RUN_ID}"
 SUITE_BLOCKED=false
 
 begin_test "Create webhook (enabled by default)"
+# CreateWebhookRequest does not accept an enabled/is_enabled field
+# (backend webhooks.rs:86-95). New webhooks default to enabled at the
+# DB layer, which is the property this case asserts.
 PAYLOAD=$(jq -n \
   --arg name "$WEBHOOK_NAME" \
   --arg url "https://httpbin.org/post" \
-  '{name: $name, url: $url, events: ["artifact.uploaded"], enabled: true}')
+  '{name: $name, url: $url, events: ["artifact_uploaded"]}')
 if resp=$(api_post "/api/v1/webhooks" "$PAYLOAD" 2>/dev/null); then
   WEBHOOK_ID=$(echo "$resp" | jq -r '.id // empty')
-  initial=$(echo "$resp" | jq -r '.enabled // empty')
+  initial=$(echo "$resp" | jq -r '.is_enabled // empty')
   if [ -z "$WEBHOOK_ID" ] || [ "$WEBHOOK_ID" = "null" ]; then
     fail "create returned no id"
   elif [ "$initial" != "true" ]; then
-    fail "webhook created with enabled='${initial}', expected 'true'"
+    fail "webhook created with is_enabled='${initial}', expected 'true'"
   else
     pass
   fi
@@ -119,7 +132,7 @@ else
   esac
 fi
 
-begin_test "GET shows enabled=false after /disable"
+begin_test "GET shows is_enabled=false after /disable"
 if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
   skip "/disable unavailable"
 else
@@ -127,7 +140,7 @@ else
   if [ "$state" = "false" ]; then
     pass
   else
-    fail "expected enabled=false after /disable, got '${state}'"
+    fail "expected is_enabled=false after /disable, got '${state}'"
   fi
 fi
 
@@ -165,7 +178,7 @@ else
   esac
 fi
 
-begin_test "GET shows enabled=true after /enable"
+begin_test "GET shows is_enabled=true after /enable"
 if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
   skip "/enable unavailable"
 else
@@ -173,7 +186,7 @@ else
   if [ "$state" = "true" ]; then
     pass
   else
-    fail "expected enabled=true after /enable, got '${state}'"
+    fail "expected is_enabled=true after /enable, got '${state}'"
   fi
 fi
 
@@ -205,7 +218,7 @@ else
   if [ "$state" = "true" ]; then
     pass
   else
-    fail "after disable->enable round-trip, .enabled='${state}' (expected 'true')"
+    fail "after disable->enable round-trip, .is_enabled='${state}' (expected 'true')"
   fi
 fi
 

--- a/tests/webhooks/test-webhook-hmac-tamper.sh
+++ b/tests/webhooks/test-webhook-hmac-tamper.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# test-webhook-hmac-tamper.sh
+#
+# Issue #75 sub-task 7.5: deepen HMAC signing coverage with negative-path
+# assertions. The existing test-webhook-hmac-signature.sh proves that the
+# X-ArtifactKeeper-Signature header is present and equals HMAC(secret, body)
+# for a clean delivery. That is the "happy path" half of 7.5.
+#
+# This test fills in the half that actually catches bugs: it computes the
+# HMAC with a DIFFERENT secret and against a TAMPERED body, and asserts the
+# header does NOT match either. A backend regression that emits a static
+# signature (e.g. forgot to hash the body, or hashes only the URL) would
+# pass the happy-path test and silently fail this one.
+#
+# Why this matters: HMAC is the only thing standing between a webhook
+# receiver and a forged delivery. If the receiver is going to drop requests
+# whose signature does not validate, the signature MUST be sensitive to
+# every byte of the signed material. Verifying that the signature changes
+# under tampering is the load-bearing security assertion, not verifying
+# that it has 64 hex digits.
+#
+# Contract under test (matches v2 wire contract, artifact-keeper#919):
+#   X-ArtifactKeeper-Signature: t=<unix_secs>,v1=<hex_hmac_sha256>
+#   Signed bytes: "<unix_secs>.<raw_body>"
+#
+# Requires: curl, jq, python3, openssl
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "webhook-hmac-tamper"
+
+WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18781}"
+WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
+WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-tamper-${RUN_ID}.log}"
+WEBHOOK_SECRET="${WEBHOOK_SECRET:-tamper-secret-${RUN_ID}}"
+WRONG_SECRET="not-the-real-secret-${RUN_ID}"
+RECEIVER_PID=""
+WEBHOOK_ID=""
+
+cleanup_and_finalize() {
+  local code=$?
+  if [ -n "${WEBHOOK_ID}" ] && [ "${WEBHOOK_ID}" != "null" ]; then
+    api_delete "/api/v1/webhooks/${WEBHOOK_ID}" >/dev/null 2>&1 || true
+  fi
+  if [ -n "${RECEIVER_PID}" ] && kill -0 "${RECEIVER_PID}" 2>/dev/null; then
+    kill "${RECEIVER_PID}" 2>/dev/null || true
+    wait "${RECEIVER_PID}" 2>/dev/null || true
+  fi
+  rm -f "${WEBHOOK_RECEIVER_LOG}"
+  exit "$code"
+}
+trap cleanup_and_finalize EXIT
+
+auth_admin
+
+# -------------------------------------------------------------------------
+# Pre-flight.
+# -------------------------------------------------------------------------
+
+begin_test "openssl, python3, and jq available"
+miss=""
+command -v openssl >/dev/null 2>&1 || miss="${miss} openssl"
+command -v python3  >/dev/null 2>&1 || miss="${miss} python3"
+command -v jq       >/dev/null 2>&1 || miss="${miss} jq"
+if [ -n "$miss" ]; then
+  skip "missing tools:${miss}"
+  end_suite
+fi
+pass
+
+# -------------------------------------------------------------------------
+# Start the mock receiver.
+# -------------------------------------------------------------------------
+
+begin_test "Start mock receiver"
+WEBHOOK_RECEIVER_PORT="$WEBHOOK_RECEIVER_PORT" \
+  WEBHOOK_FAIL_FIRST_N=0 \
+  WEBHOOK_RECEIVER_LOG="$WEBHOOK_RECEIVER_LOG" \
+  python3 "$(dirname "$0")/../lib/mock-webhook-receiver.py" \
+  >/tmp/mock-webhook-receiver-tamper-${RUN_ID}.stderr 2>&1 &
+RECEIVER_PID=$!
+
+ready=false
+for _ in $(seq 1 25); do
+  if curl -sf --max-time 1 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__health" >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 0.2
+done
+if [ "$ready" = true ]; then
+  pass
+else
+  fail "mock receiver did not come up on 127.0.0.1:${WEBHOOK_RECEIVER_PORT}"
+fi
+
+# -------------------------------------------------------------------------
+# Create a webhook with a known plaintext secret.
+# -------------------------------------------------------------------------
+
+WEBHOOK_NAME="tamper-${RUN_ID}"
+SUITE_BLOCKED=false
+
+begin_test "Create webhook with shared secret"
+if [ "$ready" != "true" ]; then
+  skip "receiver not running"
+else
+  PAYLOAD=$(jq -n \
+    --arg name "$WEBHOOK_NAME" \
+    --arg url "$WEBHOOK_RECEIVER_URL" \
+    --arg secret "$WEBHOOK_SECRET" \
+    '{name: $name, url: $url, secret: $secret, events: ["artifact.uploaded"], enabled: true}')
+  if resp=$(api_post "/api/v1/webhooks" "$PAYLOAD" 2>/dev/null); then
+    WEBHOOK_ID=$(echo "$resp" | jq -r '.id // empty')
+    if [ -z "$WEBHOOK_ID" ] || [ "$WEBHOOK_ID" = "null" ]; then
+      fail "create returned no id"
+    else
+      pass
+    fi
+  else
+    SUITE_BLOCKED=true
+    skip "webhook create rejected (URL '${WEBHOOK_RECEIVER_URL}' likely blocked by SSRF allow-list)"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Drive a /test delivery and capture the receiver entry.
+# -------------------------------------------------------------------------
+
+LATEST_HEADERS=""
+LATEST_BODY=""
+
+begin_test "Trigger /test and capture the receiver entry"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
+  skip "no webhook id"
+else
+  curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__reset" >/dev/null 2>&1 || true
+  if api_post "/api/v1/webhooks/${WEBHOOK_ID}/test" "" >/dev/null 2>&1; then
+    seen=0
+    for _ in $(seq 1 20); do
+      seen=$(curl -sf --max-time 2 "http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/__count" 2>/dev/null || echo 0)
+      [ "$seen" -gt 0 ] && break
+      sleep 0.5
+    done
+    if [ "$seen" -lt 1 ] || [ ! -s "$WEBHOOK_RECEIVER_LOG" ]; then
+      fail "no POST recorded at receiver after /test"
+    else
+      LATEST=$(tail -n 1 "$WEBHOOK_RECEIVER_LOG")
+      LATEST_HEADERS=$(echo "$LATEST" | jq -r '.headers')
+      LATEST_BODY=$(echo "$LATEST" | jq -r '.body')
+      pass
+    fi
+  else
+    SUITE_BLOCKED=true
+    skip "/test endpoint unavailable"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Parse the header. Pin to the FIRST v1= token (current secret) so the
+# negative assertions below have a single value to compare against. The
+# rotation-overlap test owns the multi-token case.
+# -------------------------------------------------------------------------
+
+SIG_HEADER=""
+SIG_TS=""
+SIG_V1=""
+
+begin_test "Capture X-ArtifactKeeper-Signature header value"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$LATEST_HEADERS" ]; then
+  skip "no receiver entry"
+else
+  SIG_HEADER=$(echo "$LATEST_HEADERS" | jq -r '
+    (.["X-ArtifactKeeper-Signature"] //
+     .["x-artifactkeeper-signature"] //
+     .["X-ARTIFACTKEEPER-SIGNATURE"] // empty)
+  ')
+  if [ -z "$SIG_HEADER" ] || [ "$SIG_HEADER" = "null" ]; then
+    fail "X-ArtifactKeeper-Signature header missing (headers: ${LATEST_HEADERS:0:300})"
+  elif echo "$SIG_HEADER" | grep -Eq '^t=[0-9]+(,v1=[0-9a-f]{64})+$'; then
+    SIG_TS=$(echo "$SIG_HEADER" | sed -nE 's/^t=([0-9]+).*/\1/p')
+    SIG_V1=$(echo "$SIG_HEADER" | sed -nE 's/.*,v1=([0-9a-f]{64}).*/\1/p' | head -n 1)
+    pass
+  else
+    fail "header value '${SIG_HEADER}' does not match t=<int>,v1=<64-hex>"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Sanity: with the RIGHT secret and the EXACT body the receiver saw, the
+# locally recomputed HMAC must equal the header. If this fails, the test
+# is broken (wrong body framing, wrong secret captured) -- not the
+# backend. Keep this assertion separate from the negative cases so a
+# breakage here is unambiguous.
+# -------------------------------------------------------------------------
+
+begin_test "Sanity: HMAC(real_secret, <t>.<body>) equals header v1 token"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$SIG_V1" ] || [ -z "$SIG_TS" ] || [ -z "$LATEST_BODY" ]; then
+  skip "no signature components captured"
+else
+  expected=$(printf '%s.%s' "$SIG_TS" "$LATEST_BODY" \
+    | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" 2>/dev/null \
+    | awk '{print $NF}')
+  if [ -z "$expected" ]; then
+    fail "openssl produced empty HMAC"
+  elif [ "$SIG_V1" = "$expected" ]; then
+    pass
+  else
+    fail "happy-path HMAC mismatch: header v1='${SIG_V1}' expected='${expected}'"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Negative case 1: signing the SAME body with the WRONG secret must
+# produce a DIFFERENT value. If they match, the backend is either not
+# using the secret at all or is using a hard-coded value -- both are
+# critical security regressions.
+# -------------------------------------------------------------------------
+
+begin_test "Tamper: HMAC with WRONG secret diverges from header v1 token"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$SIG_V1" ] || [ -z "$SIG_TS" ] || [ -z "$LATEST_BODY" ]; then
+  skip "no signature components captured"
+else
+  wrong=$(printf '%s.%s' "$SIG_TS" "$LATEST_BODY" \
+    | openssl dgst -sha256 -hmac "$WRONG_SECRET" 2>/dev/null \
+    | awk '{print $NF}')
+  if [ -z "$wrong" ]; then
+    fail "openssl produced empty HMAC for wrong-secret case"
+  elif [ "$wrong" = "$SIG_V1" ]; then
+    fail "SECURITY: HMAC under wrong secret matched header. Signature is not secret-dependent. header='${SIG_V1}' wrong-secret-hmac='${wrong}'"
+  else
+    pass
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Negative case 2: signing a TAMPERED body with the right secret must
+# produce a DIFFERENT value. We mutate the body by appending a single
+# byte; any HMAC implementation that ignores trailing bytes would be
+# catastrophically broken. The assertion here is the second half of
+# "the signature covers every byte of the body".
+# -------------------------------------------------------------------------
+
+begin_test "Tamper: HMAC over modified body diverges from header v1 token"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$SIG_V1" ] || [ -z "$SIG_TS" ] || [ -z "$LATEST_BODY" ]; then
+  skip "no signature components captured"
+else
+  tampered_body="${LATEST_BODY}X"
+  tampered=$(printf '%s.%s' "$SIG_TS" "$tampered_body" \
+    | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" 2>/dev/null \
+    | awk '{print $NF}')
+  if [ -z "$tampered" ]; then
+    fail "openssl produced empty HMAC for tampered-body case"
+  elif [ "$tampered" = "$SIG_V1" ]; then
+    fail "SECURITY: HMAC over body+'X' matched header. Signature does not cover full body. header='${SIG_V1}' tampered-hmac='${tampered}'"
+  else
+    pass
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Negative case 3: signing the body under a DIFFERENT timestamp must also
+# produce a different value. This proves t= is part of the signed string,
+# which is the only thing preventing trivial replay attacks (a receiver
+# that pins a freshness window must rely on `t` being inside the HMAC).
+# -------------------------------------------------------------------------
+
+begin_test "Tamper: HMAC with mutated timestamp diverges from header v1 token"
+if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$SIG_V1" ] || [ -z "$SIG_TS" ] || [ -z "$LATEST_BODY" ]; then
+  skip "no signature components captured"
+else
+  mutated_ts=$(( SIG_TS + 1 ))
+  off_ts=$(printf '%s.%s' "$mutated_ts" "$LATEST_BODY" \
+    | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" 2>/dev/null \
+    | awk '{print $NF}')
+  if [ -z "$off_ts" ]; then
+    fail "openssl produced empty HMAC for mutated-ts case"
+  elif [ "$off_ts" = "$SIG_V1" ]; then
+    fail "SECURITY: HMAC with t+1 matched header. Timestamp is not inside the signed string. header='${SIG_V1}' mutated-ts-hmac='${off_ts}'"
+  else
+    pass
+  fi
+fi
+
+end_suite

--- a/tests/webhooks/test-webhook-hmac-tamper.sh
+++ b/tests/webhooks/test-webhook-hmac-tamper.sh
@@ -29,7 +29,10 @@ source "$(dirname "$0")/../lib/common.sh"
 
 begin_suite "webhook-hmac-tamper"
 
-WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-18781}"
+# Receiver port: derive from PID so parallel test runs do not collide
+# on the same listen socket. Callers can still override with
+# WEBHOOK_RECEIVER_PORT.
+WEBHOOK_RECEIVER_PORT="${WEBHOOK_RECEIVER_PORT:-$(( 18000 + $$ % 1000 ))}"
 WEBHOOK_RECEIVER_URL="${WEBHOOK_RECEIVER_URL:-http://127.0.0.1:${WEBHOOK_RECEIVER_PORT}/hook}"
 WEBHOOK_RECEIVER_LOG="${WEBHOOK_RECEIVER_LOG:-/tmp/mock-webhook-receiver-tamper-${RUN_ID}.log}"
 WEBHOOK_SECRET="${WEBHOOK_SECRET:-tamper-secret-${RUN_ID}}"
@@ -105,11 +108,15 @@ begin_test "Create webhook with shared secret"
 if [ "$ready" != "true" ]; then
   skip "receiver not running"
 else
+  # CreateWebhookRequest does not accept an enabled/is_enabled field
+  # (backend webhooks.rs:86-95); new webhooks default to enabled. Event
+  # names are the snake_case Display form of WebhookEvent (webhooks.rs:
+  # 50-74), e.g. "artifact_uploaded".
   PAYLOAD=$(jq -n \
     --arg name "$WEBHOOK_NAME" \
     --arg url "$WEBHOOK_RECEIVER_URL" \
     --arg secret "$WEBHOOK_SECRET" \
-    '{name: $name, url: $url, secret: $secret, events: ["artifact.uploaded"], enabled: true}')
+    '{name: $name, url: $url, secret: $secret, events: ["artifact_uploaded"]}')
   if resp=$(api_post "/api/v1/webhooks" "$PAYLOAD" 2>/dev/null); then
     WEBHOOK_ID=$(echo "$resp" | jq -r '.id // empty')
     if [ -z "$WEBHOOK_ID" ] || [ "$WEBHOOK_ID" = "null" ]; then

--- a/tests/webhooks/test-webhook-ssrf-prevention.sh
+++ b/tests/webhooks/test-webhook-ssrf-prevention.sh
@@ -88,9 +88,12 @@ attempt_ssrf() {
   local url="$2"
   local name="ssrf-${label}-${RUN_ID}"
 
+  # CreateWebhookRequest does not accept an enabled/is_enabled field
+  # (backend webhooks.rs:86-95). Event names are the snake_case Display
+  # form of WebhookEvent (webhooks.rs:50-74).
   local payload
   payload=$(jq -n --arg name "$name" --arg url "$url" \
-    '{name: $name, url: $url, events: ["artifact.uploaded"], enabled: true}')
+    '{name: $name, url: $url, events: ["artifact_uploaded"]}')
 
   local tmp status body
   tmp=$(mktemp)

--- a/tests/webhooks/test-webhook-ssrf-prevention.sh
+++ b/tests/webhooks/test-webhook-ssrf-prevention.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# test-webhook-ssrf-prevention.sh
+#
+# Issue #75 sub-task 7.8: server-side request forgery prevention on
+# webhook URLs. A webhook destination is one of the few places where a
+# tenant-controlled URL is fetched server-side; if the backend allows the
+# tenant to point a webhook at a private IP, a loopback address, or a
+# cloud metadata endpoint, the resulting POSTs can be used to exfiltrate
+# data, scan internal services, or steal IAM credentials from the
+# instance metadata service.
+#
+# The load-bearing assertion of this suite is therefore:
+#
+#   POST /api/v1/webhooks with a private / loopback / metadata URL must
+#   be rejected with a 4xx response. Anything in 2xx is a critical
+#   security regression: the webhook is now stored and the backend will
+#   happily fan out events to internal targets at delivery time.
+#
+# We test each address class separately so a regression on only one class
+# (say, cloud-metadata 169.254.x but not RFC1918) is visible in the
+# JUnit report rather than masked by a sibling assertion. The list is
+# deliberately conservative -- we do not test every CIDR; we test one
+# representative per documented blocklist class.
+#
+# We never test against a real external IP. Every URL here points to an
+# address that should be unreachable from outside the test runner OR
+# that is universally understood to be a private/management address.
+#
+# Companion: 7.9 (DNS rebinding / re-validation at delivery time) is a
+# separate concern -- this test only covers create-time validation.
+#
+# Requires: curl, jq
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "webhook-ssrf-prevention"
+
+CREATED_IDS=()
+
+cleanup_created() {
+  for id in "${CREATED_IDS[@]}"; do
+    [ -n "$id" ] && [ "$id" != "null" ] && \
+      api_delete "/api/v1/webhooks/${id}" >/dev/null 2>&1 || true
+  done
+}
+add_exit_handler 'cleanup_created'
+
+auth_admin
+
+# -------------------------------------------------------------------------
+# Pre-flight.
+# -------------------------------------------------------------------------
+
+begin_test "jq available"
+if ! command -v jq >/dev/null 2>&1; then
+  skip "jq not available"
+  end_suite
+fi
+pass
+
+# -------------------------------------------------------------------------
+# attempt_ssrf <label> <url>
+#
+# Tries to POST /api/v1/webhooks with a destination URL drawn from a
+# blocked address class. Behavior:
+#
+#   - 4xx (validation rejection)   -> PASS. This is the expected outcome.
+#   - 2xx with an .id field        -> FAIL (and queue the row for cleanup).
+#                                     Test-marker: SSRF allow-list missed
+#                                     this class, the webhook is persisted
+#                                     and will fire against an internal
+#                                     target at delivery time.
+#   - 5xx                          -> FAIL. The backend should be reaching
+#                                     a deterministic validation verdict,
+#                                     not crashing.
+#   - 501 / "not implemented"      -> SKIP. The endpoint does not exist
+#                                     yet in this build; report it but do
+#                                     not silently pass (would be a
+#                                     silent-success per #870/#871).
+#
+# Curl is invoked with -o to capture the body so a 2xx leak can be
+# logged with the persisted id; -w to capture the HTTP status so we
+# never confuse "request failed" with "validation rejected".
+# -------------------------------------------------------------------------
+
+attempt_ssrf() {
+  local label="$1"
+  local url="$2"
+  local name="ssrf-${label}-${RUN_ID}"
+
+  local payload
+  payload=$(jq -n --arg name "$name" --arg url "$url" \
+    '{name: $name, url: $url, events: ["artifact.uploaded"], enabled: true}')
+
+  local tmp status body
+  tmp=$(mktemp)
+  status=$(curl -s -o "$tmp" -w '%{http_code}' \
+    --max-time 10 \
+    -H "$(auth_header)" \
+    -H "Content-Type: application/json" \
+    -X POST \
+    -d "$payload" \
+    "${BASE_URL}/api/v1/webhooks" 2>/dev/null) || status="000"
+  body=$(cat "$tmp" 2>/dev/null || true)
+  rm -f "$tmp"
+
+  case "$status" in
+    4??)
+      pass
+      ;;
+    501)
+      skip "endpoint not implemented (HTTP 501)"
+      ;;
+    2??)
+      # The webhook was accepted. Record the id so the cleanup trap can
+      # purge it -- a persisted SSRF target is its own follow-on risk.
+      local leaked_id
+      leaked_id=$(echo "$body" | jq -r '.id // empty' 2>/dev/null) || leaked_id=""
+      if [ -n "$leaked_id" ] && [ "$leaked_id" != "null" ]; then
+        CREATED_IDS+=("$leaked_id")
+      fi
+      fail "SECURITY: webhook URL '${url}' (${label}) accepted with HTTP ${status}. This is a server-side request forgery vector." "${body:0:400}"
+      ;;
+    000)
+      fail "network failure contacting ${BASE_URL}/api/v1/webhooks (curl returned 000) for label='${label}'"
+      ;;
+    *)
+      fail "unexpected HTTP ${status} for url='${url}' (${label}); expected 4xx rejection" "${body:0:400}"
+      ;;
+  esac
+}
+
+# -------------------------------------------------------------------------
+# Cloud metadata services. 169.254.169.254 is the long-standing AWS /
+# GCP / Azure / DigitalOcean / Oracle Cloud metadata IP. A webhook
+# pointed at it can exfiltrate short-lived IAM credentials, instance
+# tags, user-data, etc. This is the highest-impact SSRF class.
+# -------------------------------------------------------------------------
+
+begin_test "Reject cloud metadata IP (169.254.169.254)"
+attempt_ssrf "aws-metadata" "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+
+# Newer GCP metadata host. Different from the IP path because some
+# allow-lists deny by IP literal but forget the well-known hostname.
+begin_test "Reject GCP metadata hostname (metadata.google.internal)"
+attempt_ssrf "gcp-metadata" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
+
+# -------------------------------------------------------------------------
+# Link-local 169.254.0.0/16 (RFC3927). Distinct from the metadata IP
+# above because some implementations special-case 169.254.169.254 but
+# miss the rest of the /16. A webhook pointed at .169.250 reaches a
+# completely different surface (DHCP clients, APIPA, link-local probes).
+# -------------------------------------------------------------------------
+
+begin_test "Reject link-local 169.254.x (non-metadata host in same /16)"
+attempt_ssrf "linklocal" "http://169.254.169.250/"
+
+# -------------------------------------------------------------------------
+# Loopback. 127.0.0.0/8. Pointing a webhook at the host's own loopback
+# reaches anything bound to localhost: postgres, redis, kube-proxy's
+# health server, debugging endpoints, sidecars. This is the SSRF class
+# that lets a tenant hit the backend's own /admin endpoints.
+# -------------------------------------------------------------------------
+
+begin_test "Reject IPv4 loopback (127.0.0.1)"
+attempt_ssrf "loopback4" "http://127.0.0.1:8080/api/v1/users"
+
+begin_test "Reject IPv4 loopback alias (127.1.2.3)"
+attempt_ssrf "loopback-alias" "http://127.1.2.3/"
+
+begin_test "Reject IPv6 loopback ([::1])"
+attempt_ssrf "loopback6" "http://[::1]:8080/"
+
+# Allow-lists that filter on the literal string "127.0.0.1" but forget
+# that "localhost" resolves to the same place are a recurring class of
+# bug. Test the hostname form explicitly.
+begin_test "Reject 'localhost' hostname"
+attempt_ssrf "localhost-name" "http://localhost:8080/"
+
+# -------------------------------------------------------------------------
+# RFC1918 private space. One representative per /8 so the JUnit row
+# tells the on-call which block leaked if any of them does.
+# -------------------------------------------------------------------------
+
+begin_test "Reject RFC1918 10.0.0.0/8 (10.0.0.1)"
+attempt_ssrf "rfc1918-10" "http://10.0.0.1/"
+
+begin_test "Reject RFC1918 172.16.0.0/12 (172.16.0.1)"
+attempt_ssrf "rfc1918-172" "http://172.16.0.1/"
+
+begin_test "Reject RFC1918 192.168.0.0/16 (192.168.1.1)"
+attempt_ssrf "rfc1918-192" "http://192.168.1.1/"
+
+# -------------------------------------------------------------------------
+# 0.0.0.0. Treated as "all addresses on the local host" by most network
+# stacks; a webhook firing at 0.0.0.0 hits the loopback equivalently.
+# Easy to forget if the allow-list is implemented as "must be a valid
+# routable IP" without an explicit 0/8 exclusion.
+# -------------------------------------------------------------------------
+
+begin_test "Reject unspecified address (0.0.0.0)"
+attempt_ssrf "zero" "http://0.0.0.0:8080/"
+
+# -------------------------------------------------------------------------
+# Non-HTTP schemes. Even if the URL parser would accept the host, the
+# scheme should be restricted to http/https. file:// would let a webhook
+# read local files; gopher:// is the classic SSRF gadget for talking
+# arbitrary TCP protocols through a permissive HTTP client.
+# -------------------------------------------------------------------------
+
+begin_test "Reject file:// scheme"
+attempt_ssrf "scheme-file" "file:///etc/passwd"
+
+begin_test "Reject gopher:// scheme"
+attempt_ssrf "scheme-gopher" "gopher://127.0.0.1:6379/_INFO"
+
+end_suite


### PR DESCRIPTION
## Summary

Adds five E2E test scripts under `tests/webhooks/` covering well-defined
sub-tasks from issue #75 that were not yet exercised end-to-end. Each
test follows the existing pattern (sources `lib/common.sh`, uses
`RUN_ID`, EXIT-trap cleanup, skips cleanly on missing endpoints, never
silently passes).

## Delivered (issue #75)

- [x] **7.5 HMAC signing (negative path)** — `test-webhook-hmac-tamper.sh`
  Existing `test-webhook-hmac-signature.sh` proves happy-path:
  header == HMAC(secret, t.body). This suite proves the header
  DIVERGES under (a) wrong secret, (b) tampered body, (c) mutated
  timestamp. Without these the happy-path test would pass against a
  backend that emits a static or insufficiently-bound signature.

- [x] **7.8 SSRF prevention on webhook URLs** — `test-webhook-ssrf-prevention.sh`
  Asserts POST `/api/v1/webhooks` with each of these is rejected 4xx:
  cloud metadata (169.254.169.254, metadata.google.internal),
  link-local 169.254.x, IPv4 loopback (127.0.0.1 + alias 127.1.2.3),
  IPv6 loopback ([::1]), `localhost` hostname, RFC1918 (10/8, 172.16/12,
  192.168/16), 0.0.0.0, and non-http schemes (file://, gopher://).
  Load-bearing assertion: a 2xx accept here would let a tenant
  exfiltrate IAM creds or scan internal services.

- [x] **7.12 Webhook dry-run** — `test-webhook-dry-run.sh`
  POST `/{id}/test` returns 2xx, receiver actually got a POST,
  delivered body has `.event`, carries `X-ArtifactKeeper-Delivery`,
  and `/test` on an unknown id returns 404. Catches the silent-
  success regression where `/test` 200s without firing.

- [x] **7.13 Enable/disable toggle** — `test-webhook-enable-disable-toggle.sh`
  POST `/{id}/enable` and `/{id}/disable` flip the persisted
  `.enabled` flag, are idempotent (second call still 2xx), and
  `/enable` on a fabricated id returns 404. Existing CRUD test
  only PUTs `{enabled:false}` and never asserts state.

- [x] **7.14 Delivery status filter** — `test-event-delivery-status-filter.sh`
  GET `/{id}/deliveries?status=<x>`. Drives a delivery, reads
  the observed status vocabulary, asserts filter=<observed>
  returns only matching rows AND filter=<bogus> returns zero rows.
  The bogus-filter assertion is the one that catches "param is
  silently ignored" — without it, an ignored filter passes the
  positive test trivially.

## Explicitly deferred (out of scope for this PR)

- [ ] 7.1 retry engine backoff timing (30s -> 2m -> 15m -> 1h -> 4h)
- [ ] 7.2 dead-letter queue handling for exhausted attempts
- [ ] 7.3 max-attempts exhaustion scenario
- [ ] 7.4 async retry job (`process_webhook_retries`)
  Reason: all four are timing-sensitive and need a larger fixture
  (sustained backend uptime across multi-hour backoff windows).
  Better landed in a dedicated retry-engine PR with its own
  `TEST_TIMEOUT` overrides.

- [ ] 7.16 cross-handler event propagation
  (artifact.created -> webhook delivery -> SSE broadcast)
  Reason: spans the producer + SSE subsystems, deserves its own
  multi-subsystem orchestration suite.

- [ ] 7.17 gRPC SbomService
- [ ] 7.18 gRPC CveHistoryService
- [ ] 7.19 gRPC SecurityPolicyService
  Reason: different transport layer (port 9090, gRPC); the test
  runner currently only wires HTTP fixtures, gRPC needs separate
  fixture infra.

## Test plan

- [ ] CI `webhook-tests` job (release-gate workflow,
      `./scripts/run-suite.sh --suite webhooks`) goes green against
      a deployment of the in-flight backend.
- [ ] Locally:
      `BASE_URL=... ADMIN_USER=... ADMIN_PASS=... RUN_ID=local bash tests/webhooks/test-webhook-hmac-tamper.sh`
      and the four siblings; each emits PASS rows and writes
      `$JUNIT_OUTPUT_DIR/<suite>.xml`.
- [ ] Files chmod +x and `bash -n` clean.