### PR TITLE
test(security): scan findings + ack/suppress + SBOM convert + license/scan policy CRUD (#67)

### DIFF
--- a/tests/security/test-cve-history-trends-status.sh
+++ b/tests/security/test-cve-history-trends-status.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# test-cve-history-trends-status.sh - CVE history / trends / status update
+# E2E test.
+#
+# Covers Epic 2 sub-task 2.8 (artifact-keeper-test#67):
+#   GET  /api/v1/sbom/cve/history/{artifact_id}
+#   GET  /api/v1/sbom/cve/trends?repository_id=...&days=...
+#   POST /api/v1/sbom/cve/status/{id}
+# Ships in v1.2.0 (customer pain #2 -- "CVE timeline never surfaced;
+# triagers had no way to mark a CVE as accepted/false_positive").
+#
+# Flow
+# ----
+#   1. Create a generic repo, upload a fixture that the dependency
+#      scanner will fingerprint (lodash 4.17.4 -- CVE-2019-10744 is a
+#      well-known, well-aged finding that Trivy and Grype both match).
+#   2. Wait for the scan to complete so a CVE history row gets persisted.
+#   3. GET /sbom/cve/history/{artifact_id} -- assert array shape +
+#      documented CveHistoryEntry fields on the first row.
+#   4. GET /sbom/cve/trends -- assert documented CveTrends shape
+#      (total_cves, open_cves, fixed_cves, acknowledged_cves,
+#      critical_count, high_count, medium_count, low_count).
+#   5. POST /sbom/cve/status/{id} with status='acknowledged' +
+#      reason='...' -- assert the updated entry round-trips status.
+#
+# Skip semantics
+# --------------
+# Hard-fails if the endpoints return 5xx or wrong shape; skip()s
+# gracefully when the scanner is not configured on this stack
+# (same model as test-scan-depth-dependency-cves.sh). Status update
+# does NOT depend on scanner_version / scan_result_id / is_reused
+# (deferred to backend #902/#906/#907).
+#
+# Self-test mode (EXPECT_FAILURE=1):
+#   Inverts the final exit code (end_suite handles centrally).
+#
+# Requires: curl, jq, tar
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "cve-history-trends-status"
+auth_admin
+setup_workdir
+
+REPO_KEY="test-cve-hts-${RUN_ID}"
+PACKAGE_NAME="cve-hts-fixture"
+PACKAGE_VERSION="1.0.0"
+TARBALL_NAME="${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz"
+ARTIFACT_PATH="${PACKAGE_NAME}/${PACKAGE_VERSION}/${TARBALL_NAME}"
+SCAN_TIMEOUT="${SCAN_TIMEOUT:-90}"
+ARTIFACT_ID=""
+REPO_ID=""
+CVE_ENTRY_ID=""
+
+cleanup_repo() {
+  # shellcheck disable=SC2086
+  curl -sf $CURL_TIMEOUT -X DELETE -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/repositories/${REPO_KEY}" > /dev/null 2>&1 || true
+}
+add_exit_handler "cleanup_repo"
+
+# ---------------------------------------------------------------------------
+# Build fixture: known-vulnerable lodash 4.17.4 (CVE-2019-10744).
+# Same shape as test-scan-depth-dependency-cves.sh so the scanner
+# produces the same well-aged finding.
+# ---------------------------------------------------------------------------
+
+begin_test "Build fixture with known-CVE dependency (lodash 4.17.4)"
+mkdir -p "${WORK_DIR}/pkg"
+cat > "${WORK_DIR}/pkg/package.json" <<'EOF'
+{
+  "name": "cve-hts-fixture",
+  "version": "1.0.0",
+  "dependencies": { "lodash": "4.17.4" }
+}
+EOF
+cat > "${WORK_DIR}/pkg/package-lock.json" <<'EOF'
+{
+  "name": "cve-hts-fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": { "name": "cve-hts-fixture", "version": "1.0.0", "dependencies": { "lodash": "4.17.4" } },
+    "node_modules/lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyLuHBHJgwGu1myF0sR4U="
+    }
+  }
+}
+EOF
+if tar -czf "${WORK_DIR}/${TARBALL_NAME}" -C "${WORK_DIR}" pkg 2>/dev/null; then
+  pass
+else
+  fail "could not build fixture tarball"
+  end_suite
+  exit 1
+fi
+
+begin_test "Create generic local repository"
+if create_local_repo "$REPO_KEY" "generic"; then
+  # Resolve repo id for the trends call.
+  repo_resp=$(api_get "/api/v1/repositories/${REPO_KEY}" 2>/dev/null) || true
+  REPO_ID=$(echo "$repo_resp" | jq -r '.id // empty')
+  pass
+else
+  fail "could not create ${REPO_KEY}"
+  end_suite
+  exit 1
+fi
+
+begin_test "Upload fixture artifact"
+upload_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+  -X PUT -H "$(auth_header)" -H "Content-Type: application/gzip" \
+  --data-binary "@${WORK_DIR}/${TARBALL_NAME}" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/${ARTIFACT_PATH}") || upload_status="000"
+case "$upload_status" in
+  200|201) pass ;;
+  *) fail "upload returned ${upload_status}"; end_suite; exit 1 ;;
+esac
+
+sleep 3
+
+begin_test "Resolve artifact_id"
+list_resp=$(api_get "/api/v1/repositories/${REPO_KEY}/artifacts" 2>/dev/null) || true
+if [ -n "$list_resp" ]; then
+  ARTIFACT_ID=$(echo "$list_resp" | jq -r --arg p "$ARTIFACT_PATH" '
+    if type == "array" then . elif .items then .items else [] end
+    | map(select((.path // "") == $p))
+    | .[0].id // empty')
+fi
+if [ -n "$ARTIFACT_ID" ]; then
+  pass
+else
+  fail "could not resolve artifact_id"
+  end_suite
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Trigger scan + wait. Skip rest if scanner is not wired.
+# ---------------------------------------------------------------------------
+
+begin_test "Trigger scan and wait for terminal state"
+trig_payload=$(jq -n --arg id "$ARTIFACT_ID" '{artifact_id: $id}')
+trig_status=$(curl -s -o "$WORK_DIR/trig.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -X POST -H "$(auth_header)" -H "Content-Type: application/json" \
+  -d "$trig_payload" \
+  "${BASE_URL}/api/v1/security/scan") || trig_status="000"
+
+SCANNER_AVAILABLE=true
+case "$trig_status" in
+  501|503) SCANNER_AVAILABLE=false; skip "scanner not configured (HTTP ${trig_status})" ;;
+  2*)
+    # Poll for terminal state on the artifact's scan list.
+    elapsed=0
+    state=""
+    while [ "$elapsed" -lt "$SCAN_TIMEOUT" ]; do
+      sr=$(api_get "/api/v1/security/scans?artifact_id=${ARTIFACT_ID}&per_page=5" 2>/dev/null) || sr=""
+      if [ -n "$sr" ]; then
+        state=$(echo "$sr" | jq -r '.items[0].status // empty')
+        case "$state" in
+          completed|failed|error|cancelled) break ;;
+        esac
+      fi
+      sleep 5
+      elapsed=$(( elapsed + 5 ))
+    done
+    if [ -z "$state" ]; then
+      SCANNER_AVAILABLE=false
+      skip "scan never produced a record within ${SCAN_TIMEOUT}s"
+    elif [ "$state" = "completed" ]; then
+      pass
+    else
+      # Terminal-but-not-completed (failed/error/cancelled) means the
+      # scanner reached the artifact but couldn't process it; CVE
+      # history calls below will return empty, which we tolerate via
+      # the empty-array branch.
+      pass
+    fi
+    ;;
+  *) fail "POST /security/scan returned HTTP ${trig_status}" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 2.8.a -- GET /sbom/cve/history/{artifact_id} returns array of
+# CveHistoryEntry. Required fields per openapi.yaml line 12443:
+#   id, artifact_id, cve_id, first_detected_at, last_detected_at,
+#   status, created_at, updated_at.
+# ---------------------------------------------------------------------------
+
+begin_test "GET /sbom/cve/history/{artifact_id} returns CveHistoryEntry[]"
+if ! $SCANNER_AVAILABLE; then
+  skip "scanner unavailable"
+else
+  h_status=$(curl -s -o "$WORK_DIR/hist.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/sbom/cve/history/${ARTIFACT_ID}") || h_status="000"
+  if [ "$h_status" = "501" ] || [ "$h_status" = "404" ]; then
+    skip "CVE history endpoint not available (HTTP ${h_status})"
+  elif [ "$h_status" != "200" ]; then
+    fail "GET /sbom/cve/history/${ARTIFACT_ID} returned HTTP ${h_status} (body: $(head -c 200 "$WORK_DIR/hist.json"))"
+  else
+    if ! jq -e 'type == "array"' "$WORK_DIR/hist.json" > /dev/null 2>&1; then
+      fail "history response is not an array (body: $(head -c 200 "$WORK_DIR/hist.json"))"
+    else
+      n=$(jq -r 'length' "$WORK_DIR/hist.json")
+      if [ "$n" -lt 1 ]; then
+        skip "no CVE history rows for artifact (scanner may not have populated /sbom/cve_history yet)"
+      else
+        missing=""
+        for field in id artifact_id cve_id first_detected_at \
+                     last_detected_at status created_at updated_at; do
+          if ! jq -e --arg f "$field" '.[0] | has($f) and (.[$f] != null)' "$WORK_DIR/hist.json" > /dev/null 2>&1; then
+            missing="${missing} ${field}"
+          fi
+        done
+        if [ -n "$missing" ]; then
+          fail "history[0] missing required field(s):${missing}"
+        else
+          CVE_ENTRY_ID=$(jq -r '.[0].id' "$WORK_DIR/hist.json")
+          pass
+        fi
+      fi
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2.8.b -- GET /sbom/cve/trends returns documented CveTrends shape.
+# Required per openapi.yaml line 12571:
+#   total_cves, open_cves, fixed_cves, acknowledged_cves,
+#   critical_count, high_count, medium_count, low_count.
+# Works even with zero CVEs (returns counts=0); test passes regardless
+# of scanner availability so long as endpoint is mounted.
+# ---------------------------------------------------------------------------
+
+begin_test "GET /sbom/cve/trends returns CveTrends shape"
+url="${BASE_URL}/api/v1/sbom/cve/trends?days=30"
+if [ -n "$REPO_ID" ]; then
+  url="${url}&repository_id=${REPO_ID}"
+fi
+t_status=$(curl -s -o "$WORK_DIR/trends.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" "$url") || t_status="000"
+if [ "$t_status" = "501" ] || [ "$t_status" = "404" ]; then
+  skip "CVE trends endpoint not available (HTTP ${t_status})"
+elif [ "$t_status" != "200" ]; then
+  fail "GET /sbom/cve/trends returned HTTP ${t_status} (body: $(head -c 200 "$WORK_DIR/trends.json"))"
+else
+  missing=""
+  for field in total_cves open_cves fixed_cves acknowledged_cves \
+               critical_count high_count medium_count low_count; do
+    # 0 is a valid value so we accept it explicitly (jq has() handles this).
+    if ! jq -e --arg f "$field" 'has($f)' "$WORK_DIR/trends.json" > /dev/null 2>&1; then
+      missing="${missing} ${field}"
+    fi
+  done
+  if [ -n "$missing" ]; then
+    fail "CveTrends missing field(s):${missing} (body: $(head -c 250 "$WORK_DIR/trends.json"))"
+  else
+    pass
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2.8.c -- POST /sbom/cve/status/{id} round-trips a status update.
+# Requires a CVE_ENTRY_ID from 2.8.a. We use status='acknowledged' +
+# reason='...' so we exercise both fields of UpdateCveStatusRequest.
+# Note: we do NOT depend on scanner_version / scan_result_id /
+# is_reused (deferred backend work).
+# ---------------------------------------------------------------------------
+
+begin_test "POST /sbom/cve/status/{id} round-trips status='acknowledged'"
+if [ -z "$CVE_ENTRY_ID" ]; then
+  skip "no CVE history row to update"
+else
+  reason="E2E ack reason ${RUN_ID}"
+  upd_payload=$(jq -n --arg s "acknowledged" --arg r "$reason" \
+    '{status: $s, reason: $r}')
+  upd_status=$(curl -s -o "$WORK_DIR/upd.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -X POST -H "$(auth_header)" -H "Content-Type: application/json" \
+    -d "$upd_payload" \
+    "${BASE_URL}/api/v1/sbom/cve/status/${CVE_ENTRY_ID}") || upd_status="000"
+  if [ "$upd_status" = "501" ] || [ "$upd_status" = "404" ]; then
+    skip "CVE status update endpoint not available (HTTP ${upd_status})"
+  elif [ "$upd_status" != "200" ]; then
+    fail "POST /sbom/cve/status/${CVE_ENTRY_ID} returned HTTP ${upd_status} (body: $(head -c 200 "$WORK_DIR/upd.json"))"
+  else
+    got_status=$(jq -r '.status // empty' "$WORK_DIR/upd.json")
+    got_id=$(jq -r '.id // empty' "$WORK_DIR/upd.json")
+    if [ "$got_status" != "acknowledged" ]; then
+      fail "status did not round-trip: expected 'acknowledged', got '${got_status}'"
+    elif [ "$got_id" != "$CVE_ENTRY_ID" ]; then
+      fail "id mismatch in response: expected '${CVE_ENTRY_ID}', got '${got_id}'"
+    else
+      pass
+    fi
+  fi
+fi
+
+end_suite

--- a/tests/security/test-license-policy-crud.sh
+++ b/tests/security/test-license-policy-crud.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# test-license-policy-crud.sh - License policy CRUD + compliance check E2E.
+#
+# Covers Epic 2 sub-task 2.9 (artifact-keeper-test#67):
+#   GET    /api/v1/sbom/license-policies
+#   POST   /api/v1/sbom/license-policies       (upsert -- doubles as update)
+#   GET    /api/v1/sbom/license-policies/{id}
+#   DELETE /api/v1/sbom/license-policies/{id}
+#   POST   /api/v1/sbom/check-compliance
+# Ships in v1.2.0 (customer pain #2 -- "license policy was a YAML
+# nobody could edit safely").
+#
+# Flow (create -> list -> update -> get -> compliance check -> delete -> 404)
+# --------------------------------------------------------------------------
+#   1. POST upsert with a fresh name, allowed=[MIT, Apache-2.0],
+#      denied=[GPL-3.0, AGPL-3.0]. Assert documented LicensePolicyResponse
+#      shape and capture POLICY_ID.
+#   2. GET list -- assert our policy is in the array.
+#   3. POST upsert again with the SAME name but a tweaked field
+#      (description) -- assert the response reflects the update.
+#   4. GET by id -- assert the tweaked field round-tripped.
+#   5. POST /sbom/check-compliance with our denied license (GPL-3.0)
+#      -- assert compliant=false. Then with an allowed license (MIT)
+#      -- assert compliant=true.
+#   6. DELETE by id -- assert 2xx.
+#   7. GET by id -- assert 404 (not 200, not 500).
+#
+# Skip semantics
+# --------------
+# This endpoint set is CRUD over a SQL table and ships in every backend
+# build that has the sbom module enabled, which is all of them. We skip
+# only on 501/404-not-mounted at the suite entry (zero CRUD ops). The
+# compliance check sub-test can be skip()ed if /sbom/check-compliance
+# returns 404-no-policy-configured (404 is documented for this endpoint).
+#
+# Self-test mode (EXPECT_FAILURE=1):
+#   Inverts the final exit code.
+#
+# Requires: curl, jq
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "license-policy-crud"
+auth_admin
+setup_workdir
+
+POLICY_NAME="e2e-lic-${RUN_ID}"
+POLICY_ID=""
+
+# Belt-and-suspenders cleanup: even if the DELETE test below succeeds,
+# a previous failed run can leave dangling rows. Look up by name on
+# entry and delete if found.
+cleanup_policy() {
+  if [ -n "$POLICY_ID" ]; then
+    # shellcheck disable=SC2086
+    curl -sf $CURL_TIMEOUT -X DELETE -H "$(auth_header)" \
+      "${BASE_URL}/api/v1/sbom/license-policies/${POLICY_ID}" > /dev/null 2>&1 || true
+  fi
+}
+add_exit_handler "cleanup_policy"
+
+# ---------------------------------------------------------------------------
+# 2.9.a -- POST upsert creates the policy. Required LicensePolicyResponse
+# fields per openapi.yaml line 14118:
+#   id, name, allowed_licenses, denied_licenses, allow_unknown,
+#   action, is_enabled, created_at.
+# ---------------------------------------------------------------------------
+
+begin_test "POST /sbom/license-policies creates a policy"
+create_payload=$(jq -n --arg n "$POLICY_NAME" '{
+  name: $n,
+  description: "initial description",
+  allowed_licenses: ["MIT", "Apache-2.0"],
+  denied_licenses: ["GPL-3.0", "AGPL-3.0"],
+  allow_unknown: false,
+  action: "block",
+  is_enabled: true
+}')
+c_status=$(curl -s -o "$WORK_DIR/create.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -X POST -H "$(auth_header)" -H "Content-Type: application/json" \
+  -d "$create_payload" \
+  "${BASE_URL}/api/v1/sbom/license-policies") || c_status="000"
+
+case "$c_status" in
+  501|404)
+    skip_suite "license policy endpoint not available (HTTP ${c_status})"
+    ;;
+  200|201)
+    missing=""
+    for field in id name allowed_licenses denied_licenses allow_unknown \
+                 action is_enabled created_at; do
+      if ! jq -e --arg f "$field" 'has($f)' "$WORK_DIR/create.json" > /dev/null 2>&1; then
+        missing="${missing} ${field}"
+      fi
+    done
+    if [ -n "$missing" ]; then
+      fail "create response missing required field(s):${missing} (body: $(head -c 250 "$WORK_DIR/create.json"))"
+    else
+      POLICY_ID=$(jq -r '.id' "$WORK_DIR/create.json")
+      uuid_re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+      got_name=$(jq -r '.name' "$WORK_DIR/create.json")
+      if ! [[ "$POLICY_ID" =~ $uuid_re ]]; then
+        fail "policy id '${POLICY_ID}' is not a UUID"
+      elif [ "$got_name" != "$POLICY_NAME" ]; then
+        fail "policy name did not round-trip: sent='${POLICY_NAME}' got='${got_name}'"
+      else
+        pass
+      fi
+    fi
+    ;;
+  *)
+    fail "POST /sbom/license-policies returned HTTP ${c_status} (body: $(head -c 200 "$WORK_DIR/create.json"))"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 2.9.b -- GET list contains our policy.
+# ---------------------------------------------------------------------------
+
+begin_test "GET /sbom/license-policies contains created policy"
+if [ -z "$POLICY_ID" ]; then
+  skip "no policy id"
+else
+  l_status=$(curl -s -o "$WORK_DIR/list.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" "${BASE_URL}/api/v1/sbom/license-policies") || l_status="000"
+  if [ "$l_status" != "200" ]; then
+    fail "GET list returned HTTP ${l_status}"
+  elif ! jq -e 'type == "array"' "$WORK_DIR/list.json" > /dev/null 2>&1; then
+    fail "list response is not an array"
+  elif ! jq -e --arg id "$POLICY_ID" 'any(.id == $id)' "$WORK_DIR/list.json" > /dev/null 2>&1; then
+    fail "list does not contain id=${POLICY_ID} (list head: $(head -c 200 "$WORK_DIR/list.json"))"
+  else
+    pass
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2.9.c -- POST upsert with the same name updates the existing row.
+# We change description; the response must reflect the new value
+# (proves it's an UPDATE, not a duplicate INSERT).
+# ---------------------------------------------------------------------------
+
+NEW_DESC="updated by E2E run ${RUN_ID}"
+
+begin_test "POST upsert with same name updates description"
+if [ -z "$POLICY_ID" ]; then
+  skip "no policy id"
+else
+  upd_payload=$(jq -n --arg n "$POLICY_NAME" --arg d "$NEW_DESC" '{
+    name: $n,
+    description: $d,
+    allowed_licenses: ["MIT", "Apache-2.0"],
+    denied_licenses: ["GPL-3.0", "AGPL-3.0"],
+    allow_unknown: false,
+    action: "block",
+    is_enabled: true
+  }')
+  u_status=$(curl -s -o "$WORK_DIR/upd.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -X POST -H "$(auth_header)" -H "Content-Type: application/json" \
+    -d "$upd_payload" \
+    "${BASE_URL}/api/v1/sbom/license-policies") || u_status="000"
+  if [ "$u_status" != "200" ] && [ "$u_status" != "201" ]; then
+    fail "upsert returned HTTP ${u_status} (body: $(head -c 200 "$WORK_DIR/upd.json"))"
+  else
+    upd_id=$(jq -r '.id' "$WORK_DIR/upd.json")
+    upd_desc=$(jq -r '.description // empty' "$WORK_DIR/upd.json")
+    if [ "$upd_id" != "$POLICY_ID" ]; then
+      fail "upsert created new row id=${upd_id} instead of updating ${POLICY_ID}"
+    elif [ "$upd_desc" != "$NEW_DESC" ]; then
+      fail "description did not update: expected='${NEW_DESC}' got='${upd_desc}'"
+    else
+      pass
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2.9.d -- GET by id reflects the updated description (and is not the
+# cached pre-update copy).
+# ---------------------------------------------------------------------------
+
+begin_test "GET /sbom/license-policies/{id} reflects update"
+if [ -z "$POLICY_ID" ]; then
+  skip "no policy id"
+else
+  g_status=$(curl -s -o "$WORK_DIR/get.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" "${BASE_URL}/api/v1/sbom/license-policies/${POLICY_ID}") || g_status="000"
+  if [ "$g_status" != "200" ]; then
+    fail "GET by id returned HTTP ${g_status}"
+  else
+    got_desc=$(jq -r '.description // empty' "$WORK_DIR/get.json")
+    if [ "$got_desc" != "$NEW_DESC" ]; then
+      fail "GET description='${got_desc}' did not match expected updated='${NEW_DESC}'"
+    else
+      pass
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2.9.e -- POST /sbom/check-compliance evaluates a license list against
+# active policies. Required LicenseCheckResult fields per openapi.yaml
+# line 14100: compliant, violations[], warnings[].
+# ---------------------------------------------------------------------------
+
+begin_test "POST /sbom/check-compliance: denied license -> compliant=false"
+if [ -z "$POLICY_ID" ]; then
+  skip "no policy id"
+else
+  bad_payload=$(jq -n '{licenses: ["GPL-3.0"]}')
+  b_status=$(curl -s -o "$WORK_DIR/bad.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -X POST -H "$(auth_header)" -H "Content-Type: application/json" \
+    -d "$bad_payload" \
+    "${BASE_URL}/api/v1/sbom/check-compliance") || b_status="000"
+  case "$b_status" in
+    404) skip "no license policy configured for this scope (HTTP 404 documented)" ;;
+    501) skip "check-compliance endpoint not available" ;;
+    200)
+      compliant=$(jq -r '.compliant // empty' "$WORK_DIR/bad.json")
+      viol_type=$(jq -r '.violations | type' "$WORK_DIR/bad.json")
+      warn_type=$(jq -r '.warnings | type' "$WORK_DIR/bad.json")
+      if [ "$compliant" != "false" ]; then
+        fail "denied license GPL-3.0 returned compliant='${compliant}' (expected false). body: $(head -c 200 "$WORK_DIR/bad.json")"
+      elif [ "$viol_type" != "array" ] || [ "$warn_type" != "array" ]; then
+        fail "violations or warnings is not an array (violations=${viol_type}, warnings=${warn_type})"
+      else
+        pass
+      fi
+      ;;
+    *) fail "check-compliance returned HTTP ${b_status} (body: $(head -c 200 "$WORK_DIR/bad.json"))" ;;
+  esac
+fi
+
+begin_test "POST /sbom/check-compliance: allowed license -> compliant=true"
+if [ -z "$POLICY_ID" ]; then
+  skip "no policy id"
+else
+  ok_payload=$(jq -n '{licenses: ["MIT"]}')
+  o_status=$(curl -s -o "$WORK_DIR/ok.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -X POST -H "$(auth_header)" -H "Content-Type: application/json" \
+    -d "$ok_payload" \
+    "${BASE_URL}/api/v1/sbom/check-compliance") || o_status="000"
+  case "$o_status" in
+    404|501) skip "endpoint/policy not available (HTTP ${o_status})" ;;
+    200)
+      compliant=$(jq -r '.compliant // empty' "$WORK_DIR/ok.json")
+      if [ "$compliant" != "true" ]; then
+        fail "allowed license MIT returned compliant='${compliant}' (expected true). body: $(head -c 200 "$WORK_DIR/ok.json")"
+      else
+        pass
+      fi
+      ;;
+    *) fail "check-compliance returned HTTP ${o_status}" ;;
+  esac
+fi
+
+# ---------------------------------------------------------------------------
+# 2.9.f -- DELETE + GET-after-delete returns 404 (not 200, not 500).
+# ---------------------------------------------------------------------------
+
+begin_test "DELETE /sbom/license-policies/{id} returns 2xx"
+if [ -z "$POLICY_ID" ]; then
+  skip "no policy id"
+else
+  d_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+    -X DELETE -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/sbom/license-policies/${POLICY_ID}") || d_status="000"
+  case "$d_status" in
+    200|204)
+      pass
+      # Clear POLICY_ID so cleanup_policy doesn't double-DELETE (which
+      # would log a benign 404).
+      POLICY_ID=""
+      ;;
+    *) fail "DELETE returned HTTP ${d_status}" ;;
+  esac
+fi
+
+begin_test "GET-after-delete returns 404"
+# We saved the id before clearing POLICY_ID. Re-fetch from the create
+# response so we can assert the 404.
+GHOST_ID=$(jq -r '.id // empty' "$WORK_DIR/create.json" 2>/dev/null || echo "")
+if [ -z "$GHOST_ID" ]; then
+  skip "no original policy id to re-check"
+else
+  ga_status=$(curl -s -o "$WORK_DIR/ga.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" "${BASE_URL}/api/v1/sbom/license-policies/${GHOST_ID}") || ga_status="000"
+  case "$ga_status" in
+    404) pass ;;
+    200) fail "GET after DELETE returned 200 (policy still exists; DELETE was a no-op)" ;;
+    *) fail "GET after DELETE returned HTTP ${ga_status} (expected 404)" ;;
+  esac
+fi
+
+end_suite

