### PR TITLE
fix(release-gate): rename webhook private-IP env var to match backend

### DIFF
--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -34,8 +34,10 @@ backend:
     # Allow private-IP webhook URLs in the test deploy. See values-test.yaml
     # for the full rationale -- webhook tests run a mock receiver on
     # 127.0.0.1 in the test pod, which the artifact-keeper#1201 opt-in
-    # SSRF allowlist rejects by default.
-    WEBHOOK_ALLOW_PRIVATE_IPS: "1"
+    # SSRF allowlist rejects by default. The backend env var is
+    # UPSTREAM_ALLOW_PRIVATE_IPS, not WEBHOOK_ALLOW_PRIVATE_IPS (the latter
+    # was the placeholder name PR #187 used and the backend never read).
+    UPSTREAM_ALLOW_PRIVATE_IPS: "1"
     # NOTE: TRIVY_URL and SCAN_WORKSPACE_PATH were previously set here, but
     # the chart's backend-deployment.yaml auto-injects them when
     # trivy.enabled=true. Setting them here too produces duplicate env keys

--- a/helm/values-test.yaml
+++ b/helm/values-test.yaml
@@ -41,11 +41,17 @@ backend:
     # 127.0.0.1:18772 in the test pod and register webhooks pointing at
     # that address. The backend's opt-in private-IP SSRF allowlist (from
     # artifact-keeper#1201) rejects 127.0.0.1 by default, which fails
-    # tests/webhooks/test-webhook-* in release-gate (see triage doc
-    # /tmp/ak-goal/v1.2.0-gate-triage.md row 11). Enabling here scopes
-    # the relaxation to the test deploy only; production deploys keep
-    # the default deny-private behavior.
-    WEBHOOK_ALLOW_PRIVATE_IPS: "1"
+    # tests/webhooks/test-webhook-* in release-gate. The relevant backend
+    # env var is `UPSTREAM_ALLOW_PRIVATE_IPS` (read by
+    # `validation::upstream_allow_private_ips_enabled`); the
+    # `validate_webhook_url` helper routes through the same
+    # `validate_outbound_url` gate. Enabling here scopes the relaxation
+    # to the test deploy only; production deploys keep the default
+    # deny-private behavior. (PR #187 originally used a placeholder
+    # `WEBHOOK_ALLOW_PRIVATE_IPS` env name that the backend does not
+    # read; rc.1 release-gate run 26116464151 confirmed the flag had no
+    # effect because of the rename.)
+    UPSTREAM_ALLOW_PRIVATE_IPS: "1"
   persistence:
     size: 2Gi
 


### PR DESCRIPTION
## Summary

PR #187 added \`WEBHOOK_ALLOW_PRIVATE_IPS: \"1\"\` to \`values-test*.yaml\` to unblock webhook-tests. **The backend never reads that env name.** The actual flag is \`UPSTREAM_ALLOW_PRIVATE_IPS\` (read by \`backend/src/api/validation.rs::upstream_allow_private_ips_enabled\`, consumed by \`validate_outbound_url\` which \`validate_webhook_url\` calls through to).

## Evidence

Release-gate run [26116464151](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/26116464151) (v1.2.0-rc.1) confirmed the mis-named flag had no effect:

\`\`\`
FAIL: expected 200/201 creating webhook without version, got 400:
  {\"code\":\"VALIDATION_ERROR\",
   \"message\":\"Webhook URL IP '127.0.0.1' is not allowed (private/internal network)\"}
\`\`\`

Grep against the backend at v1.2.0-rc.1:

\`\`\`
$ grep -r WEBHOOK_ALLOW_PRIVATE_IPS backend/src/
(no matches)

$ grep -r UPSTREAM_ALLOW_PRIVATE_IPS backend/src/
backend/src/api/validation.rs:280:pub fn upstream_allow_private_ips_enabled() -> bool {
backend/src/api/validation.rs:281:    match std::env::var(\"UPSTREAM_ALLOW_PRIVATE_IPS\") {
\`\`\`

## Change

Single env-key rename in both \`values-test.yaml\` and \`values-test-full.yaml\`. The chart already renders the \`backend.env\` map via a generic \`range\` so no chart change is needed. Comments updated to flag the placeholder-name footgun for future readers.

## Expected effect on rc.2

Should clear webhook-tests outright. lifecycle-tests still has a separate 500 INTERNAL_ERROR (NOT addressed here -- the \`auth_type\` payload fix from #187 landed and the 422 is gone, but the backend returns 500 on create-connection; needs separate investigation).