### PR TITLE
fix(pullthrough,drift): close 4 quality gaps from #152 post-merge review

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1047,6 +1047,14 @@ jobs:
       # A silently-skipped test in release-gate context is exactly the
       # silent-success class (#870/#871/#888) the gate exists to catch.
       RELEASE_GATE: '1'
+      # Per-script timeout for run-suite.sh. SCAN_TIMEOUT defaults to
+      # 180s in test-stuck-scan-janitor.sh and the scan-depth scripts;
+      # virtual-shadowing-guard.sh walks 6 formats serially. The default
+      # 120s budget will SIGTERM polls mid-flight on a slightly slow
+      # backend, masking real signal with timeout failures. 300s gives
+      # ~2x headroom over the worst per-script case and matches the
+      # security-tests / webhook-tests jobs.
+      TEST_TIMEOUT: '300'
       # AK_BACKEND_BRANCH feeds the branch-aware feature flag layer
       # in tests/lib/feature-flags.sh (issue #65). We derive the branch
       # from the backend image tag: a tag like `1.1.9` or `1.1.10-rc.2`

--- a/tests/lib/feature-flags.sh
+++ b/tests/lib/feature-flags.sh
@@ -151,10 +151,15 @@ feature_flags_init() {
     main|master)
       raw="$AK_BACKEND_BRANCH_MAIN"
       ;;
-    release/1.1.x|release/1.1*|v1.1.*|1.1.*)
+    release/1.1.x|release/1.1.*|v1.1.*|1.1.*)
+      # Anchored on the third `.` to avoid the moment-1.10-ships footgun:
+      # the looser `release/1.1*` form also matches `release/1.10.x` /
+      # `release/1.11.x` lexically, so a future 1.10 branch would map to
+      # the 1.1.x flag set instead of either main or its own bundle.
       raw="$AK_BACKEND_BRANCH_1_1_X"
       ;;
-    release/1.2.x|release/1.2*|v1.2.*|1.2.*)
+    release/1.2.x|release/1.2.*|v1.2.*|1.2.*)
+      # Same anchoring as 1.1.x above: `release/1.2.*` not `release/1.2*`.
       raw="$AK_BACKEND_BRANCH_1_2_X"
       ;;
     *)

--- a/tests/pullthrough/test-virtual-shadowing-guard.sh
+++ b/tests/pullthrough/test-virtual-shadowing-guard.sh
@@ -286,7 +286,17 @@ run_native_block() {
     # path, not a refusal.
     case "$http_status" in
       4*)
+        # The guard correctly refused to serve. We count this as an
+        # observation toward the floor assertion: the suite verified
+        # that for this format the virtual either served the trusted
+        # bytes (success branch below) OR refused outright. If we did
+        # NOT count refusals, a backend that 404s on every native
+        # format (e.g. handler routing regression) would skip all 6
+        # native blocks and trip the MIN_FORMATS_OBSERVED floor for
+        # the wrong reason, drowning the real signal in a misleading
+        # failure mode.
         skip "format ${format} virtual returned HTTP ${http_status}; guard may refuse to serve until both members agree (acceptable refuse-class)"
+        _record_observed
         return 0
         ;;
       5*|000)

--- a/tests/security/test-feature-flag-drift.sh
+++ b/tests/security/test-feature-flag-drift.sh
@@ -43,16 +43,22 @@ fi
 # Fetch /health. We bypass auth_admin because /health is unauth and
 # the drift check runs before any other suite logic; if /health is
 # broken we want a precise reason in the failure message.
+#
+# Use mktemp so two concurrent invocations of this script on the same
+# runner pod cannot race on a shared /tmp path. The previous form
+# (/tmp/.health-resp.$$) was unique per PID but not per concurrent
+# invocation when run-suite.sh fans out (CLAUDE.md /tmp hygiene rule).
 begin_test "Fetch /health"
 health_resp=""
-http_status=$(curl -s -o /tmp/.health-resp.$$ -w '%{http_code}' --max-time 5 \
+health_resp_file=$(mktemp -t health-resp.XXXXXXXX)
+http_status=$(curl -s -o "${health_resp_file}" -w '%{http_code}' --max-time 5 \
     "${BASE_URL}/health" 2>/dev/null) || http_status="000"
 if [ "$http_status" = "200" ]; then
-  health_resp=$(cat /tmp/.health-resp.$$ 2>/dev/null || echo "")
-  rm -f /tmp/.health-resp.$$
+  health_resp=$(cat "${health_resp_file}" 2>/dev/null || echo "")
+  rm -f "${health_resp_file}"
   pass
 else
-  rm -f /tmp/.health-resp.$$
+  rm -f "${health_resp_file}"
   fail "GET ${BASE_URL}/health returned HTTP ${http_status}; cannot drift-check"
 fi
 
@@ -104,9 +110,9 @@ case "$AK_BACKEND_BRANCH" in
     # last-released minor we know about".
     allow_main_markers=1
     ;;
-  release/1.1.x|release/1.1*|v1.1.*|1.1.*)
+  release/1.1.x|release/1.1.*|v1.1.*|1.1.*)
     expected_major=1; expected_minor=1 ;;