--- a/tests/security/test-license-policy-crud.sh
+++ b/tests/security/test-license-policy-crud.sh
@@ -47,9 +47,12 @@ setup_workdir
 POLICY_NAME="e2e-lic-${RUN_ID}"
 POLICY_ID=""
 
-# Belt-and-suspenders cleanup: even if the DELETE test below succeeds,
-# a previous failed run can leave dangling rows. Look up by name on
-# entry and delete if found.
+# Cleanup: DELETE by id on exit if we still hold one. The DELETE test
+# below clears POLICY_ID on success so this is a no-op on the happy
+# path; the only case this guards is suite-aborts between create and
+# DELETE (network blip, fail). POLICY_NAME embeds RUN_ID so dangling
+# rows from previous runs cannot collide with this run -- no
+# name-lookup fallback is needed.
 cleanup_policy() {
   if [ -n "$POLICY_ID" ]; then
     # shellcheck disable=SC2086

--- a/tests/security/test-license-policy-crud.sh
+++ b/tests/security/test-license-policy-crud.sh
@@ -88,7 +88,7 @@ case "$c_status" in
   501|404)
     skip_suite "license policy endpoint not available (HTTP ${c_status})"
     ;;
-  200|201)
+  200)
     missing=""
     for field in id name allowed_licenses denied_licenses allow_unknown \
                  action is_enabled created_at; do
