### PR TITLE
fix(release-gate): unblock v1.2.0 by addressing 2 small test-side bugs

### DIFF
--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -31,6 +31,11 @@ backend:
     # See values-test.yaml for rationale (iac#97). Parallel test pods exhaust
     # the default 120/min auth rate-limit on shared admin bootstrap.
     RATE_LIMIT_EXEMPT_USERNAMES: "admin"
+    # Allow private-IP webhook URLs in the test deploy. See values-test.yaml
+    # for the full rationale -- webhook tests run a mock receiver on
+    # 127.0.0.1 in the test pod, which the artifact-keeper#1201 opt-in
+    # SSRF allowlist rejects by default.
+    WEBHOOK_ALLOW_PRIVATE_IPS: "1"
     # NOTE: TRIVY_URL and SCAN_WORKSPACE_PATH were previously set here, but
     # the chart's backend-deployment.yaml auto-injects them when
     # trivy.enabled=true. Setting them here too produces duplicate env keys

--- a/helm/values-test.yaml
+++ b/helm/values-test.yaml
@@ -37,6 +37,15 @@ backend:
     # bootstrap flow doesn't compete with itself across parallel pods. Per-test
     # users that the suites create are still rate-limited normally.
     RATE_LIMIT_EXEMPT_USERNAMES: "admin"
+    # Allow private-IP webhook URLs. Webhook tests run a mock receiver on
+    # 127.0.0.1:18772 in the test pod and register webhooks pointing at
+    # that address. The backend's opt-in private-IP SSRF allowlist (from
+    # artifact-keeper#1201) rejects 127.0.0.1 by default, which fails
+    # tests/webhooks/test-webhook-* in release-gate (see triage doc
+    # /tmp/ak-goal/v1.2.0-gate-triage.md row 11). Enabling here scopes
+    # the relaxation to the test deploy only; production deploys keep
+    # the default deny-private behavior.
+    WEBHOOK_ALLOW_PRIVATE_IPS: "1"
   persistence:
     size: 2Gi
 

--- a/tests/lifecycle/test-migrations-assess.sh
+++ b/tests/lifecycle/test-migrations-assess.sh
@@ -111,6 +111,7 @@ CREATE_PAYLOAD=$(jq -nc \
     name: $name,
     source_type: "artifactory",
     url: "https://example.invalid/artifactory",
+    auth_type: "basic_auth",
     credentials: { type: "basic", username: "test", password: "test" }
   }')
 

--- a/tests/lifecycle/test-migrations-lifecycle-transitions.sh
+++ b/tests/lifecycle/test-migrations-lifecycle-transitions.sh
@@ -128,6 +128,7 @@ CREATE_PAYLOAD=$(jq -nc \
     name: $name,
     source_type: "artifactory",
     url: "https://example.invalid/artifactory",
+    auth_type: "basic_auth",
     credentials: { type: "basic", username: "test", password: "test" }
   }')
 

--- a/tests/lifecycle/test-migrations-lifecycle.sh
+++ b/tests/lifecycle/test-migrations-lifecycle.sh
@@ -119,6 +119,7 @@ CREATE_PAYLOAD=$(jq -nc \
     name: $name,
     source_type: "artifactory",
     url: "https://example.invalid/artifactory",
+    auth_type: "basic_auth",
     credentials: { type: "basic", username: "test", password: "test" }
   }')
 

--- a/tests/lifecycle/test-migrations-report.sh
+++ b/tests/lifecycle/test-migrations-report.sh
@@ -102,6 +102,7 @@ CREATE_PAYLOAD=$(jq -nc \
     name: $name,
     source_type: "artifactory",
     url: "https://example.invalid/artifactory",
+    auth_type: "basic_auth",
     credentials: { type: "basic", username: "test", password: "test" }
   }')
 

--- a/tests/lifecycle/test-migrations-sse-stream.sh
+++ b/tests/lifecycle/test-migrations-sse-stream.sh
@@ -106,6 +106,7 @@ CREATE_PAYLOAD=$(jq -nc \
     name: $name,
     source_type: "artifactory",
     url: "https://example.invalid/artifactory",
+    auth_type: "basic_auth",
     credentials: { type: "basic", username: "test", password: "test" }
   }')
 


### PR DESCRIPTION
## Summary

Two small test-side fixes that unblock v1.2.0's release-gate. Triage of the 2026-05-18 failing run (`26008441321`, 13 gates failed) identified **ZERO real backend bugs** — most failures were v1.1.2-vs-main artifacts cleared by the in-flight run on commit `6c99077` (current main with #1216 #1248 #1250 #1252 #1254 #1256). This PR addresses the remaining two test-side bugs so the in-flight run can complete clean.

Full triage: [`/tmp/ak-goal/v1.2.0-gate-triage.md`](/tmp/ak-goal/v1.2.0-gate-triage.md)

## Fix 1: 5 migration tests missing `auth_type`

Backend's `SourceConnectionRow` schema requires an `auth_type` field (one of `basic_auth` | `api_token`, snake_case per `backend/src/models/migration.rs:32`). Pre-#1199 the field was inferred from `credentials.type`; post-#1199 it's an explicit top-level required field. The test payloads emitted only the nested `credentials` block, producing `422 missing field 'auth_type'`.

Patched all 5 migration test payloads:
- `tests/lifecycle/test-migrations-assess.sh`
- `tests/lifecycle/test-migrations-lifecycle-transitions.sh`
- `tests/lifecycle/test-migrations-report.sh`
- `tests/lifecycle/test-migrations-lifecycle.sh`
- `tests/lifecycle/test-migrations-sse-stream.sh`

## Fix 2: `WEBHOOK_ALLOW_PRIVATE_IPS` not enabled in test deploy

artifact-keeper#1201 introduced an opt-in private-IP allowlist for webhook URL validation. By default 127.0.0.1, RFC 1918, and link-local addresses are rejected (SSRF prevention). Webhook tests in release-gate run a mock receiver on `127.0.0.1:18772` inside the test pod; registering webhooks against that fails with "URL points to private network".

The right scope is the test deploy only — production retains the default deny-private behavior. Added `WEBHOOK_ALLOW_PRIVATE_IPS: "1"` to backend env in:
- `helm/values-test.yaml` (default smoke)
- `helm/values-test-full.yaml` (full-stack with Trivy)

## Out of scope (tracked separately)

- **pinned-cve-gate** — requires Trivy in the gate's Helm install; will file an iac issue
- **chart-upgrade-smoke** — web pod readiness timeout; rerun once, document if persistent
- **Backend-image pin to 1.1.2 despite `AK_BACKEND_BRANCH=main`** — deploy-script issue; audit separately

## Refs

- artifact-keeper#1201 (opt-in private-IP allowlist)
- artifact-keeper#1199 (OIDC overhaul that added `auth_type`)
- Release-gate run [26008441321](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/26008441321) (the failing baseline)
- Release-gate run [26107615074](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/26107615074) (in-flight against current main)