-  release/1.2.x|release/1.2*|v1.2.*|1.2.*)
+  release/1.2.x|release/1.2.*|v1.2.*|1.2.*)
     expected_major=1; expected_minor=2 ;;
   *)
     # Already warned by feature_flags_init; let the assertion still


### PR DESCRIPTION
## Summary

Independent agent review of [#152](https://github.com/artifact-keeper/artifact-keeper-test/pull/152) (pull-through cache + scan depth + misc E2E, merged 2026-05-16) surfaced 4 issues in the merged code. None of these change behavior of the production backend; they are CI/test-side fixes that prevent the new gate from masking real signal with infrastructure noise.

Local checks: `bash -n` clean on all 3 shell scripts, `python3 -c 'import yaml; yaml.safe_load(...)'` clean on the workflow.

## The 4 fixes

### 1. `release-gate.yml` pullthrough-tests: add `TEST_TIMEOUT=300`

The job had no `TEST_TIMEOUT` set, so `scripts/run-suite.sh` was defaulting to 120s per script. But:

- `tests/security/test-scan-depth-{dependency,os,persistence}.sh`: `SCAN_TIMEOUT=180`
- `tests/pullthrough/test-stuck-scan-janitor.sh`: `SCAN_TIMEOUT=180`
- `tests/pullthrough/test-virtual-shadowing-guard.sh`: 6 format roundtrips serially

On a slightly slow backend, polls get SIGTERM'd mid-flight and the suite reports a wrong-reason timeout failure instead of the real scan state. 300s gives ~2x headroom over the worst per-script case and matches the security-tests / webhook-tests jobs.

### 2. `tests/security/test-feature-flag-drift.sh`: replace `/tmp/.health-resp.$$` with `mktemp`

Per the workspace CLAUDE.md `/tmp` hygiene rule. `$$` is unique per process but the same shell can fork this script through `run-suite.sh` fan-out and reuse it, racing on the shared path. `mktemp -t` is unique per invocation and respects `TMPDIR`.

### 3. Glob pattern footgun in `feature-flags.sh` and `test-feature-flag-drift.sh`

Pattern was `release/1.1.x|release/1.1*|v1.1.*|1.1.*`. The unanchored `release/1.1*` lexically matches future `release/1.10.x` and `release/1.11.x` branches when they ship, silently mapping them into the 1.1.x feature-flag bundle instead of detecting the new branch and warning. Same fix on the 1.2 line.

`v1.1.*` and `1.1.*` (without `release/`) were already correctly anchored by the literal dot — `v1.10` doesn't match `v1.1.` because the dot constraint fails at character position 4.

### 4. `test-virtual-shadowing-guard.sh`: call `_record_observed` in the 4xx skip arm

The 4xx 'guard correctly refused to serve' arm `return 0`'d without incrementing the observation floor counter. A backend that 404s on every native format (e.g. handler routing regression) would skip all 6 native blocks, `observed_count` stays at 0, and the `MIN_FORMATS_OBSERVED` floor assertion fires with `only 0/3 formats reached the guard assertion` — a misleading wrong-reason failure that drowns the real signal.

Adding `_record_observed` to the refuse-class arm preserves the floor's intent (catch silent no-op suites) while letting handler regressions surface as per-format diagnostics rather than getting buried under floor failure.

## What this does NOT fix

The reality-checker on #152 also flagged 4 issues that are out of scope for this PR (they need new issues, not a CI patch):

- #100 doesn't actually test S3 fail-fast (no exit-code/log-grep assertion)
- #101 doesn't pin wasmtime 36 specifically (no version probe)
- #65 didn't actually remove the legacy dynamic version checker (additive)
- #152's new suites were never executed against a backend (workflow_dispatch never triggered)

Will file follow-up issues for those separately so the queue stays durable.

## Test plan

- [x] `bash -n` on all touched shell scripts
- [x] `python3 yaml.safe_load` on release-gate.yml
- [ ] Smoke self-test fixtures (run automatically on this PR)
- [ ] Manual: trigger a release-gate `workflow_dispatch` with an `inputs.backend_tag` matching a current release to confirm pullthrough-tests now runs end-to-end (depends on #152 backend-test follow-up)

Refs: #152 (closed), #69, #67