@@ -162,7 +162,7 @@ else
     -X POST -H "$(auth_header)" -H "Content-Type: application/json" \
     -d "$upd_payload" \
     "${BASE_URL}/api/v1/sbom/license-policies") || u_status="000"
-  if [ "$u_status" != "200" ] && [ "$u_status" != "201" ]; then
+  if [ "$u_status" != "200" ]; then
     fail "upsert returned HTTP ${u_status} (body: $(head -c 200 "$WORK_DIR/upd.json"))"
   else
     upd_id=$(jq -r '.id' "$WORK_DIR/upd.json")

--- a/tests/security/test-repo-scoped-scans.sh
+++ b/tests/security/test-repo-scoped-scans.sh
@@ -144,11 +144,16 @@ list_status=$(curl -s -o "$WORK_DIR/list.json" -w '%{http_code}' $CURL_TIMEOUT \
   -H "$(auth_header)" -H "Accept: application/json" \
   "${BASE_URL}/api/v1/repositories/${REPO_KEY}/security/scans") || list_status="000"
 
-if [ "$list_status" = "501" ] || [ "$list_status" = "404" ]; then
-  # 404 here would mean the repo-scoped scan endpoint is not mounted on
-  # this backend (some minimal stacks); skip the entire suite per
-  # contract (file header).
+if [ "$list_status" = "501" ]; then
+  # 501 means the repo-scoped scan endpoint is not mounted on this
+  # backend (some minimal stacks); skip the entire suite per contract
+  # (file header).
   skip "repo-scoped scans endpoint not available (HTTP ${list_status})"
+elif [ "$list_status" = "404" ]; then
+  # OpenAPI documents 404 as "repo not found" (spec line 7352). The
+  # repo was just created above; a 404 here means the create lied or
+  # the read path is broken. That's a regression, not a skip.
+  fail "repo-scoped scans listing returned 404 for just-created repo ${REPO_KEY} (OpenAPI documents 404 as repo-not-found; create succeeded so this is a regression)"
 elif [ "$list_status" = "200" ]; then
   # Required keys per ScanListResponse: items (array), total (integer).
   # next_page metadata: must be null/absent when total <= per_page (the

--- a/tests/security/test-repo-scoped-scans.sh
+++ b/tests/security/test-repo-scoped-scans.sh
@@ -151,12 +151,22 @@ if [ "$list_status" = "501" ] || [ "$list_status" = "404" ]; then
   skip "repo-scoped scans endpoint not available (HTTP ${list_status})"
 elif [ "$list_status" = "200" ]; then
   # Required keys per ScanListResponse: items (array), total (integer).
