### PR TITLE
test(auth): E2E reproducer tests for #1369 #1370 #1371

### DIFF
--- a/tests/auth/test-deactivated-user-token-1371.sh
+++ b/tests/auth/test-deactivated-user-token-1371.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# test-deactivated-user-token-1371.sh
+#
+# Reproducer for artifact-keeper#1371: an API token issued to a user remained
+# valid for up to API_TOKEN_CACHE_TTL_SECS (300s) after the user was
+# deactivated. The validation query already filtered `is_active = true`, but
+# auth_service kept a 5-minute in-process cache keyed on token hash and never
+# evicted on user state change. From a security standpoint, "token works for
+# 5 more minutes after we revoked access" is the kind of finding that lands
+# in a penetration test report.
+#
+# Fix landed in artifact-keeper PR #1390. After the fix:
+#   - PATCH /users/{id} { is_active: false } flushes the API-token cache
+#     entries belonging to that user
+#   - any subsequent token use returns 401 within seconds, not minutes
+#
+# Pre-fix backend (1.1.0-rc.2): token accepted for ~300s after deactivation
+# Post-fix backend (main):      token rejected with 401 within 5s
+#
+# The existing test-user-deactivation-revokes-tokens.sh polls for ~30s and
+# SKIPs when require_feature("user_deactivation_token_flush") says the
+# backend is older than v1.1.9. That suite is intentionally tolerant so it
+# can run against older release branches.
+#
+# This script is the stricter reproducer: a 5-second poll budget that asserts
+# the cache flush happened promptly. It targets the SAME feature flag so a
+# backend that lacks the fix is still gracefully skipped — but where the fix
+# IS present (v1.1.9+, current main), 30s of waiting is too loose to catch a
+# half-broken cache flush (e.g. one that only evicts on the next eviction
+# tick instead of immediately).
+#
+# Backend reference:
+#   - backend/src/services/auth_service.rs API_TOKEN_CACHE_TTL_SECS / cache
+#   - backend/src/api/handlers/users.rs PATCH /users/{id} -> set_user_active
+#   - PR #1390: flush_api_token_cache_for_user invoked on is_active flip
+#
+# Requires: curl, jq
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "auth-deactivated-user-token-1371"
+auth_admin
+setup_workdir
+
+DEACT_USER="e2e-1371-${RUN_ID}"
+DEACT_PASS="Deact1371Pass!_strong"
+DEACT_EMAIL="e2e-1371-${RUN_ID}@test.local"
+USER_ID=""
+USER_TOKEN=""
+API_TOKEN=""
+API_TOKEN_ID=""
+
+# 5-second poll budget, 500ms steps. Total max attempts = 10. We want a
+# response within seconds, not minutes — that is the bug being asserted.
+POLL_TIMEOUT_SECS=5
+POLL_STEP_SECS=0.5
+
+# ---------------------------------------------------------------------------
+# Setup: create the user, log in, mint an API token, confirm it works.
+# ---------------------------------------------------------------------------
+
+begin_test "Create test user"
+USER_ID=$(create_test_user "${DEACT_USER}" "${DEACT_PASS}" "${DEACT_EMAIL}") || true
+if [ -n "$USER_ID" ]; then
+  pass
+else
+  fail "could not create user"
+fi
+
+begin_test "Login + mint API token in user's session"
+if [ -z "${USER_ID:-}" ]; then
+  skip "no user"
+else
+  USER_TOKEN=$(login_as "${DEACT_USER}" "${DEACT_PASS}") || true
+  if [ -z "$USER_TOKEN" ]; then
+    fail "login failed"
+  else
+    tok_resp=$(curl -sf $CURL_TIMEOUT -X POST \
+      -H "Authorization: Bearer ${USER_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d '{"name":"e2e-1371","scopes":["read","write"]}' \
+      "${BASE_URL}/api/v1/auth/tokens" 2>/dev/null) || true
+    API_TOKEN=$(echo "$tok_resp" | jq -r '.token // empty')
+    API_TOKEN_ID=$(echo "$tok_resp" | jq -r '.id // empty')
+    if [ -n "$API_TOKEN" ] && [ "$API_TOKEN" != "null" ]; then
+      pass
+    else
+      fail "could not mint API token: ${tok_resp:0:200}"
+    fi
+  fi
+fi
+
+# Prime the in-process API-token cache by using the token at least once
+# before deactivation. Without this prime call, the post-deactivation poll
+# could pass for the wrong reason (the cache was simply empty all along).
+# Priming guarantees we are testing the FLUSH path, not the COLD-MISS path.
+begin_test "API token works before deactivation (and primes cache)"
+if [ -z "${API_TOKEN:-}" ] || [ "$API_TOKEN" = "null" ]; then
+  skip "no API token"
+else
+  status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+    -H "Authorization: Bearer ${API_TOKEN}" \
+    "${BASE_URL}/api/v1/repositories" 2>/dev/null) || status="000"
+  if [ "$status" -ge 200 ] 2>/dev/null && [ "$status" -lt 300 ] 2>/dev/null; then
+    pass
+  else
+    fail "API token returned HTTP ${status} before deactivation"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Deactivate the user. Backend route is PATCH-only (users.rs uses
+# axum::routing::patch). If a regression switches the verb, this assert
+# catches it before we get to the cache-flush check.
+# ---------------------------------------------------------------------------
+
+begin_test "Admin deactivates user (PATCH /users/{id})"
+if [ -z "${USER_ID:-}" ] || [ "$USER_ID" = "null" ]; then
+  skip "no user ID"
+else
+  status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+    -X PATCH \
+    -H "$(auth_header)" \
+    -H "Content-Type: application/json" \
+    -d '{"is_active":false}' \
+    "${BASE_URL}/api/v1/users/${USER_ID}" 2>/dev/null) || status="000"
+  if [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
+    pass
+  else
+    fail "deactivate returned HTTP ${status}"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# THE BUG (#1371): the token used to work for ~5 minutes after deactivation.
+# Post-fix, it must be rejected within 5 seconds.
+#
+# require_feature gates this against backends that lack the fix so the same
+# script can run against release/1.1.x without spurious failures. When the
+# feature is present (main, v1.1.9+), we hold the backend to the tight SLA.
+# ---------------------------------------------------------------------------
+
+begin_test "Deactivated user's API token is rejected within 5s (#1371 SLA)"
+if [ -z "${API_TOKEN:-}" ] || [ "$API_TOKEN" = "null" ]; then
+  skip "no API token to test"
+elif require_feature "user_deactivation_token_flush"; then
+  rejected=false
+  last_status=""
+  attempts=0
+  # Wall-clock budget: we want to know how fast the cache flush propagates.
+  start_ts=$(date +%s)
+  while :; do
+    attempts=$(( attempts + 1 ))
+    last_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+      -H "Authorization: Bearer ${API_TOKEN}" \
+      "${BASE_URL}/api/v1/repositories" 2>/dev/null) || last_status="000"
+    if [ "$last_status" = "401" ]; then
+      rejected=true
+      break
+    fi
+    now_ts=$(date +%s)
+    elapsed=$(( now_ts - start_ts ))
+    if [ "$elapsed" -ge "$POLL_TIMEOUT_SECS" ]; then
+      break
+    fi
+    sleep "$POLL_STEP_SECS"
+  done
+  if [ "$rejected" = "true" ]; then
+    pass
+  else
+    # The pre-fix backend lingers at HTTP 200 because the cache hands out a
+    # stale "user.is_active = true" verdict. Surface the actual status so
+    # CI logs make the regression obvious instead of opaque.
+    fail "token still accepted (HTTP ${last_status}) after ${POLL_TIMEOUT_SECS}s — cache flush did not propagate (#1371)" \
+      "attempts=${attempts}, last_status=${last_status}, user_id=${USER_ID}"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Belt-and-suspenders: a fresh login as the deactivated user must fail
+# outright. The login query has its own is_active filter, so this catches
+# any future refactor that accidentally drops it from the login path while
+# leaving the token path "correct".
+# ---------------------------------------------------------------------------
+
+begin_test "Login as deactivated user fails with 401"
+if [ -z "${USER_ID:-}" ] || [ "$USER_ID" = "null" ]; then
+  skip "no user ID"
+else
+  status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "{\"username\":\"${DEACT_USER}\",\"password\":\"${DEACT_PASS}\"}" \
+    "${BASE_URL}/api/v1/auth/login" 2>/dev/null) || status="000"
+  if [ "$status" = "401" ]; then
+    pass
+  else
+    fail "expected 401 for deactivated user login, got HTTP ${status}"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Cleanup: reactivate so delete works cleanly, then delete the user.
+# Same pattern as test-user-deactivation-revokes-tokens.sh — keep them in
+# sync so a future shared helper can replace both.
+# ---------------------------------------------------------------------------
+
+if [ -n "${USER_ID:-}" ] && [ "$USER_ID" != "null" ]; then
+  curl -s -o /dev/null -X PATCH \
+    -H "$(auth_header)" \
+    -H "Content-Type: application/json" \
+    -d '{"is_active":true}' \
+    "${BASE_URL}/api/v1/users/${USER_ID}" > /dev/null 2>&1 || true
+  api_delete "/api/v1/users/${USER_ID}" > /dev/null 2>&1 || true
+fi
+
+enable_expect_failure_trap
+
+end_suite

