### PR TITLE
fix(release-gate): enable Trivy in test-full deploy so pinned-cve-gate has a target (closes artifact-keeper#1379)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -564,7 +564,11 @@ jobs:
           mkdir -p /tmp/test-logs
           kubectl -n "$NS" logs -l app.kubernetes.io/component=scanner \
             --tail=2000 > /tmp/test-logs/scanner-${{ matrix.format }}.log 2>&1 || true
-          kubectl -n "$NS" logs -l app.kubernetes.io/name=trivy \
+          # #1379: chart labels Trivy pods with app.kubernetes.io/component=trivy
+          # (app.kubernetes.io/name is the chart name "artifact-keeper", not the
+          # component). Use the component label so the log capture actually finds
+          # the pod when the gate is failing and the operator most needs the logs.
+          kubectl -n "$NS" logs -l app.kubernetes.io/component=trivy \
             --tail=2000 > /tmp/test-logs/trivy-${{ matrix.format }}.log 2>&1 || true
           kubectl -n "$NS" logs -l app=artifact-keeper-backend \
             --tail=1000 > /tmp/test-logs/backend-${{ matrix.format }}.log 2>&1 || true
@@ -718,11 +722,25 @@ jobs:
           # Locate the Trivy pod. The Helm chart names the deployment
           # artifact-keeper-trivy; we kubectl-exec into the first ready
           # pod backed by that deployment.
+          #
+          # Label selector note (#1379): the chart's _helpers.tpl labels
+          # every component with app.kubernetes.io/name=artifact-keeper
+          # (the chart name) and distinguishes components via
+          # app.kubernetes.io/component=<name>. Earlier revisions of this
+          # pre-flight queried `app.kubernetes.io/name=trivy`, which
+          # never matched, producing the misleading "Trivy pod not
+          # found" error even though the deploy job's
+          # `kubectl rollout status deployment/artifact-keeper-trivy`
+          # had already succeeded. The correct selector is
+          # `app.kubernetes.io/component=trivy`.
           POD=$(kubectl -n "$NS" get pods \
-            -l app.kubernetes.io/name=trivy \
+            -l app.kubernetes.io/component=trivy \
             -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
           if [ -z "$POD" ]; then
             echo "::error::Trivy pod not found in namespace ${NS} (pre-flight cannot run)"
+            echo "::error::Checked selector: app.kubernetes.io/component=trivy"
+            echo "::error::Deploy job should have installed Trivy via values-test-full.yaml (trivy.enabled=true)."
+            kubectl -n "$NS" get pods --show-labels 2>&1 | head -40 || true
             exit 43
           fi
 


### PR DESCRIPTION
## Summary

Fixes the `pinned-cve-gate` pre-flight in `release-gate.yml` exiting 43 with `Trivy pod not found in namespace test-...` even though the deploy job successfully installed Trivy via `values-test-full.yaml` (which already has `trivy.enabled: true`).

The pre-flight was using the wrong Kubernetes label selector: it queried `app.kubernetes.io/name=trivy`, but the artifact-keeper helm chart labels every component pod with `app.kubernetes.io/name=artifact-keeper` (the chart name) and distinguishes components via `app.kubernetes.io/component=<name>`. The correct selector for the Trivy deployment is `app.kubernetes.io/component=trivy`.

Closes artifact-keeper/artifact-keeper#1379.

## Root cause

`charts/artifact-keeper/templates/_helpers.tpl` defines:

```
artifact-keeper.selectorLabels:
  app.kubernetes.io/name: {{ include "artifact-keeper.name" . }}   # always "artifact-keeper"
  app.kubernetes.io/instance: {{ .Release.Name }}

artifact-keeper.trivy.selectorLabels:
  {{ include "artifact-keeper.selectorLabels" . }}
  app.kubernetes.io/component: trivy
```

So a rendered Trivy pod has labels `app.kubernetes.io/name=artifact-keeper, app.kubernetes.io/component=trivy, app.kubernetes.io/instance=<release>`. The pre-flight's `app.kubernetes.io/name=trivy` could never match.

The deploy job's `kubectl rollout status deployment/artifact-keeper-trivy` uses the deployment name directly, so it correctly verified Trivy was up; the bug only surfaced one step downstream in the freshness pre-flight.

## Changes

- `.github/workflows/release-gate.yml` line 722 (`pinned-cve-gate` -> `Trivy DB freshness pre-flight`): switch selector from `app.kubernetes.io/name=trivy` to `app.kubernetes.io/component=trivy`. Add diagnostic `kubectl get pods --show-labels` on the failure path so a future regression surfaces the actual labels, not just "not found".
- `.github/workflows/release-gate.yml` line 567 (`scan-completion-gate` -> `Capture scanner pod logs on failure`): same wrong selector, fixed. Without this, Trivy logs were silently dropped on gate failure when the operator most needs them.

## Verification

Verified by rendering the chart locally:

```
helm template testrel /Users/khan/ak/artifact-keeper-iac/charts/artifact-keeper \
  --values helm/values-test-full.yaml
```

The rendered Trivy Deployment carries `app.kubernetes.io/name=artifact-keeper` and `app.kubernetes.io/component=trivy`. A full cluster verification will run in CI when this PR opens.

No changes needed in `artifact-keeper-iac/`: `values-test-full.yaml` already enables Trivy (`trivy.enabled: true` at line 113-114), and the chart correctly labels the pod. Only the selector in the workflow was wrong.

## Risk

Workflow-only change, scoped to two label-selector strings. The pre-flight now correctly finds the Trivy pod and proceeds to its `trivy --version` parse, so `pinned-cve-gate` should run end-to-end on the next release-gate dispatch.

## Out of scope

- A scan of other workflows for the same wrong-selector pattern (line 1469 references `app.kubernetes.io/name=opensearch` which has the same shape; not fixed here because (a) it's a different gate, (b) #1379 is scoped to Trivy, (c) the opensearch lookup is guarded by an `if kubectl ... | grep -q pod/` so it fails open rather than hard-erroring). Worth a follow-up issue.

## Checklist

- [x] Linked tracking issue (artifact-keeper#1379)
- [x] No em-dashes, emoji, or AI attribution in commit/PR
- [x] Branch off origin/main
- [x] Will not merge until CI is green