+  # next_page metadata: must be null/absent when total <= per_page (the
+  # default page contains the whole set); otherwise must be a number.
   if ! jq -e '.items | type == "array"' "$WORK_DIR/list.json" > /dev/null 2>&1; then
     fail "response missing items[] array (body: $(head -c 200 "$WORK_DIR/list.json"))"
   elif ! jq -e '.total | type == "number"' "$WORK_DIR/list.json" > /dev/null 2>&1; then
     fail "response missing total integer (body: $(head -c 200 "$WORK_DIR/list.json"))"
   else
-    pass
+    # The default page contains everything that exists in this fresh
+    # repo, so next_page must be null or absent. Either is acceptable
+    # per the documented shape.
+    np_type=$(jq -r 'if has("next_page") then (.next_page | type) else "absent" end' "$WORK_DIR/list.json")
+    if [ "$np_type" != "null" ] && [ "$np_type" != "absent" ]; then
+      fail "default page next_page='${np_type}' but total fits on one page (expected null/absent). body: $(head -c 200 "$WORK_DIR/list.json")"
+    else
+      pass
+    fi
   fi
 else
   fail "GET /repositories/${REPO_KEY}/security/scans returned HTTP ${list_status} (body: $(head -c 200 "$WORK_DIR/list.json" 2>/dev/null))"
@@ -168,7 +178,7 @@ fi
 # (b) page=999 returns an empty items[] but total is unchanged.
 # ---------------------------------------------------------------------------
 
-begin_test "Pagination: per_page=1 returns at most one item"
+begin_test "Pagination: per_page=1 returns at most one item, next_page reflects total"
 p1_status=$(curl -s -o "$WORK_DIR/p1.json" -w '%{http_code}' $CURL_TIMEOUT \
   -H "$(auth_header)" \
   "${BASE_URL}/api/v1/repositories/${REPO_KEY}/security/scans?page=1&per_page=1") || p1_status="000"
@@ -176,10 +186,27 @@ if [ "$p1_status" != "200" ]; then
   skip "endpoint not available (HTTP ${p1_status})"
 else
   count=$(jq -r '.items | length' "$WORK_DIR/p1.json" 2>/dev/null || echo "x")
-  if [[ "$count" =~ ^[0-9]+$ ]] && [ "$count" -le 1 ]; then
-    pass
-  else
+  total_p1_raw=$(jq -r '.total // 0' "$WORK_DIR/p1.json" 2>/dev/null || echo "0")
+  np_type=$(jq -r 'if has("next_page") then (.next_page | type) else "absent" end' "$WORK_DIR/p1.json")
+  np_val=$(jq -r '.next_page // empty' "$WORK_DIR/p1.json" 2>/dev/null || echo "")
+  if ! [[ "$count" =~ ^[0-9]+$ ]] || [ "$count" -gt 1 ]; then
     fail "per_page=1 returned ${count} items (expected 0 or 1)"
+  elif [ "$total_p1_raw" -gt 1 ]; then
+    # total > per_page -> next_page MUST be a number pointing at page 2.
+    if [ "$np_type" != "number" ]; then
+      fail "per_page=1 total=${total_p1_raw} but next_page type='${np_type}' (expected number)"
+    elif [ "$np_val" != "2" ]; then
+      fail "per_page=1 next_page='${np_val}' (expected 2 since we requested page=1)"
+    else
+      pass
+    fi
+  else
+    # total <= per_page -> next_page must be null or absent.
+    if [ "$np_type" != "null" ] && [ "$np_type" != "absent" ]; then
+      fail "per_page=1 total=${total_p1_raw} (single page) but next_page='${np_val}' type='${np_type}' (expected null/absent)"
+    else
+      pass
+    fi
   fi
 fi
 

--- a/tests/security/test-repo-scoped-scans.sh
+++ b/tests/security/test-repo-scoped-scans.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# test-repo-scoped-scans.sh - Repository-scoped scan endpoint E2E test.
+#
+# Covers Epic 2 sub-task 2.3 (artifact-keeper-test#67): the
+#   GET /api/v1/repositories/{key}/security/scans
+# endpoint that ships in v1.2.0 (customer pain #2 from discussion #872).
+#
+# Why a separate test
+# -------------------
+# The existing test-scan-findings-list.sh exercises the artifact-scoped
+# /security/scans?artifact_id=... path. The repo-scoped variant has its
+# own handler, its own routing, and its own pagination shape; a regression
+# in either one would silently make the UI "scans for this repo" tab
+# return either 404 or the wrong rows. We assert:
+#   1. 200 + documented ScanListResponse shape ({items: [...], total: N}).
+#   2. Pagination parameters page= / per_page= are honored.
+#   3. Filtering by status= returns only matching scans (or empty items
+#      with total unchanged if no matching scan exists).
+#   4. Unknown repo key -> 404 (not 500).
+#
+# Skip semantics
+# --------------
+# If the scanner is not configured on this stack the GET still works
+# (it just returns total=0), so this test is NOT scanner-gated. It IS
+# repo-create gated -- which is bedrock and would already have flagged
+# upstream in the gate.
+#
+# Self-test mode (EXPECT_FAILURE=1):
+#   Inverts the final exit code; same pattern as test-scan-findings-list.sh.
+#
+# Requires: curl, jq, shasum
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "repo-scoped-scans"
+auth_admin
+setup_workdir
+
+REPO_KEY="test-rscans-${RUN_ID}"
+IMAGE_NAME="rscans-target"
+UNIQUE_TAG="1.0.${RUN_ID}"
+# 60s leaves headroom under run-suite.sh's 120s TEST_TIMEOUT.
+SCAN_TIMEOUT="${SCAN_TIMEOUT:-60}"
+
+cleanup_repo() {
+  # shellcheck disable=SC2086  # CURL_TIMEOUT must word-split per common.sh
+  curl -sf $CURL_TIMEOUT -X DELETE -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/repositories/${REPO_KEY}" > /dev/null 2>&1 || true
+}
+add_exit_handler "cleanup_repo"
+
+# ---------------------------------------------------------------------------
+# Setup: create a docker repo + push a minimal manifest so a scan record
+# can plausibly exist. The point of this test is the listing endpoint
+# shape, not finding count, so we don't require the scanner to be wired.
+# ---------------------------------------------------------------------------
+
+begin_test "Create Docker/OCI repository"
+if create_local_repo "$REPO_KEY" "docker"; then
+  pass
+else
+  fail "could not create docker repo ${REPO_KEY}"
+  end_suite
+  exit 1
+fi
+
+# Push a manifest so an artifact (and potentially a scan) exists. We
+# tolerate failures from the registry path: the listing endpoint itself
+# is the load-bearing assertion and works with zero scans (total=0).
+begin_test "Obtain registry token (best-effort)"
+TOKEN=""
+token_resp=$(curl -sf -u "${ADMIN_USER}:${ADMIN_PASS}" "${BASE_URL}/v2/token" 2>/dev/null) || true
+if [ -n "$token_resp" ]; then TOKEN=$(echo "$token_resp" | jq -r '.token // empty'); fi
+if [ -n "$TOKEN" ]; then pass; else skip "no registry token; will test listing with zero scans"; fi
+
+if [ -n "$TOKEN" ]; then
+  begin_test "Push minimal OCI artifact"
+  CONFIG_CONTENT='{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]},"config":{}}'
+  CONFIG_DIGEST="sha256:$(printf '%s' "$CONFIG_CONTENT" | shasum -a 256 | awk '{print $1}')"
+  CONFIG_SIZE=${#CONFIG_CONTENT}
+
+  upload_resp=$(curl -s -D "$WORK_DIR/cfg-headers.txt" -o /dev/null \
+    -X POST -H "Authorization: Bearer $TOKEN" \
+    "${BASE_URL}/v2/${REPO_KEY}/${IMAGE_NAME}/blobs/uploads/" 2>/dev/null) || true
+  loc=$(grep -i '^location:' "$WORK_DIR/cfg-headers.txt" 2>/dev/null | tr -d '\r' | awk '{print $2}') || true
+  cfg_put="000"
+  if [ -n "$loc" ]; then
+    if [[ "$loc" == http* ]]; then put_url="$loc"; else put_url="${BASE_URL}${loc}"; fi
+    if [[ "$put_url" == *"?"* ]]; then put_url="${put_url}&digest=${CONFIG_DIGEST}"; else put_url="${put_url}?digest=${CONFIG_DIGEST}"; fi
+    cfg_put=$(curl -s -o /dev/null -w '%{http_code}' \
+      -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/octet-stream" \
+      -d "$CONFIG_CONTENT" "$put_url") || true
+  fi
+
+  dd if=/dev/urandom bs=1024 count=2 of="${WORK_DIR}/layer.bin" 2>/dev/null
+  LAYER_DIGEST="sha256:$(shasum -a 256 "${WORK_DIR}/layer.bin" | awk '{print $1}')"
+  LAYER_SIZE=$(wc -c < "${WORK_DIR}/layer.bin" | tr -d ' ')
+  layer_resp=$(curl -s -D "$WORK_DIR/lyr-headers.txt" -o /dev/null \
+    -X POST -H "Authorization: Bearer $TOKEN" \
+    "${BASE_URL}/v2/${REPO_KEY}/${IMAGE_NAME}/blobs/uploads/" 2>/dev/null) || true
+  lloc=$(grep -i '^location:' "$WORK_DIR/lyr-headers.txt" 2>/dev/null | tr -d '\r' | awk '{print $2}') || true
+  layer_put="000"
+  if [ -n "$lloc" ]; then
+    if [[ "$lloc" == http* ]]; then lput_url="$lloc"; else lput_url="${BASE_URL}${lloc}"; fi
+    if [[ "$lput_url" == *"?"* ]]; then lput_url="${lput_url}&digest=${LAYER_DIGEST}"; else lput_url="${lput_url}?digest=${LAYER_DIGEST}"; fi
+    layer_put=$(curl -s -o /dev/null -w '%{http_code}' \
+      -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/octet-stream" \
+      --data-binary "@${WORK_DIR}/layer.bin" "$lput_url") || true
+  fi
+
+  MANIFEST=$(cat <<EOFM
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": { "mediaType": "application/vnd.oci.image.config.v1+json", "digest": "${CONFIG_DIGEST}", "size": ${CONFIG_SIZE} },
+  "layers": [
+    { "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip", "digest": "${LAYER_DIGEST}", "size": ${LAYER_SIZE} }
+  ]
+}
+EOFM
+  )
+  manifest_status=$(curl -s -o /dev/null -w '%{http_code}' \
+    -X PUT -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/vnd.oci.image.manifest.v1+json" \
+    -d "$MANIFEST" \
+    "${BASE_URL}/v2/${REPO_KEY}/${IMAGE_NAME}/manifests/${UNIQUE_TAG}") || true
+  if [ "$cfg_put" = "201" ] && [ "$layer_put" = "201" ] && { [ "$manifest_status" = "201" ] || [ "$manifest_status" = "200" ]; }; then
+    pass
+  else
+    skip "OCI push incomplete (cfg=${cfg_put} layer=${layer_put} manifest=${manifest_status}); will test listing on empty repo"
+  fi
+
+  # Give the upload pipeline a chance to flush before we list scans.
+  sleep 3
+fi
+
+# ---------------------------------------------------------------------------
+# 2.3.a -- GET /api/v1/repositories/{key}/security/scans returns documented
+# ScanListResponse shape: {items: [...], total: integer}.
+# ---------------------------------------------------------------------------
+
+begin_test "GET /repositories/{key}/security/scans returns ScanListResponse shape"
+list_status=$(curl -s -o "$WORK_DIR/list.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" -H "Accept: application/json" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/security/scans") || list_status="000"
+
+if [ "$list_status" = "501" ] || [ "$list_status" = "404" ]; then
+  # 404 here would mean the repo-scoped scan endpoint is not mounted on
+  # this backend (some minimal stacks); skip the entire suite per
+  # contract (file header).
+  skip "repo-scoped scans endpoint not available (HTTP ${list_status})"
+elif [ "$list_status" = "200" ]; then
+  # Required keys per ScanListResponse: items (array), total (integer).
+  if ! jq -e '.items | type == "array"' "$WORK_DIR/list.json" > /dev/null 2>&1; then
+    fail "response missing items[] array (body: $(head -c 200 "$WORK_DIR/list.json"))"
+  elif ! jq -e '.total | type == "number"' "$WORK_DIR/list.json" > /dev/null 2>&1; then
+    fail "response missing total integer (body: $(head -c 200 "$WORK_DIR/list.json"))"
+  else
+    pass
+  fi
+else
+  fail "GET /repositories/${REPO_KEY}/security/scans returned HTTP ${list_status} (body: $(head -c 200 "$WORK_DIR/list.json" 2>/dev/null))"
+fi
+
+# ---------------------------------------------------------------------------
+# 2.3.b -- Pagination params are honored. We don't depend on a particular
+# scan existing; we assert (a) per_page=1 returns at most 1 item and
+# (b) page=999 returns an empty items[] but total is unchanged.
+# ---------------------------------------------------------------------------
+
+begin_test "Pagination: per_page=1 returns at most one item"
+p1_status=$(curl -s -o "$WORK_DIR/p1.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/security/scans?page=1&per_page=1") || p1_status="000"
+if [ "$p1_status" != "200" ]; then
+  skip "endpoint not available (HTTP ${p1_status})"
+else
+  count=$(jq -r '.items | length' "$WORK_DIR/p1.json" 2>/dev/null || echo "x")
+  if [[ "$count" =~ ^[0-9]+$ ]] && [ "$count" -le 1 ]; then
+    pass
+  else
+    fail "per_page=1 returned ${count} items (expected 0 or 1)"
+  fi
+fi
+
+begin_test "Pagination: page=999 returns empty items, total unchanged"
+total_p1=$(jq -r '.total // 0' "$WORK_DIR/p1.json" 2>/dev/null || echo "0")
+p999_status=$(curl -s -o "$WORK_DIR/p999.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/security/scans?page=999&per_page=10") || p999_status="000"
+if [ "$p999_status" != "200" ]; then
+  skip "endpoint not available (HTTP ${p999_status})"
+else
+  cnt=$(jq -r '.items | length' "$WORK_DIR/p999.json" 2>/dev/null || echo "x")
+  total_p999=$(jq -r '.total // 0' "$WORK_DIR/p999.json" 2>/dev/null || echo "0")
+  # total must be stable across pages -- not "0 on page=999 because the
+  # backend re-bound it to page-count instead of repo-count". We don't
+  # assert the exact value because it could legitimately be 0 (no scans
+  # yet) or N (scans flushed during the manifest push above).
+  if [ "$cnt" != "0" ]; then
+    fail "page=999 returned ${cnt} items (expected 0)"
+  elif [ "$total_p1" != "$total_p999" ]; then
+    fail "total changed across pages: page1=${total_p1} page999=${total_p999}"
+  else
+    pass
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2.3.c -- status= filter accepts a documented value without erroring.
+# We use "completed" because it's a documented terminal value; the
+# response may be empty if no scan reached that state yet.
+# ---------------------------------------------------------------------------
+
+begin_test "Filter: status=completed returns ScanListResponse shape"
+filt_status=$(curl -s -o "$WORK_DIR/filt.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/security/scans?status=completed") || filt_status="000"
+if [ "$filt_status" = "200" ]; then
+  if jq -e '.items | type == "array"' "$WORK_DIR/filt.json" > /dev/null 2>&1 \
+     && jq -e '.total | type == "number"' "$WORK_DIR/filt.json" > /dev/null 2>&1; then
+    pass
+  else
+    fail "filtered response missing items/total (body: $(head -c 200 "$WORK_DIR/filt.json"))"
+  fi
+else
+  skip "filter request returned HTTP ${filt_status}"
+fi
+
+# ---------------------------------------------------------------------------
+# 2.3.d -- Unknown repo key must return 404, not 500. This is the
+# documented response per openapi.yaml line 7352.
+# ---------------------------------------------------------------------------
+
+begin_test "Unknown repo key returns 404 (not 500)"
+nope_status=$(curl -s -o "$WORK_DIR/nope.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/does-not-exist-${RUN_ID}/security/scans") || nope_status="000"
+case "$nope_status" in
+  404) pass ;;
+  501) skip "endpoint not available (HTTP 501)" ;;
+  500|000) fail "expected 404 for unknown repo, got HTTP ${nope_status} (body: $(head -c 200 "$WORK_DIR/nope.json"))" ;;
+  *) fail "expected 404 for unknown repo, got HTTP ${nope_status}" ;;
+esac
+
+end_suite

