### PR TITLE
fix(release-gate): decouple web image tag from backend PREVIOUS_TAG (closes artifact-keeper#1378)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -336,6 +336,15 @@ jobs:
           # stable"). The script accepts the unprefixed semver form
           # because docker tags drop the leading 'v' (see CLAUDE.md).
           PREVIOUS_TAG: '1.1.9'
+          # PREVIOUS_WEB_TAG: the web image tag for the previous-tag side
+          # of the upgrade. The web repo cuts its own release cadence and
+          # does NOT mirror backend version tags, so the backend's
+          # PREVIOUS_TAG (e.g. "1.1.9") is NOT a valid web image tag and
+          # causes ImagePullBackOff (closes artifact-keeper#1378). `main`
+          # is published on every push to artifact-keeper-web main and is
+          # always pullable. If a future release wants stricter pinning,
+          # bump this to a specific SHA tag (e.g. `sha-ea664a1`).
+          PREVIOUS_WEB_TAG: 'main'
         run: |
           chmod +x tests/release-gate/chart-upgrade-smoke.sh
           RUN_ID="${{ github.run_id }}-${{ github.run_attempt }}-upgrade"
@@ -349,6 +358,7 @@ jobs:
             --previous-tag "${PREVIOUS_TAG}" \
             --backend-tag "${BACKEND_TAG}" \
             --web-tag "${WEB_TAG}" \
+            --previous-web-tag "${PREVIOUS_WEB_TAG}" \
             --iac-ref "${IAC_REF}" \
             --previous-iac-ref "${PREVIOUS_IAC_REF}" \
             --timeout 600

--- a/tests/release-gate/chart-upgrade-smoke.sh
+++ b/tests/release-gate/chart-upgrade-smoke.sh
@@ -14,10 +14,21 @@
 #       --previous-tag <tag> \
 #       --backend-tag <tag> \
 #       [--web-tag <tag>] \
+#       [--previous-web-tag <tag>] \
 #       [--iac-ref <ref>] \
 #       [--previous-iac-ref <ref>] \
 #       [--same-chart] \
 #       [--timeout <seconds>]
+#
+# Note on web tags: the backend repo cuts versioned releases on every
+# bugfix bump, but the artifact-keeper-web repo cuts its own release
+# cadence and does NOT mirror backend tags. As of v1.2.0, the web
+# registry only publishes `dev`, `main`, `latest`, and SHA tags for
+# every push, plus rare release tags (e.g. `1.1.3`). Passing the
+# backend's previous-tag (e.g. `1.1.9`) to web.image.tag will fail
+# with ImagePullBackOff because no such web tag exists. The script
+# therefore tracks PREVIOUS_WEB_TAG separately from PREVIOUS_TAG and
+# defaults it to `main`, which is always pullable.
 #
 # By default the script clones TWO copies of the iac repo: one at
 # `previous-iac-ref` (default `artifact-keeper-1.1.9`) and one at
@@ -43,6 +54,10 @@ RUN_ID=""
 PREVIOUS_TAG=""
 BACKEND_TAG=""
 WEB_TAG="dev"
+# previous-web-tag tracks the web image to install on the previous-tag
+# side. Defaults to `main` because the web registry does NOT publish
+# tags aligned with backend release numbers (closes artifact-keeper#1378).
+PREVIOUS_WEB_TAG="main"
 IAC_REF="main"
 # previous-iac-ref tracks the chart that shipped with the previous
 # release. Default matches PREVIOUS_TAG default in release-gate.yml.
@@ -61,6 +76,7 @@ while [[ $# -gt 0 ]]; do
     --previous-tag)      PREVIOUS_TAG="${2:-}"; shift 2 ;;
     --backend-tag)       BACKEND_TAG="${2:-}"; shift 2 ;;
     --web-tag)           WEB_TAG="${2:-}"; shift 2 ;;
+    --previous-web-tag)  PREVIOUS_WEB_TAG="${2:-}"; shift 2 ;;
     --iac-ref)           IAC_REF="${2:-}"; shift 2 ;;
     --previous-iac-ref)  PREVIOUS_IAC_REF="${2:-}"; shift 2 ;;
     --same-chart)        SAME_CHART=true; shift ;;
@@ -93,7 +109,8 @@ echo "  Namespace:           ${NAMESPACE}"
 echo "  Release:             ${RELEASE_NAME}"
 echo "  Previous tag:        ${PREVIOUS_TAG}"
 echo "  Current tag:         ${BACKEND_TAG}"
-echo "  Web tag:             ${WEB_TAG}"
+echo "  Web tag (upgrade):   ${WEB_TAG}"
+echo "  Web tag (previous):  ${PREVIOUS_WEB_TAG}"
 echo "  Timeout:             ${TIMEOUT_SECONDS}s"
 echo "  iac ref (current):   ${IAC_REF}"
 if [ "$SAME_CHART" = "true" ]; then
@@ -252,7 +269,7 @@ helm upgrade --install "$RELEASE_NAME" "$PREVIOUS_CHART_DIR" \
   --namespace "$NAMESPACE" \
   --values "$PREVIOUS_PROD_VALUES" \
   --set backend.image.tag="$PREVIOUS_TAG" \
-  --set web.image.tag="$PREVIOUS_TAG" \
+  --set web.image.tag="$PREVIOUS_WEB_TAG" \
   "${HELM_BASE_OVERRIDES[@]}" \
   --wait=false || {
     echo "ERROR: helm install (previous tag) failed" >&2


### PR DESCRIPTION
## Summary

- Release-gate run 26344757642 (v1.2.0-rc.2) saw `chart-upgrade-smoke` fail because `ak-upgrade-web` was stuck in `ImagePullBackOff` trying to pull `ghcr.io/artifact-keeper/artifact-keeper-web:1.1.9`, a tag the web registry never published.
- The script fed backend `PREVIOUS_TAG` (`1.1.9`) to both `backend.image.tag` and `web.image.tag`. Backend releases on every bugfix; web releases on its own cadence (last release `1.1.3`).
- Adds `--previous-web-tag` CLI option (default `main`) so the previous-tag side of the upgrade uses a tag the web registry actually has.
- Threads `PREVIOUS_WEB_TAG: 'main'` through the release-gate workflow with documented comments matching the existing `PREVIOUS_TAG` block.

## Closes
- artifact-keeper/artifact-keeper#1378

## Test plan
- [ ] Trigger release-gate manually after merge: `gh workflow run release-gate.yml -f backend_tag=dev` and confirm `chart-upgrade-smoke` no longer ImagePullBackOffs on the web container.
- [x] `bash -n` on the modified script
- [x] yaml validity check on the modified workflow
- [x] manual verification that web registry has `main` tag at the time of writing
- [ ] full release-gate run on next tag (v1.2.0-rc.3)

## Notes
The longer-term fix is for `artifact-keeper-web` to start cutting version-aligned release tags. Until then, `main` is the most stable always-available tag. A specific SHA tag (e.g. `sha-ea664a1`) is a stricter alternative; documented in the env-var comment.