--- a/tests/auth/test-oidc-callback-empty-state-1369.sh
+++ b/tests/auth/test-oidc-callback-empty-state-1369.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# test-oidc-callback-empty-state-1369.sh
+#
+# Reproducer for artifact-keeper#1369: the OIDC callback handler used to feed
+# an empty `state` query parameter straight into the SSO session lookup, which
+# bubbled up as AppError::Authentication and returned HTTP 401. That was wrong
+# on two counts:
+#   1. An empty `state` is a malformed callback, not a CSRF failure. The
+#      correct status for a missing required parameter is 400 with a
+#      VALIDATION_ERROR code so frontends can distinguish "you forgot a
+#      parameter" from "your session expired / replay detected".
+#   2. The 401 path leaked timing/branch info about session lookup. Failing
+#      validation first means we never touch the session store for malformed
+#      requests.
+#
+# Fix landed in artifact-keeper PR #1383 (validate_oidc_callback_params runs
+# BEFORE the session lookup in both oidc_callback and oidc_callback_generic).
+#
+# Pre-fix backend (1.1.0-rc.2): empty state -> 401
+# Post-fix backend (main):      empty state -> 400 with code = VALIDATION_ERROR
+#
+# Backend reference:
+#   - backend/src/api/handlers/sso.rs:183-190 validate_oidc_callback_params
+#   - backend/src/api/handlers/sso.rs:217, 257 (called before session lookup)
+#   - backend/src/error.rs:119 Validation -> 400 VALIDATION_ERROR
+#
+# This test also verifies the CSRF defense (non-empty but invalid state still
+# returns 401) was preserved by the fix — that is the load-bearing security
+# behavior we must not regress.
+#
+# Requires: curl, jq
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "auth-oidc-callback-empty-state-1369"
+auth_admin
+
+# Use a UUID-shaped path id for the per-provider route so its parameter parser
+# accepts the request and we reach validate_oidc_callback_params. A bogus id is
+# fine: we never get past param validation in the cases we care about.
+PROVIDER_ID="00000000-0000-0000-0000-000000000000"
+GENERIC_PATH="/api/v1/auth/sso/oidc/callback"
+PROVIDER_PATH="/api/v1/auth/sso/oidc/${PROVIDER_ID}/callback"
+
+# ---------------------------------------------------------------------------
+# Helper: hit the callback and capture both status and the error code from
+# the JSON envelope. Echoes "<status>|<code>" on stdout.
+#
+# We deliberately split the curl into status (-o /dev/null -w '%{http_code}')
+# and a separate body fetch so a malformed/empty body cannot break the
+# status check. Two calls add no real cost and keep the assertion crisp.
+# ---------------------------------------------------------------------------
+oidc_call() {
+  local url="$1"
+  local status body code
+  status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT "$url" 2>/dev/null) || status="000"
+  body=$(curl -s $CURL_TIMEOUT "$url" 2>/dev/null) || body=""
+  code=$(echo "$body" | jq -r '.code // .error.code // empty' 2>/dev/null) || code=""
+  echo "${status}|${code}|${body:0:200}"
+}
+
+# ---------------------------------------------------------------------------
+# 1) Empty state on the generic callback returns 400, not 401.
+#    code=X, state=   (empty)
+# ---------------------------------------------------------------------------
+
+begin_test "Generic callback: empty state returns 400 with VALIDATION_ERROR"
+result=$(oidc_call "${BASE_URL}${GENERIC_PATH}?code=X&state=")
+status="${result%%|*}"
+rest="${result#*|}"
+code="${rest%%|*}"
+body="${rest#*|}"
+if [ "$status" = "400" ] && [ "$code" = "VALIDATION_ERROR" ]; then
+  pass
+elif [ "$status" = "401" ]; then
+  fail "pre-fix bug: empty state returned 401 (CSRF path) instead of 400 (validation). #1369 regression" "$body"
+elif [ "$status" = "400" ]; then
+  # Backend accepted as bad request but didn't tag the structured code we want.
+  # Treat as failure so we catch any envelope-format regression. The fix in
+  # #1383 specifically wires AppError::Validation -> VALIDATION_ERROR.
+  fail "got HTTP 400 but error code was '${code}', expected VALIDATION_ERROR" "$body"
+else
+  fail "unexpected HTTP ${status} for empty state (want 400)" "$body"
+fi
+
+# ---------------------------------------------------------------------------
+# 2) Empty code (state present) also returns 400.
+# ---------------------------------------------------------------------------
+
+begin_test "Generic callback: empty code returns 400 with VALIDATION_ERROR"
+result=$(oidc_call "${BASE_URL}${GENERIC_PATH}?code=&state=somestate")
+status="${result%%|*}"
+rest="${result#*|}"
+code="${rest%%|*}"
+body="${rest#*|}"
+if [ "$status" = "400" ] && [ "$code" = "VALIDATION_ERROR" ]; then
+  pass
+elif [ "$status" = "400" ]; then
+  fail "got HTTP 400 but error code was '${code}', expected VALIDATION_ERROR" "$body"
+else
+  fail "expected 400 VALIDATION_ERROR for empty code, got HTTP ${status} code='${code}'" "$body"
+fi
+
+# ---------------------------------------------------------------------------
+# 3) Both code and state empty: still 400 (not 401, not 500).
+# ---------------------------------------------------------------------------
+
+begin_test "Generic callback: both empty returns 400 with VALIDATION_ERROR"
+result=$(oidc_call "${BASE_URL}${GENERIC_PATH}?code=&state=")
+status="${result%%|*}"
+rest="${result#*|}"
+code="${rest%%|*}"
+body="${rest#*|}"
+if [ "$status" = "400" ] && [ "$code" = "VALIDATION_ERROR" ]; then
+  pass
+else
+  fail "expected 400 VALIDATION_ERROR for both empty, got HTTP ${status} code='${code}'" "$body"
+fi
+
+# ---------------------------------------------------------------------------
+# 4) Per-provider callback (UUID path) also validates state shape before
+#    session lookup. Same fix lives in oidc_callback as well as the generic
+#    variant — both must behave identically.
+# ---------------------------------------------------------------------------
+
+begin_test "Per-provider callback: empty state returns 400 with VALIDATION_ERROR"
+result=$(oidc_call "${BASE_URL}${PROVIDER_PATH}?code=X&state=")
+status="${result%%|*}"
+rest="${result#*|}"
+code="${rest%%|*}"
+body="${rest#*|}"
+if [ "$status" = "400" ] && [ "$code" = "VALIDATION_ERROR" ]; then
+  pass
+elif [ "$status" = "401" ]; then
+  fail "pre-fix bug: per-provider callback with empty state returned 401 instead of 400" "$body"
+else
+  fail "expected 400 VALIDATION_ERROR on per-provider path, got HTTP ${status} code='${code}'" "$body"
+fi
+
+# ---------------------------------------------------------------------------
+# 5) CSRF defense preserved: a NON-empty state that has no matching SSO
+#    session must still return 401. Empty != invalid; the fix only changes
+#    the empty-string branch, never the replay-defense branch.
+#
+#    This is the load-bearing security assertion. If a refactor accidentally
+#    collapses "no session" into VALIDATION_ERROR, we lose the CSRF signal
+#    and an attacker can probe state values without 401 telemetry.
+# ---------------------------------------------------------------------------
+
+begin_test "Non-empty but invalid state still returns 401 (CSRF defense preserved)"
+# Use a RUN_ID-scoped state value so parallel suites can't collide.
+INVALID_STATE="not-a-real-session-${RUN_ID}"
+result=$(oidc_call "${BASE_URL}${GENERIC_PATH}?code=X&state=${INVALID_STATE}")
+status="${result%%|*}"
+body="${result##*|}"
+if [ "$status" = "401" ]; then
+  pass
+elif [ "$status" = "400" ]; then
+  fail "regression: non-empty invalid state returned 400 — CSRF defense was over-broadened" "$body"
+else
+  # Any 5xx here means the validation/session pipeline crashed, which is also a fail.
+  fail "expected 401 for non-empty invalid state, got HTTP ${status}" "$body"
+fi
+
+# EXPECT_FAILURE=1 inverts the suite's exit code so this script can be used
+# as a fixture to validate the gate (a "broken" gate is a passing self-test).
+enable_expect_failure_trap
+
+end_suite