--- a/tests/security/test-sbom-convert-and-components.sh
+++ b/tests/security/test-sbom-convert-and-components.sh
@@ -166,7 +166,7 @@ gen_status=$(curl -s -o "$WORK_DIR/gen.json" -w '%{http_code}' $CURL_TIMEOUT \
   "${BASE_URL}/api/v1/sbom") || gen_status="000"
 
 case "$gen_status" in
-  200|201)
+  200)
     SBOM_ID=$(jq -r '.id // empty' "$WORK_DIR/gen.json" 2>/dev/null || echo "")
     ORIGINAL_FORMAT=$(jq -r '.format // empty' "$WORK_DIR/gen.json" 2>/dev/null || echo "")
     if [ -n "$SBOM_ID" ]; then

--- a/tests/security/test-sbom-convert-and-components.sh
+++ b/tests/security/test-sbom-convert-and-components.sh
@@ -306,7 +306,13 @@ else
         fail "converted SbomResponse missing required field(s):${missing} (body: $(head -c 250 "$WORK_DIR/conv.json"))"
       elif [ -z "$new_format" ]; then
         fail "converted SBOM has empty format field"
-      elif [ -n "$ORIGINAL_FORMAT" ] && [ "$new_format" = "$ORIGINAL_FORMAT" ]; then
+      elif [ -z "$ORIGINAL_FORMAT" ]; then
+        # An SBOM that materialized successfully must carry a format
+        # field; an empty pre-convert format is a regression in
+        # SbomResponse, not a soft state we should silently skip past
+        # by shape-only checking the post-convert body.
+        fail "pre-convert SBOM has empty format field (regression: SbomResponse.format missing/null on generate or GET /sbom/{id})"
+      elif [ "$new_format" = "$ORIGINAL_FORMAT" ]; then
         fail "convert did not change format: original='${ORIGINAL_FORMAT}', after-convert='${new_format}' (target='${target_format}')"
       else
         pass

--- a/tests/security/test-sbom-convert-and-components.sh
+++ b/tests/security/test-sbom-convert-and-components.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# test-sbom-convert-and-components.sh - SBOM format conversion + components
+# enumeration E2E test.
+#
+# Covers Epic 2 sub-tasks 2.5 + 2.6 (artifact-keeper-test#67):
+#   POST /api/v1/sbom/{id}/convert      (CycloneDX <-> SPDX)
+#   GET  /api/v1/sbom/{id}/components
+# Ships in v1.2.0 (customer pain #2 from discussion #872 -- "SBOMs were
+# generated but never re-formatted or drilled into, so we trusted nothing").
+#
+# Flow
+# ----
+#   1. Create a generic repo, upload a tarball containing a npm
+#      package-lock.json (lodash) so the SBOM generator has real
+#      components to walk.
+#   2. Generate SBOM via POST /api/v1/sbom with {artifact_id, format:
+#      "cyclonedx"} (uses GenerateSbomRequest schema, line 13610).
+#   3. GET /api/v1/sbom/{id}/components and assert documented
+#      ComponentResponse shape (id, sbom_id, name, licenses[]) on each
+#      element and that the array is non-empty.
+#   4. POST /api/v1/sbom/{id}/convert with {target_format: "spdx"} and
+#      assert the response SbomResponse has format != original format
+#      and the documented top-level fields (id, format, format_version,
+#      component_count, generated_at) are present.
+#
+# Skip semantics
+# --------------
+# SBOM generation depends on the language-specific scanner being wired
+# (the npm/pypi walkers ship in v1.2.0 backends but local-dev compose
+# sometimes runs with the legacy image-only scanner). Per the file
+# header on test-scan-findings-list.sh, we skip() rather than fail()
+# so the gate stays clean on minimal stacks. Hard fail mode is reached
+# only when the generate succeeds but the convert / components handler
+# crashes.
+#
+# Self-test mode (EXPECT_FAILURE=1):
+#   Inverts the final exit code (end_suite handles this centrally).
+#
+# Requires: curl, jq, tar
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "sbom-convert-components"
+auth_admin
+setup_workdir
+
+REPO_KEY="test-sbom-cc-${RUN_ID}"
+PACKAGE_NAME="sbom-cc-fixture"
+PACKAGE_VERSION="1.0.0"
+TARBALL_NAME="${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz"
+ARTIFACT_PATH="${PACKAGE_NAME}/${PACKAGE_VERSION}/${TARBALL_NAME}"
+# Most SBOM generators finish in <30s on a healthy stack; budget 90s
+# leaves headroom under run-suite's 120s TEST_TIMEOUT.
+SBOM_TIMEOUT="${SBOM_TIMEOUT:-90}"
+SBOM_ID=""
+ORIGINAL_FORMAT=""
+
+cleanup_sbom_repo() {
+  if [ -n "$SBOM_ID" ]; then
+    # shellcheck disable=SC2086
+    curl -sf $CURL_TIMEOUT -X DELETE -H "$(auth_header)" \
+      "${BASE_URL}/api/v1/sbom/${SBOM_ID}" > /dev/null 2>&1 || true
+  fi
+  # shellcheck disable=SC2086
+  curl -sf $CURL_TIMEOUT -X DELETE -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/repositories/${REPO_KEY}" > /dev/null 2>&1 || true
+}
+add_exit_handler "cleanup_sbom_repo"
+
+# ---------------------------------------------------------------------------
+# Build fixture: minimal npm-style tarball with a known component
+# (lodash 4.17.21) so the SBOM generator emits at least one component
+# with a license field populated.
+# ---------------------------------------------------------------------------
+
+begin_test "Build npm-style fixture tarball"
+mkdir -p "${WORK_DIR}/pkg"
+cat > "${WORK_DIR}/pkg/package.json" <<'EOF'
+{
+  "name": "sbom-cc-fixture",
+  "version": "1.0.0",
+  "license": "MIT",
+  "dependencies": { "lodash": "4.17.21" }
+}
+EOF
+cat > "${WORK_DIR}/pkg/package-lock.json" <<'EOF'
+{
+  "name": "sbom-cc-fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sbom-cc-fixture",
+      "version": "1.0.0",
+      "dependencies": { "lodash": "4.17.21" }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    }
+  }
+}
+EOF
+if tar -czf "${WORK_DIR}/${TARBALL_NAME}" -C "${WORK_DIR}" pkg 2>/dev/null; then
+  pass
+else
+  fail "could not build fixture tarball"
+  end_suite
+  exit 1
+fi
+
+begin_test "Create generic local repository"
+if create_local_repo "$REPO_KEY" "generic"; then
+  pass
+else
+  fail "could not create ${REPO_KEY}"
+  end_suite
+  exit 1
+fi
+
+begin_test "Upload fixture artifact"
+upload_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+  -X PUT -H "$(auth_header)" -H "Content-Type: application/gzip" \
+  --data-binary "@${WORK_DIR}/${TARBALL_NAME}" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/${ARTIFACT_PATH}") || upload_status="000"
+case "$upload_status" in
+  200|201) pass ;;
+  *) fail "upload returned ${upload_status}"; end_suite; exit 1 ;;
+esac
+
+# Give the artifact pipeline a beat before we look it up.
+sleep 2
+
+begin_test "Resolve artifact_id"
+ARTIFACT_ID=""
+list_resp=$(api_get "/api/v1/repositories/${REPO_KEY}/artifacts" 2>/dev/null) || true
+if [ -n "$list_resp" ]; then
+  ARTIFACT_ID=$(echo "$list_resp" | jq -r --arg p "$ARTIFACT_PATH" --arg n "$PACKAGE_NAME" '
+    (if type == "array" then . elif .items then .items else [] end)
+    | map(select(((.path // "") == $p) or ((.name // "") | tostring | contains($n))))
+    | .[0].id // empty')
+fi
+if [ -n "$ARTIFACT_ID" ]; then
+  pass
+else
+  fail "could not resolve artifact_id (list_resp head: $(echo "$list_resp" | head -c 200))"
+  end_suite
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 2.5/2.6 prerequisite: generate an SBOM. If the generator is not wired
+# on this backend we skip the rest of the suite (the SBOM endpoints
+# require an SBOM ID; nothing to test without one). Backend returns
+# 404/501 for "no generator for format" today.
+# ---------------------------------------------------------------------------
+
+begin_test "Generate SBOM (cyclonedx) for fixture artifact"
+gen_payload=$(jq -n --arg id "$ARTIFACT_ID" '{artifact_id: $id, format: "cyclonedx"}')
+gen_status=$(curl -s -o "$WORK_DIR/gen.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -X POST -H "$(auth_header)" -H "Content-Type: application/json" \
+  -d "$gen_payload" \
+  "${BASE_URL}/api/v1/sbom") || gen_status="000"
+
+case "$gen_status" in
+  200|201)
+    SBOM_ID=$(jq -r '.id // empty' "$WORK_DIR/gen.json" 2>/dev/null || echo "")
+    ORIGINAL_FORMAT=$(jq -r '.format // empty' "$WORK_DIR/gen.json" 2>/dev/null || echo "")
+    if [ -n "$SBOM_ID" ]; then
+      pass
+    else
+      skip "SBOM generated but no id in response (body: $(head -c 200 "$WORK_DIR/gen.json"))"
+    fi
+    ;;
+  404|501|503)
+    skip "SBOM generator not configured (HTTP ${gen_status})"
+    ;;
+  *)
+    fail "POST /sbom returned HTTP ${gen_status} (body: $(head -c 200 "$WORK_DIR/gen.json"))"
+    ;;
+esac
+
+# Some backends return the SbomResponse synchronously, others queue and
+# require a follow-up GET. Poll briefly for the SBOM to materialize.
+if [ -n "$SBOM_ID" ]; then
+  begin_test "SBOM materializes (GET /sbom/{id} returns 200)"
+  elapsed=0
+  ready=0
+  while [ "$elapsed" -lt "$SBOM_TIMEOUT" ]; do
+    s=$(curl -s -o "$WORK_DIR/sbom.json" -w '%{http_code}' $CURL_TIMEOUT \
+      -H "$(auth_header)" "${BASE_URL}/api/v1/sbom/${SBOM_ID}") || s="000"
+    if [ "$s" = "200" ]; then
+      ready=1
+      ORIGINAL_FORMAT=$(jq -r '.format // empty' "$WORK_DIR/sbom.json" 2>/dev/null || echo "$ORIGINAL_FORMAT")
+      break
+    fi
+    sleep 3
+    elapsed=$(( elapsed + 3 ))
+  done
+  if [ "$ready" = "1" ]; then
+    pass
+  else
+    skip "SBOM not retrievable within ${SBOM_TIMEOUT}s; last status=${s}"
+    SBOM_ID=""
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2.6 -- GET /api/v1/sbom/{id}/components returns array of
+# ComponentResponse. Required fields per openapi.yaml line 11474:
+#   id (uuid), sbom_id (uuid), name (string), licenses (array of string).
+# ---------------------------------------------------------------------------
+
+begin_test "GET /sbom/{id}/components returns ComponentResponse[]"
+if [ -z "$SBOM_ID" ]; then
+  skip "no SBOM id"
+else
+  comp_status=$(curl -s -o "$WORK_DIR/comp.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" "${BASE_URL}/api/v1/sbom/${SBOM_ID}/components") || comp_status="000"
+  if [ "$comp_status" = "501" ] || [ "$comp_status" = "404" ]; then
+    skip "components endpoint not available (HTTP ${comp_status})"
+  elif [ "$comp_status" != "200" ]; then
+    fail "GET /sbom/${SBOM_ID}/components returned HTTP ${comp_status} (body: $(head -c 200 "$WORK_DIR/comp.json"))"
+  else
+    # Must be an array.
+    if ! jq -e 'type == "array"' "$WORK_DIR/comp.json" > /dev/null 2>&1; then
+      fail "components response is not an array (body: $(head -c 200 "$WORK_DIR/comp.json"))"
+    else
+      n=$(jq -r 'length' "$WORK_DIR/comp.json")
+      if [ "$n" -lt 1 ]; then
+        # Empty array is suspicious for a fixture with a known package-lock
+        # entry, but possible if the SBOM generator only walks runtime
+        # artifacts. Skip rather than fail.
+        skip "components array empty (n=0); SBOM generator may not walk this fixture format"
+      else
+        # Spot-check first element has the required ComponentResponse shape.
+        uuid_re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+        first_id=$(jq -r '.[0].id // empty' "$WORK_DIR/comp.json")
+        first_sbom_id=$(jq -r '.[0].sbom_id // empty' "$WORK_DIR/comp.json")
+        first_name=$(jq -r '.[0].name // empty' "$WORK_DIR/comp.json")
+        first_licenses_type=$(jq -r '.[0].licenses | type' "$WORK_DIR/comp.json")
+        if ! [[ "$first_id" =~ $uuid_re ]]; then
+          fail "components[0].id='${first_id}' is not a UUID"
+        elif [ "$first_sbom_id" != "$SBOM_ID" ]; then
+          fail "components[0].sbom_id='${first_sbom_id}' != requested SBOM '${SBOM_ID}'"
+        elif [ -z "$first_name" ]; then
+          fail "components[0].name is empty"
+        elif [ "$first_licenses_type" != "array" ]; then
+          fail "components[0].licenses is type=${first_licenses_type} (expected array)"
+        else
+          pass
+        fi
+      fi
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2.5 -- POST /api/v1/sbom/{id}/convert with {target_format: "spdx"}
+# returns a SbomResponse whose format differs from the original.
+# Required top-level fields per openapi.yaml line 16517:
+#   id, artifact_id, repository_id, format, format_version,
+#   component_count, dependency_count, license_count, licenses[],
+#   content_hash, generated_at, created_at.
+# ---------------------------------------------------------------------------
+
+begin_test "POST /sbom/{id}/convert CycloneDX -> SPDX returns SbomResponse"
+if [ -z "$SBOM_ID" ]; then
+  skip "no SBOM id"
+else
+  # Pick a target_format that differs from the original. We requested
+  # cyclonedx above; if the backend normalized that string differently
+  # (e.g. "CycloneDX" vs "cyclonedx") we still expect format to change
+  # to spdx after a convert.
+  target_format="spdx"
+  conv_payload=$(jq -n --arg t "$target_format" '{target_format: $t}')
+  conv_status=$(curl -s -o "$WORK_DIR/conv.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -X POST -H "$(auth_header)" -H "Content-Type: application/json" \
+    -d "$conv_payload" \
+    "${BASE_URL}/api/v1/sbom/${SBOM_ID}/convert") || conv_status="000"
+
+  case "$conv_status" in
+    501|404)
+      skip "convert endpoint not available (HTTP ${conv_status})"
+      ;;
+    422)
+      # 422 could mean "target_format=spdx not supported on this build".
+      # That's a legitimate disabled-feature signal -- skip not fail.
+      skip "convert rejected target_format=${target_format} (HTTP 422, body: $(head -c 200 "$WORK_DIR/conv.json"))"
+      ;;
+    200)
+      # Required SbomResponse fields.
+      missing=""
+      for field in id artifact_id repository_id format format_version \
+                   component_count dependency_count license_count \
+                   licenses content_hash generated_at created_at; do
+        if ! jq -e --arg f "$field" 'has($f) and (.[$f] != null)' "$WORK_DIR/conv.json" > /dev/null 2>&1; then
+          missing="${missing} ${field}"
+        fi
+      done
+      new_format=$(jq -r '.format // empty' "$WORK_DIR/conv.json")
+      if [ -n "$missing" ]; then
+        fail "converted SbomResponse missing required field(s):${missing} (body: $(head -c 250 "$WORK_DIR/conv.json"))"
+      elif [ -z "$new_format" ]; then
+        fail "converted SBOM has empty format field"
+      elif [ -n "$ORIGINAL_FORMAT" ] && [ "$new_format" = "$ORIGINAL_FORMAT" ]; then
+        fail "convert did not change format: original='${ORIGINAL_FORMAT}', after-convert='${new_format}' (target='${target_format}')"
+      else
+        pass
+      fi
+      ;;
+    *)
+      fail "POST /sbom/${SBOM_ID}/convert returned HTTP ${conv_status} (body: $(head -c 200 "$WORK_DIR/conv.json"))"
+      ;;
+  esac
+fi
+
+end_suite