--- a/tests/auth/test-totp-disable-preserves-session-1370.sh
+++ b/tests/auth/test-totp-disable-preserves-session-1370.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# test-totp-disable-preserves-session-1370.sh
+#
+# Reproducer for artifact-keeper#1370: /auth/totp/disable returned 401 even
+# when the caller supplied a correct password AND a current TOTP code. The
+# regression was visible because the existing test-totp-disable.sh covered
+# the rejection paths (wrong password, wrong code) but did not exercise the
+# happy path against a Bearer-authenticated session — so a session/auth
+# context check inside disable_totp could silently break without a gate
+# catching it.
+#
+# Fix landed in artifact-keeper PR #1389. After the fix:
+#   - disable with correct password + correct TOTP code returns 2xx
+#   - /auth/me afterwards reports totp_enabled = false
+#   - the original bearer token continues to work (session not invalidated)
+#
+# Pre-fix backend (1.1.0-rc.2): correct creds -> 401 (bug)
+# Post-fix backend (main):      correct creds -> 200 + totp_enabled=false
+#
+# Backend reference:
+#   - backend/src/api/handlers/totp.rs:371-423 disable_totp
+#   - bcrypt::verify(password) AND totp.check_current(code) both must pass
+#   - response: totp_enabled now reflects DB state, not cached claim
+#
+# This test deliberately overlaps with test-totp-disable.sh's "correct creds"
+# branch so a future refactor that drops the happy-path assertion from the
+# older suite still leaves the #1370-specific reproducer in place.
+#
+# Requires: curl, jq, python3 (for TOTP via totp_code helper)
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "auth-totp-disable-preserves-session-1370"
+auth_admin
+setup_workdir
+
+# RUN_ID scoping prevents collisions when this and test-totp-disable.sh run in
+# the same suite (release-gate runs both in parallel against one namespace).
+TOTP_USER="totp-1370-${RUN_ID}"
+TOTP_PASS="Totp1370Pass!_secure"
+TOTP_EMAIL="totp-1370-${RUN_ID}@test.local"
+USER_ID=""
+USER_TOKEN=""
+TOTP_SECRET=""
+
+# ---------------------------------------------------------------------------
+# Setup: create user, log in, enable TOTP.
+# ---------------------------------------------------------------------------
+
+begin_test "Create test user"
+USER_ID=$(create_test_user "${TOTP_USER}" "${TOTP_PASS}" "${TOTP_EMAIL}") || true
+if [ -n "$USER_ID" ]; then
+  pass
+else
+  fail "could not create user"
+fi
+
+begin_test "Login as test user"
+if [ -z "${USER_ID:-}" ]; then
+  skip "no user"
+else
+  USER_TOKEN=$(login_as "${TOTP_USER}" "${TOTP_PASS}") || true
+  if [ -n "$USER_TOKEN" ]; then
+    pass
+  else
+    fail "login failed"
+  fi
+fi
+
+begin_test "Enable TOTP (setup + enable)"
+if [ -z "${USER_TOKEN:-}" ]; then
+  skip "no user token"
+else
+  setup_resp=$(curl -sf $CURL_TIMEOUT -X POST \
+    -H "Authorization: Bearer ${USER_TOKEN}" \
+    "${BASE_URL}/api/v1/auth/totp/setup" 2>/dev/null) || true
+  TOTP_SECRET=$(echo "$setup_resp" | jq -r '.secret // empty')
+  if [ -z "$TOTP_SECRET" ] || [ "$TOTP_SECRET" = "null" ]; then
+    fail "TOTP setup did not return a secret: ${setup_resp:0:200}"
+  else
+    CODE=$(totp_code "$TOTP_SECRET") || true
+    enable_resp=$(curl -sf $CURL_TIMEOUT -X POST \
+      -H "Authorization: Bearer ${USER_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "{\"code\":\"${CODE}\"}" \
+      "${BASE_URL}/api/v1/auth/totp/enable" 2>/dev/null) || true
+    backup_count=$(echo "$enable_resp" | jq '.backup_codes | length // 0' 2>/dev/null)
+    if [ "$backup_count" -ge 1 ]; then
+      pass
+    else
+      fail "TOTP enable did not return backup_codes: ${enable_resp:0:200}"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Confirm TOTP really is enabled before we try to disable it — otherwise a
+# "disable succeeded" result would be ambiguous (was it never enabled?).
+# ---------------------------------------------------------------------------
+
+begin_test "Confirm totp_enabled = true after enable"
+if [ -z "${USER_TOKEN:-}" ] || [ -z "${TOTP_SECRET:-}" ]; then
+  skip "TOTP not enabled"
+else
+  me_resp=$(curl -sf $CURL_TIMEOUT \
+    -H "Authorization: Bearer ${USER_TOKEN}" \
+    "${BASE_URL}/api/v1/auth/me" 2>/dev/null) || true
+  # See test-totp-disable.sh for why we don't use `jq -r '.totp_enabled // empty'`:
+  # jq's `//` operator treats `false` as a missing alternative.
+  totp_state=$(echo "$me_resp" | jq -r '
+    if has("totp_enabled") then
+      if .totp_enabled == false then "false"
+      elif .totp_enabled == true then "true"
+      else "non-bool"
+      end
+    else "missing"
+    end
+  ' 2>/dev/null) || totp_state=""
+  if [ "$totp_state" = "true" ]; then
+    pass
+  else
+    fail "pre-condition: expected totp_enabled=true after enable, got '${totp_state}'" "$me_resp"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# THE BUG: correct password + correct TOTP code returned 401 before #1389.
+#
+# Use 'wait' mode for totp_code so we don't reuse the code consumed by /enable
+# — the backend rejects code reuse inside a 30s window as a replay defense.
+# Without 'wait', this assertion can spuriously fail with HTTP 401 even on a
+# fixed backend, exactly the false-positive class we want to avoid in a gate.
+# ---------------------------------------------------------------------------
+
+begin_test "Disable with correct password + correct code returns 2xx (#1370)"
+if [ -z "${USER_TOKEN:-}" ] || [ -z "${TOTP_SECRET:-}" ]; then
+  skip "TOTP not enabled"
+else
+  CODE=$(totp_code "$TOTP_SECRET" wait) || true
+  # Capture body so the failure message is actionable. The pre-fix backend
+  # returns AppError::Authentication("invalid session") which makes the
+  # regression unambiguous in CI logs.
+  tmp=$(mktemp)
+  status=$(curl -s -o "$tmp" -w '%{http_code}' $CURL_TIMEOUT \
+    -X POST \
+    -H "Authorization: Bearer ${USER_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "{\"password\":\"${TOTP_PASS}\",\"code\":\"${CODE}\"}" \
+    "${BASE_URL}/api/v1/auth/totp/disable" 2>/dev/null) || status="000"
+  body=$(cat "$tmp" 2>/dev/null || true)
+  rm -f "$tmp"
+  if [ "$status" -ge 200 ] 2>/dev/null && [ "$status" -lt 300 ] 2>/dev/null; then
+    pass
+  elif [ "$status" = "401" ]; then
+    fail "pre-fix bug: disable returned 401 with correct password + correct code (#1370 regression)" "$body"
+  else
+    fail "expected 2xx from /totp/disable with correct creds, got HTTP ${status}" "$body"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# After disable, the persisted user state must reflect totp_enabled = false.
+# A bug that returns 2xx but doesn't actually flip the column would otherwise
+# slip through the previous assertion.
+# ---------------------------------------------------------------------------
+
+begin_test "After disable, /auth/me reports totp_enabled = false"
+if [ -z "${USER_TOKEN:-}" ]; then
+  skip "no user token"
+else
+  me_resp=$(curl -sf $CURL_TIMEOUT \
+    -H "Authorization: Bearer ${USER_TOKEN}" \
+    "${BASE_URL}/api/v1/auth/me" 2>/dev/null) || true
+  totp_state=$(echo "$me_resp" | jq -r '
+    if has("totp_enabled") then
+      if .totp_enabled == false then "false"
+      elif .totp_enabled == true then "true"
+      else "non-bool"
+      end
+    else "missing"
+    end
+  ' 2>/dev/null) || totp_state=""
+  if [ "$totp_state" = "false" ]; then
+    pass
+  else
+    fail "expected totp_enabled=false after disable, got '${totp_state}'" "$me_resp"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Session preservation: the bearer token used to call /totp/disable must
+# remain valid afterwards. Some early drafts of the fix invalidated the
+# session as a "safety" step; that broke the UI because the user got logged
+# out at the moment they disabled 2FA. #1370's acceptance criteria require
+# the session to survive.
+# ---------------------------------------------------------------------------
+
+begin_test "Bearer token still works after disable (session preserved)"
+if [ -z "${USER_TOKEN:-}" ]; then
+  skip "no user token"
+else
+  status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+    -H "Authorization: Bearer ${USER_TOKEN}" \
+    "${BASE_URL}/api/v1/auth/me" 2>/dev/null) || status="000"
+  if [ "$status" -ge 200 ] 2>/dev/null && [ "$status" -lt 300 ] 2>/dev/null; then
+    pass
+  else
+    fail "session was invalidated by /totp/disable (HTTP ${status} on /auth/me) — #1370 expects session to survive"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+if [ -n "${USER_ID:-}" ] && [ "$USER_ID" != "null" ]; then
+  api_delete "/api/v1/users/${USER_ID}" > /dev/null 2>&1 || true
+fi
+
+enable_expect_failure_trap
+
+end_suite


### PR DESCRIPTION
## Summary

Adds three E2E reproducer scripts under `tests/auth/` that exercise the bugs fixed by backend PRs #1383, #1389, and #1390. Each script is designed so it would FAIL on a pre-fix backend (1.1.0-rc.2) and PASS on current main.

- `test-oidc-callback-empty-state-1369.sh` — covers artifact-keeper#1369. Empty `state` on the OIDC callback used to fall through into the session lookup and return 401. Asserts that empty state now returns HTTP 400 with `code = VALIDATION_ERROR`, that empty code and both-empty cases match, that the per-provider `/oidc/{id}/callback` variant behaves the same, and that the CSRF defense (non-empty but unknown state still returns 401) was preserved.
- `test-totp-disable-preserves-session-1370.sh` — covers artifact-keeper#1370. Creates a user, enables TOTP, then calls `/auth/totp/disable` with the correct password and a current code. Asserts 2xx response, `totp_enabled=false` on `/auth/me` afterwards, and that the bearer token used to call disable remains valid (session not invalidated).
- `test-deactivated-user-token-1371.sh` — covers artifact-keeper#1371. Mints an API token, primes the auth cache, then PATCHes `is_active=false`. Asserts the token is rejected with 401 inside a 5-second poll budget. Gated by `require_feature "user_deactivation_token_flush"` so older release branches skip cleanly.

All three sit alongside the existing `tests/auth/test-*.sh` files and use the standard harness: `auth_admin`, `login_as`, `create_test_user`, `totp_code`, `RUN_ID` scoping, `setup_workdir`, `require_feature`, and `enable_expect_failure_trap`.

Refs:
- artifact-keeper#1369, fixed by artifact-keeper#1383
- artifact-keeper#1370, fixed by artifact-keeper#1389
- artifact-keeper#1371, fixed by artifact-keeper#1390

## Test Plan

- [x] `bash -n` syntax-checks all three scripts
- [x] Confirmed harness symbols (`auth_admin`, `login_as`, `totp_code` wait-mode, `require_feature`, `enable_expect_failure_trap`) exist in `tests/lib/common.sh`
- [x] Verified OIDC route path matches backend (`/api/v1/auth/sso/oidc/callback`) per existing `test-oidc-callback.sh`
- [x] `chmod +x` on all three files
- [ ] Run against current main backend in release-gate namespace — expect all PASS
- [ ] Run against 1.1.0-rc.2 backend — expect FAIL on the regression-asserting tests
- [ ] Confirm milestone v1.2.0 is set