--- a/tests/security/test-scan-policy-crud.sh
+++ b/tests/security/test-scan-policy-crud.sh
@@ -94,7 +94,7 @@ c_status=$(curl -s -o "$WORK_DIR/create.json" -w '%{http_code}' $CURL_TIMEOUT \
   -d "$create_payload" \
   "${BASE_URL}/api/v1/security/policies") || c_status="000"
 case "$c_status" in
-  200|201)
+  200)
     POLICY_ID=$(jq -r '.id // empty' "$WORK_DIR/create.json")
     uuid_re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
     missing=""

--- a/tests/security/test-scan-policy-crud.sh
+++ b/tests/security/test-scan-policy-crud.sh
@@ -177,14 +177,19 @@ begin_test "PUT /security/policies/{id} updates max_severity AND is_enabled"
 if [ -z "$POLICY_ID" ]; then
   skip "no policy id"
 else
+  # Regression guard for the file-header bug class: PUT silently dropped
+  # min_staging_hours / max_artifact_age_days. If we re-send the same
+  # values used at create, a buggy PUT that ignores those columns would
+  # still pass the GET-after-PUT check (the row already has those
+  # values). Send DIFFERENT values so a regression fails loudly here.
   upd_payload=$(jq -n --arg n "$POLICY_NAME" '{
     name: $n,
     max_severity: "critical",
     block_unscanned: true,
     block_on_fail: true,
     is_enabled: false,
-    max_artifact_age_days: 30,
-    min_staging_hours: 24,
+    max_artifact_age_days: 60,
+    min_staging_hours: 48,
     require_signature: false
   }')
   u_status=$(curl -s -o "$WORK_DIR/upd.json" -w '%{http_code}' $CURL_TIMEOUT \
@@ -196,10 +201,16 @@ else
   else
     upd_sev=$(jq -r '.max_severity // empty' "$WORK_DIR/upd.json")
     upd_en=$(jq -r '.is_enabled // empty' "$WORK_DIR/upd.json")
+    upd_stag=$(jq -r '.min_staging_hours // empty' "$WORK_DIR/upd.json")
+    upd_age=$(jq -r '.max_artifact_age_days // empty' "$WORK_DIR/upd.json")
     if [ "$upd_sev" != "critical" ]; then
       fail "max_severity did not update: expected 'critical' got '${upd_sev}'"
     elif [ "$upd_en" != "false" ]; then
       fail "is_enabled did not update: expected false got '${upd_en}' (regression: PUT dropped 2nd-and-later fields)"
+    elif [ "$upd_stag" != "48" ]; then
+      fail "min_staging_hours did not update: expected 48 got '${upd_stag}' (regression: PUT silently dropped this column)"
+    elif [ "$upd_age" != "60" ]; then
+      fail "max_artifact_age_days did not update: expected 60 got '${upd_age}' (regression: PUT silently dropped this column)"
     else
       pass
     fi
@@ -222,8 +233,18 @@ else
   else
     sev=$(jq -r '.max_severity // empty' "$WORK_DIR/g2.json")
     en=$(jq -r '.is_enabled // empty' "$WORK_DIR/g2.json")
+    stag=$(jq -r '.min_staging_hours // empty' "$WORK_DIR/g2.json")
+    age=$(jq -r '.max_artifact_age_days // empty' "$WORK_DIR/g2.json")
+    # Assert the NEW values from PUT, not the create-row values: the
+    # whole point of the changed-values regression guard above is that
+    # a buggy PUT that silently drops min_staging_hours /
+    # max_artifact_age_days must fail loudly here.
     if [ "$sev" != "critical" ] || [ "$en" != "false" ]; then
       fail "post-PUT GET shows stale data: max_severity='${sev}' is_enabled='${en}' (expected 'critical', false)"
+    elif [ "$stag" != "48" ]; then
+      fail "post-PUT GET min_staging_hours='${stag}' (expected 48 -- PUT silently dropped this column)"
+    elif [ "$age" != "60" ]; then
+      fail "post-PUT GET max_artifact_age_days='${age}' (expected 60 -- PUT silently dropped this column)"
     else
       pass
     fi

--- a/tests/security/test-scan-policy-crud.sh
+++ b/tests/security/test-scan-policy-crud.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# test-scan-policy-crud.sh - Scan (security) policy CRUD E2E test.
+#
+# Covers Epic 2 sub-task 2.10 part 1 (artifact-keeper-test#67):
+#   GET    /api/v1/security/policies
+#   POST   /api/v1/security/policies
+#   GET    /api/v1/security/policies/{id}
+#   PUT    /api/v1/security/policies/{id}
+#   DELETE /api/v1/security/policies/{id}
+# Ships in v1.2.0 (customer pain #2 -- "security policy CRUD existed in
+# code but was never E2E-asserted; we found two regressions where PUT
+# silently lost min_staging_hours / max_artifact_age_days").
+#
+# The companion "policy actually blocks upload on violation" sub-task is
+# tracked separately under test-quality-gate-enforcement.sh + future work;
+# this script is the CRUD half so a release gate that breaks DELETE or
+# PUT fails loudly here rather than waiting for a customer to file
+# a bug.
+#
+# Flow (create -> list -> get -> update -> get -> delete -> 404)
+# --------------------------------------------------------------
+#   1. POST with CreatePolicyRequest. Capture POLICY_ID.
+#      Required PolicyResponse fields per openapi.yaml line 15542:
+#        id, name, max_severity, block_unscanned, block_on_fail,
+#        is_enabled, require_signature, created_at, updated_at.
+#   2. GET list -- assert array contains our id.
+#   3. GET by id -- assert returns our policy.
+#   4. PUT with UpdatePolicyRequest changing max_severity from "high"
+#      to "critical" + is_enabled from true to false. Assert the
+#      response reflects BOTH changes. (Regression guard: an earlier
+#      PUT impl only updated the first field.)
+#   5. GET by id -- assert update persisted.
+#   6. DELETE -- assert 2xx.
+#   7. GET by id -- assert 404.
+#
+# Skip semantics
+# --------------
+# Hard-fail on 5xx or shape mismatches. skip_suite if the endpoint set
+# itself is not mounted (501/404 on the LIST). No scanner dependency.
+#
+# Self-test mode (EXPECT_FAILURE=1):
+#   Inverts the final exit code.
+#
+# Requires: curl, jq
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "scan-policy-crud"
+auth_admin
+setup_workdir
+
+POLICY_NAME="e2e-scan-policy-${RUN_ID}"
+POLICY_ID=""
+
+cleanup_policy() {
+  if [ -n "$POLICY_ID" ]; then
+    # shellcheck disable=SC2086
+    curl -sf $CURL_TIMEOUT -X DELETE -H "$(auth_header)" \
+      "${BASE_URL}/api/v1/security/policies/${POLICY_ID}" > /dev/null 2>&1 || true
+  fi
+}
+add_exit_handler "cleanup_policy"
+
+# ---------------------------------------------------------------------------
+# Pre-flight: confirm the endpoint set is mounted. We pick LIST (cheap,
+# read-only, no body) and gracefully skip_suite if it's 501/404.
+# ---------------------------------------------------------------------------
+
+begin_test "Pre-flight: GET /security/policies is mounted"
+pf_status=$(curl -s -o "$WORK_DIR/pf.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" "${BASE_URL}/api/v1/security/policies") || pf_status="000"
+case "$pf_status" in
+  200) pass ;;
+  501|404) skip_suite "security policies endpoint not available (HTTP ${pf_status})" ;;
+  *) fail "pre-flight LIST returned HTTP ${pf_status} (body: $(head -c 200 "$WORK_DIR/pf.json"))" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 2.10.a -- POST creates a policy.
+# ---------------------------------------------------------------------------
+
+begin_test "POST /security/policies creates a policy"
+create_payload=$(jq -n --arg n "$POLICY_NAME" '{
+  name: $n,
+  max_severity: "high",
+  block_unscanned: true,
+  block_on_fail: true,
+  max_artifact_age_days: 30,
+  min_staging_hours: 24,
+  require_signature: false
+}')
+c_status=$(curl -s -o "$WORK_DIR/create.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -X POST -H "$(auth_header)" -H "Content-Type: application/json" \
+  -d "$create_payload" \
+  "${BASE_URL}/api/v1/security/policies") || c_status="000"
+case "$c_status" in
+  200|201)
+    POLICY_ID=$(jq -r '.id // empty' "$WORK_DIR/create.json")
+    uuid_re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+    missing=""
+    for field in id name max_severity block_unscanned block_on_fail \
+                 is_enabled require_signature created_at updated_at; do
+      if ! jq -e --arg f "$field" 'has($f)' "$WORK_DIR/create.json" > /dev/null 2>&1; then
+        missing="${missing} ${field}"
+      fi
+    done
+    if [ -n "$missing" ]; then
+      fail "create response missing required field(s):${missing} (body: $(head -c 250 "$WORK_DIR/create.json"))"
+    elif ! [[ "$POLICY_ID" =~ $uuid_re ]]; then
+      fail "policy id '${POLICY_ID}' is not a UUID"
+    else
+      pass
+    fi
+    ;;
+  *)
+    fail "POST returned HTTP ${c_status} (body: $(head -c 250 "$WORK_DIR/create.json"))"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 2.10.b -- GET list contains our policy.
+# ---------------------------------------------------------------------------
+
+begin_test "GET /security/policies contains created policy"
+if [ -z "$POLICY_ID" ]; then
+  skip "no policy id"
+else
+  l_status=$(curl -s -o "$WORK_DIR/list.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" "${BASE_URL}/api/v1/security/policies") || l_status="000"
+  if [ "$l_status" != "200" ]; then
+    fail "list returned HTTP ${l_status}"
+  elif ! jq -e --arg id "$POLICY_ID" 'any(.id == $id)' "$WORK_DIR/list.json" > /dev/null 2>&1; then
+    fail "list does not contain id=${POLICY_ID}"
+  else
+    pass
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2.10.c -- GET by id returns the policy we created.
+# ---------------------------------------------------------------------------
+
+begin_test "GET /security/policies/{id} returns created policy"
+if [ -z "$POLICY_ID" ]; then
+  skip "no policy id"
+else
+  g_status=$(curl -s -o "$WORK_DIR/get.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" "${BASE_URL}/api/v1/security/policies/${POLICY_ID}") || g_status="000"
+  if [ "$g_status" != "200" ]; then
+    fail "GET returned HTTP ${g_status}"
+  else
+    got_id=$(jq -r '.id // empty' "$WORK_DIR/get.json")
+    got_sev=$(jq -r '.max_severity // empty' "$WORK_DIR/get.json")
+    got_stag=$(jq -r '.min_staging_hours // empty' "$WORK_DIR/get.json")
+    got_age=$(jq -r '.max_artifact_age_days // empty' "$WORK_DIR/get.json")
+    if [ "$got_id" != "$POLICY_ID" ]; then
+      fail "id mismatch: expected '${POLICY_ID}' got '${got_id}'"
+    elif [ "$got_sev" != "high" ]; then
+      fail "max_severity did not round-trip on create: expected 'high' got '${got_sev}'"
+    elif [ "$got_stag" != "24" ]; then
+      fail "min_staging_hours did not round-trip: expected 24 got '${got_stag}'"
+    elif [ "$got_age" != "30" ]; then
+      fail "max_artifact_age_days did not round-trip: expected 30 got '${got_age}'"
+    else
+      pass
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2.10.d -- PUT updates multiple fields in one request. Regression
+# guard: we change BOTH max_severity AND is_enabled; older PUT impl
+# only persisted the first field.
+# ---------------------------------------------------------------------------
+
+begin_test "PUT /security/policies/{id} updates max_severity AND is_enabled"
+if [ -z "$POLICY_ID" ]; then
+  skip "no policy id"
+else
+  upd_payload=$(jq -n --arg n "$POLICY_NAME" '{
+    name: $n,
+    max_severity: "critical",
+    block_unscanned: true,
+    block_on_fail: true,
+    is_enabled: false,
+    max_artifact_age_days: 30,
+    min_staging_hours: 24,
+    require_signature: false
+  }')
+  u_status=$(curl -s -o "$WORK_DIR/upd.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -X PUT -H "$(auth_header)" -H "Content-Type: application/json" \
+    -d "$upd_payload" \
+    "${BASE_URL}/api/v1/security/policies/${POLICY_ID}") || u_status="000"
+  if [ "$u_status" != "200" ]; then
+    fail "PUT returned HTTP ${u_status} (body: $(head -c 200 "$WORK_DIR/upd.json"))"
+  else
+    upd_sev=$(jq -r '.max_severity // empty' "$WORK_DIR/upd.json")
+    upd_en=$(jq -r '.is_enabled // empty' "$WORK_DIR/upd.json")
+    if [ "$upd_sev" != "critical" ]; then
+      fail "max_severity did not update: expected 'critical' got '${upd_sev}'"
+    elif [ "$upd_en" != "false" ]; then
+      fail "is_enabled did not update: expected false got '${upd_en}' (regression: PUT dropped 2nd-and-later fields)"
+    else
+      pass
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2.10.e -- GET-after-PUT confirms the update was actually persisted
+# (not just returned in the PUT response from a cached object).
+# ---------------------------------------------------------------------------
+
+begin_test "GET-after-PUT confirms persistence"
+if [ -z "$POLICY_ID" ]; then
+  skip "no policy id"
+else
+  g2_status=$(curl -s -o "$WORK_DIR/g2.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" "${BASE_URL}/api/v1/security/policies/${POLICY_ID}") || g2_status="000"
+  if [ "$g2_status" != "200" ]; then
+    fail "GET-after-PUT returned HTTP ${g2_status}"
+  else
+    sev=$(jq -r '.max_severity // empty' "$WORK_DIR/g2.json")
+    en=$(jq -r '.is_enabled // empty' "$WORK_DIR/g2.json")
+    if [ "$sev" != "critical" ] || [ "$en" != "false" ]; then
+      fail "post-PUT GET shows stale data: max_severity='${sev}' is_enabled='${en}' (expected 'critical', false)"
+    else
+      pass
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2.10.f -- DELETE returns 2xx; GET-after-DELETE returns 404.
+# ---------------------------------------------------------------------------
+
+begin_test "DELETE /security/policies/{id} returns 2xx"
+if [ -z "$POLICY_ID" ]; then
+  skip "no policy id"
+else
+  d_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+    -X DELETE -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/security/policies/${POLICY_ID}") || d_status="000"
+  case "$d_status" in
+    200|204)
+      pass
+      GHOST_ID="$POLICY_ID"
+      POLICY_ID=""
+      ;;
+    *) fail "DELETE returned HTTP ${d_status}" ;;
+  esac
+fi
+
+begin_test "GET-after-DELETE returns 404"
+if [ -z "${GHOST_ID:-}" ]; then
+  skip "no deleted policy id to re-check"
+else
+  ga_status=$(curl -s -o "$WORK_DIR/ga.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" "${BASE_URL}/api/v1/security/policies/${GHOST_ID}") || ga_status="000"
+  case "$ga_status" in
+    404) pass ;;
+    200) fail "GET after DELETE returned 200 (DELETE was a no-op)" ;;
+    *) fail "GET after DELETE returned HTTP ${ga_status} (expected 404)" ;;
+  esac
+fi
+
+end_suite


### PR DESCRIPTION
## Summary

Adds E2E coverage for Epic 2 (security scanning depth) sub-tasks landing in v1.2.0, per issue #67. Five new test scripts under `tests/security/`, each sourcing `tests/lib/common.sh`, scoping resources by `RUN_ID`, and installing cleanup via `add_exit_handler`.

## Delivered sub-tasks

- **2.3** `test-repo-scoped-scans.sh` -- `GET /api/v1/repositories/{key}/security/scans` ScanListResponse shape, pagination (`per_page=1`, `page=999` empty + total stable), `status=` filter, and unknown-key 404 path.
- **2.5** `test-sbom-convert-and-components.sh` (part 1) -- `POST /api/v1/sbom/{id}/convert` CycloneDX -> SPDX returns SbomResponse with required top-level fields and a changed `format`.
- **2.6** `test-sbom-convert-and-components.sh` (part 2) -- `GET /api/v1/sbom/{id}/components` returns ComponentResponse[] with required `{id, sbom_id, name, licenses}` on each element; uploads a real npm fixture so the array is non-empty.
- **2.8** `test-cve-history-trends-status.sh` -- CVE history (CveHistoryEntry shape), trends (CveTrends counts), and status update round-trip (`status=acknowledged` + reason).
- **2.9** `test-license-policy-crud.sh` -- License policy create -> list -> upsert-as-update -> get -> compliance check (allow + deny) -> delete -> 404.
- **2.10** `test-scan-policy-crud.sh` -- Security policy create -> list -> get -> PUT (multi-field regression guard for `max_severity` + `is_enabled`) -> GET-after-PUT -> delete -> 404.

## Explicitly deferred (per issue body)

Tests do **not** depend on `scanner_version`, `scan_result_id`, or `is_reused` (deferred to backend artifact-keeper#902, #906, #907).

Out of scope for this PR (larger fixtures or separate epics):

- 2.4 reuse-via-checksum
- 2.7 SBOM by-artifact (covered by existing sbom-correctness-gate)
- 2.10 part 2: scan policy actually blocks on violation (composed test pending)
- 2.11 DependencyTrack (9 endpoints)
- 2.12 auto-scan-on-upload trigger (covered indirectly by existing scan-completes)
- 2.13 cron / 2.14 OpenSCAP / 2.15 Grype / 2.16 quality-gate-blocks

## Skip semantics

Each test skips gracefully on 404/501 when an optional component (scanner, SBOM generator, license-policy module) is not mounted on the target stack. Endpoint shape assertions still run on minimal stacks (where applicable), so a release-gate run never reports silent-success when these endpoints break.

## Test plan

- [ ] `bash -n` passes on all 5 new files (verified locally)
- [ ] Each test executes against a full stack and records PASS/SKIP/FAIL into JUnit
- [ ] Each test executes against a minimal stack and skip()s cleanly (no FAIL)
- [ ] Resources created by `RUN_ID` are deleted by the EXIT handler on success and on interrupt
- [ ] No new dependency added to `tests/lib/common.sh`, `release-gate.yml`, or other shared infra