### PR TITLE
test(pullthrough+webhooks): E2E reproducer tests for #1377 + #1367

### DIFF
--- a/tests/pullthrough/test-npm-scoped-tarball-1377.sh
+++ b/tests/pullthrough/test-npm-scoped-tarball-1377.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# test-npm-scoped-tarball-1377.sh - NPM Remote scoped package + tarball against npmjs.org
+#
+# E2E reproducer for artifact-keeper#1377 assertion (c): a Remote npm
+# repo backed by https://registry.npmjs.org must serve scoped package
+# metadata AND the tarball for that package without leaking the @scope
+# encoding or routing to the unscoped path.
+#
+# Closing PR: artifact-keeper#1391 (merged at 172508c0).
+#
+# Per #1391, the production code path that encodes @scope/pkg as
+# @scope%2Fpkg when proxying to upstream was already correct. The PR
+# adds a wiremock-backed Rust regression test
+#
+#   backend/src/api/handlers/npm::tests::
+#     test_remote_proxy_download_scoped_tarball_hits_encoded_upstream_path
+#
+# This bash test is the externally-visible E2E counterpart: it points
+# a Remote at the real npm registry and walks the client-facing wire
+# (metadata -> tarball) so a future refactor that drops %2F encoding
+# or mis-routes scoped paths to the unscoped fallback fails the gate.
+#
+# Package choice: @types/node
+#   * Stable, dependency-free, ubiquitous, and large enough that an
+#     empty response is unambiguous.
+#   * The metadata document advertises many versions and each version's
+#     `dist.tarball` URL is publicly resolvable.
+#   * We don't pin a specific tarball version up front; instead we
+#     parse the metadata, pull a tarball URL out of it, rewrite to the
+#     local Remote path, and assert the tarball downloads with non-zero
+#     bytes. This avoids breakage when upstream rotates versions.
+#
+# What this test asserts:
+#   1. /npm/<remote>/@types/node returns HTTP 200 with valid JSON whose
+#      .name == "@types/node" (i.e. the Remote proxy + %2F encoding for
+#      the upstream metadata request is correct).
+#   2. The metadata document advertises at least one version with a
+#      .dist.tarball URL.
+#   3. GET /npm/<remote>/@types/node/-/node-<version>.tgz returns 200
+#      with a non-empty body (the binary tarball). This is the exact
+#      assertion from #1377 -- "the tarball downloads (200, non-empty
+#      bytes)" -- against a real upstream.
+#
+# Skip behaviour:
+#   If registry.npmjs.org is unreachable, the suite skips gracefully.
+#   The reachability gate is the first test.
+#
+# Requires: curl, jq
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "npm-scoped-tarball-1377"
+auth_admin
+setup_workdir
+
+REMOTE_KEY="test-npm-scoped-1377-${RUN_ID}"
+UPSTREAM_URL="https://registry.npmjs.org"
+SCOPE="@types"
+PKG_SHORT="node"
+SCOPED_NAME="${SCOPE}/${PKG_SHORT}"
+
+UPSTREAM_REACHABLE=false
+
+# -------------------------------------------------------------------------
+# Reachability gate. Probe registry.npmjs.org for the @types/node
+# document before touching the API so an offline runner produces a
+# clean "skip" rather than a cascade of failures.
+# -------------------------------------------------------------------------
+
+begin_test "Probe upstream registry.npmjs.org reachability"
+if curl -sf --max-time 10 "${UPSTREAM_URL}/@types%2Fnode" -o /dev/null 2>/dev/null; then
+  UPSTREAM_REACHABLE=true
+  pass
+else
+  skip "registry.npmjs.org unreachable from test environment"
+fi
+
+# -------------------------------------------------------------------------
+# Create Remote npm repo.
+# -------------------------------------------------------------------------
+
+begin_test "Create Remote npm repo against registry.npmjs.org"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+elif create_remote_repo "$REMOTE_KEY" "npm" "$UPSTREAM_URL"; then
+  pass
+else
+  fail "could not create Remote npm repo against ${UPSTREAM_URL}"
+fi
+
+sleep 2
+
+# -------------------------------------------------------------------------
+# Assertion (c) part 1: scoped metadata fetches end-to-end.
+#
+# Client GET path is the un-encoded @scope/pkg form. The handler must
+# encode the upstream request as @scope%2Fpkg internally. Pre-fix
+# regressions would route to the unscoped fallback or 404; we assert
+# 200 + .name == "@types/node".
+# -------------------------------------------------------------------------
+
+METADATA_JSON=""
+
+begin_test "GET scoped metadata via Remote proxy"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+else
+  meta_tmp="${WORK_DIR}/metadata.json"
+  meta_status=$(curl -s -o "$meta_tmp" -w '%{http_code}' \
+    $CURL_TIMEOUT \
+    -H "$(format_auth_header)" \
+    "${BASE_URL}/npm/${REMOTE_KEY}/${SCOPED_NAME}" 2>/dev/null) || meta_status="000"
+  METADATA_JSON=$(cat "$meta_tmp" 2>/dev/null || echo "")
+  if [ "$meta_status" != "200" ]; then
+    fail "expected HTTP 200 for scoped metadata, got ${meta_status}" "${METADATA_JSON:0:500}"
+  else
+    fetched_name=$(echo "$METADATA_JSON" | jq -r '.name // empty' 2>/dev/null) || fetched_name=""
+    if [ "$fetched_name" = "${SCOPED_NAME}" ]; then
+      pass
+    else
+      fail "metadata .name='${fetched_name}', expected '${SCOPED_NAME}'" "${METADATA_JSON:0:500}"
+    fi
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Assertion (c) part 2: extract a published version + its tarball URL
+# from the metadata. We pick the latest version advertised in
+# .dist-tags.latest so the version we attempt to download is one the
+# registry actually serves right now.
+# -------------------------------------------------------------------------
+
+TARBALL_VERSION=""
+TARBALL_FILENAME=""
+
+begin_test "Metadata advertises at least one version with dist.tarball"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+elif [ -z "$METADATA_JSON" ]; then
+  fail "no metadata to parse"
+else
+  TARBALL_VERSION=$(echo "$METADATA_JSON" | jq -r '."dist-tags".latest // empty' 2>/dev/null) || TARBALL_VERSION=""
+  if [ -z "$TARBALL_VERSION" ] || [ "$TARBALL_VERSION" = "null" ]; then
+    # Fall back to the first version key. .versions is an object keyed
+    # by version string; .versions | keys[0] is the first by jq's
+    # lexicographic ordering, which is fine for "any one version".
+    TARBALL_VERSION=$(echo "$METADATA_JSON" | jq -r '.versions | keys[0] // empty' 2>/dev/null) || TARBALL_VERSION=""
+  fi
+
+  if [ -z "$TARBALL_VERSION" ] || [ "$TARBALL_VERSION" = "null" ]; then
+    fail "no version advertised in metadata document" "${METADATA_JSON:0:500}"
+  else
+    upstream_tarball=$(echo "$METADATA_JSON" | jq -r --arg v "$TARBALL_VERSION" '.versions[$v].dist.tarball // empty' 2>/dev/null) || upstream_tarball=""
+    if [ -z "$upstream_tarball" ] || [ "$upstream_tarball" = "null" ]; then
+      fail "version ${TARBALL_VERSION} has no dist.tarball" "${METADATA_JSON:0:500}"
+    else
+      # Tarballs in the npm registry use a stable URL shape:
+      #   https://registry.npmjs.org/@types/node/-/node-20.x.x.tgz
+      # We need just the filename for the local Remote path.
+      TARBALL_FILENAME=$(basename "$upstream_tarball")
+      if [ -z "$TARBALL_FILENAME" ]; then
+        fail "could not extract tarball filename from ${upstream_tarball}"
+      else
+        pass
+      fi
+    fi
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Assertion (c) part 3: GET the tarball through the Remote proxy.
+#
+# Client URL is /npm/<remote>/@scope/pkg/-/<filename>. The backend must
+# encode @scope/pkg as @scope%2Fpkg when calling upstream. Pre-fix
+# regressions surface as either a 404 (unscoped fallback path) or a
+# zero-byte response (encoding dropped). We assert HTTP 200 AND
+# non-zero file size.
+# -------------------------------------------------------------------------
+
+begin_test "Download scoped tarball via Remote proxy (200 + non-empty)"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+elif [ -z "$TARBALL_FILENAME" ]; then
+  fail "no tarball filename from previous step"
+else
+  out_file="${WORK_DIR}/remote-scoped.tgz"
+  tar_status=$(curl -s -o "$out_file" -w '%{http_code}' \
+    $CURL_TIMEOUT \
+    -H "$(format_auth_header)" \
+    "${BASE_URL}/npm/${REMOTE_KEY}/${SCOPED_NAME}/-/${TARBALL_FILENAME}" 2>/dev/null) || tar_status="000"
+
+  if [ "$tar_status" != "200" ]; then
+    body_snip=""
+    if [ -f "$out_file" ]; then
+      body_snip=$(head -c 200 "$out_file" 2>/dev/null || echo "")
+    fi
+    fail "expected HTTP 200 downloading tarball, got ${tar_status}" "$body_snip"
+  elif [ ! -s "$out_file" ]; then
+    fail "tarball downloaded (200) but file is empty"
+  else
+    file_size=$(wc -c < "$out_file" | tr -d ' ')
+    # Real @types/node tarballs are >>1KB; anything under a few hundred
+    # bytes is likely an error page misclassified by curl, so we
+    # require a meaningful minimum.
+    if [ "${file_size:-0}" -lt 256 ]; then
+      fail "tarball is suspiciously small (${file_size} bytes), likely not a real tarball"
+    else
+      pass
+    fi
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Cleanup
+# -------------------------------------------------------------------------
+
+api_delete "/api/v1/repositories/${REMOTE_KEY}" > /dev/null 2>&1 || true
+
+end_suite

--- a/tests/pullthrough/test-pypi-simple-root-1377.sh
+++ b/tests/pullthrough/test-pypi-simple-root-1377.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# test-pypi-simple-root-1377.sh - PyPI Remote simple-root index against a real upstream
+#
+# E2E reproducer for artifact-keeper#1377 assertion (a): the PyPI Remote
+# /simple/ root index must return a non-empty HTML listing when proxied
+# against a real upstream.
+#
+# Closing PR: artifact-keeper#1391 (merged at 172508c0).
+#
+# Root cause (per #1391):
+#   pypi.rs::simple_root previously only queried the local artifacts
+#   table, so a pure-proxy Remote PyPI repo returned an empty
+#   <body></body> for /simple/ even when the upstream advertised
+#   hundreds of projects. The fix in #1391 adds an upstream proxy +
+#   merge path for Remote/Virtual repos and parses PEP 503 root HTML.
+#
+# What this test asserts:
+#   1. /pypi/<remote-key>/simple/ returns HTTP 200 against a real
+#      pypi.org-backed Remote repo (reachability gate first).
+#   2. The body contains at least one <a ...>...</a> anchor entry,
+#      proving simple_root proxied + parsed the upstream rather than
+#      returning the previously-empty local-only result.
+#   3. A second fetch of /simple/ also returns HTTP 200 with the same
+#      shape, exercising the cache_path="simple/" proxy cache the fix
+#      wired up (no upstream re-fetch is required for the assertion to
+#      pass, but a working cache roundtrip would also satisfy it).
+#
+# Companion #1377 assertion (b) -- PyPI simple-root XSS sanitisation
+# against a hostile upstream -- is NOT covered here. It is covered by
+# the inline Rust unit tests added in #1391:
+#
+#   backend/src/api/handlers/pypi::tests::
+#     test_parse_simple_root_projects_extracts_from_pep503_html
+#     test_parse_simple_root_projects_falls_back_to_href_when_text_missing
+#     test_parse_simple_root_projects_empty_when_no_anchors
+#     test_parse_simple_root_projects_accepts_single_quoted_hrefs
+#     test_parse_simple_root_projects_mixed_quote_styles
+#     test_parse_simple_root_projects_decodes_html_entities_in_text
+#     test_parse_simple_root_projects_decodes_html_entities_in_href_fallback
+#     test_simple_root_remote_proxies_and_caches_upstream_index
+#
+# Driving a hostile upstream from bash would require a wiremock-style
+# fixture serving crafted PEP 503 HTML with <script> payloads; the unit
+# tests above already exercise the parser directly, so an E2E sanity
+# check against real pypi.org is sufficient for the proxy + cache path.
+#
+# Skip behaviour:
+#   If pypi.org is unreachable from the test runner (offline CI, egress
+#   restrictions), the suite skips gracefully rather than failing. The
+#   reachability gate is the first test so partial state doesn't leak
+#   into the JUnit output.
+#
+# Requires: curl, jq
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "pypi-simple-root-1377"
+auth_admin
+setup_workdir
+
+REMOTE_KEY="test-pypi-simpleroot-1377-${RUN_ID}"
+UPSTREAM_URL="https://pypi.org"
+
+UPSTREAM_REACHABLE=false
+
+# -------------------------------------------------------------------------
+# Reachability gate. Probe pypi.org BEFORE creating any repos so an
+# offline runner produces a single "skip" line rather than failing later.
+# -------------------------------------------------------------------------
+
+begin_test "Probe upstream pypi.org reachability"
+if curl -sf --max-time 10 "https://pypi.org/simple/" -o /dev/null 2>/dev/null; then
+  UPSTREAM_REACHABLE=true
+  pass
+else
+  skip "pypi.org unreachable from test environment"
+fi
+
+# -------------------------------------------------------------------------
+# Create Remote PyPI repo pointing at pypi.org.
+# -------------------------------------------------------------------------
+
+begin_test "Create Remote PyPI repo against pypi.org"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+elif create_remote_repo "$REMOTE_KEY" "pypi" "$UPSTREAM_URL"; then
+  pass
+else
+  fail "could not create Remote PyPI repo against ${UPSTREAM_URL}"
+fi
+
+# Brief settle before the first proxy fetch.
+sleep 2
+
+# -------------------------------------------------------------------------
+# Assertion (a) part 1: /simple/ returns 200 with non-empty HTML.
+#
+# Before #1391, this returned an empty <body></body>. After #1391,
+# simple_root proxies the upstream and merges with any local artifacts.
+# -------------------------------------------------------------------------
+
+FIRST_BODY=""
+FIRST_STATUS="000"
+ROOT_TMP="${WORK_DIR}/simple-root-first.html"
+
+begin_test "GET /simple/ returns non-empty HTML listing"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+else
+  FIRST_STATUS=$(curl -s -o "$ROOT_TMP" -w '%{http_code}' \
+    $CURL_TIMEOUT \
+    -H "$(format_auth_header)" \
+    "${BASE_URL}/pypi/${REMOTE_KEY}/simple/" 2>/dev/null) || FIRST_STATUS="000"
+  FIRST_BODY=$(cat "$ROOT_TMP" 2>/dev/null || echo "")
+  if [ "$FIRST_STATUS" != "200" ]; then
+    fail "expected HTTP 200, got ${FIRST_STATUS}" "${FIRST_BODY:0:500}"
+  elif [ -z "$FIRST_BODY" ]; then
+    fail "/simple/ returned 200 with an empty body (the exact #1377 regression)"
+  else
+    pass
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Assertion (a) part 2: body contains at least one <a ...>...</a> anchor.
+#
+# This is the strict bar from the task: "non-empty HTML listing at
+# least one anchor tag". PEP 503 root indexes look like:
+#   <a href="/simple/foo/">foo</a>
+# The pre-#1391 regression returned <html><body></body></html> with
+# zero anchors. We grep -c so the count itself is asserted, not just
+# the presence of the substring.
+# -------------------------------------------------------------------------
+
+begin_test "Body contains at least one anchor tag"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+elif [ -z "$FIRST_BODY" ]; then
+  fail "no body to inspect (earlier fetch failed)"
+else
+  anchor_count=$(printf '%s' "$FIRST_BODY" | grep -oE '<a [^>]*>' | wc -l | tr -d ' ')
+  if [ "${anchor_count:-0}" -lt 1 ]; then
+    fail "expected >=1 <a ...> anchor in /simple/ body, got ${anchor_count}" "${FIRST_BODY:0:500}"
+  else
+    pass
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Cache roundtrip: second fetch should also return 200 with a
+# similarly-shaped body. The fix wired the response through the
+# proxy_service cache under cache_path="simple/", so this exercises
+# both the cache-write (first call) and cache-read (this call) paths.
+#
+# We don't byte-diff the bodies because upstream pypi.org adds new
+# packages constantly and the listing can drift between the two
+# fetches; the anchor-count assertion is the load-bearing check.
+# -------------------------------------------------------------------------
+
+begin_test "Second GET /simple/ also returns non-empty HTML"
+if [ "$UPSTREAM_REACHABLE" != "true" ]; then
+  skip "upstream unreachable"
+else
+  sleep 1
+  SECOND_TMP="${WORK_DIR}/simple-root-second.html"
+  SECOND_STATUS=$(curl -s -o "$SECOND_TMP" -w '%{http_code}' \
+    $CURL_TIMEOUT \
+    -H "$(format_auth_header)" \
+    "${BASE_URL}/pypi/${REMOTE_KEY}/simple/" 2>/dev/null) || SECOND_STATUS="000"
+  SECOND_BODY=$(cat "$SECOND_TMP" 2>/dev/null || echo "")
+  if [ "$SECOND_STATUS" != "200" ]; then
+    fail "expected HTTP 200 on second fetch, got ${SECOND_STATUS}" "${SECOND_BODY:0:500}"
+  elif [ -z "$SECOND_BODY" ]; then
+    fail "second /simple/ fetch returned 200 with an empty body (cache regression?)"
+  else
+    second_anchor_count=$(printf '%s' "$SECOND_BODY" | grep -oE '<a [^>]*>' | wc -l | tr -d ' ')
+    if [ "${second_anchor_count:-0}" -lt 1 ]; then
+      fail "expected >=1 anchor on second fetch, got ${second_anchor_count}"
+    else
+      pass
+    fi
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Cleanup
+# -------------------------------------------------------------------------
+
+api_delete "/api/v1/repositories/${REMOTE_KEY}" > /dev/null 2>&1 || true
+
+end_suite

--- a/tests/webhooks/test-webhook-delivery.sh
+++ b/tests/webhooks/test-webhook-delivery.sh
@@ -20,6 +20,17 @@
 # database row; with the receiver wired we can also assert the wire
 # headers on the actual delivery.
 #
+# Also serves as the E2E reproducer for artifact-keeper#1367 ("Webhook
+# subsystem broken in release-gate deploy"). Closing PR
+# artifact-keeper-test#188 fixed the env-var rename
+# (WEBHOOK_ALLOW_PRIVATE_IPS -> UPSTREAM_ALLOW_PRIVATE_IPS) that this
+# test depends on; without that rename the mock receiver at 127.0.0.1
+# is rejected at create time and the steps below all fail at "Create
+# webhook subscribed to repository_created". With the rename in place,
+# the suite proves the producer task is alive, EventBus is wired, and
+# the delivery worker POSTs to a real receiver within 30s of the
+# triggering repo creation, which is the regression bar for #1367.
+#
 # Requires: curl, jq, python3
 
 source "$(dirname "$0")/../lib/common.sh"


### PR DESCRIPTION
## Summary

E2E reproducer tests for the v1.2.0 proxy + webhook bug buckets closed by `artifact-keeper#1391` (merged at 172508c0) and `artifact-keeper-test#188` (merged). Three files, one new commit, do-not-merge until each suite has been run against a v1.2.0-rc backend.

| Assertion | File | Status |
|---|---|---|
| #1377 (a) PyPI simple-root listing against real upstream | `tests/pullthrough/test-pypi-simple-root-1377.sh` (new) | added |
| #1377 (b) PyPI simple-root XSS defense | covered by Rust unit tests in #1391 | documented in test header, no E2E |
| #1377 (c) NPM scoped tarball download against npmjs.org | `tests/pullthrough/test-npm-scoped-tarball-1377.sh` (new) | added |
| #1367 webhook delivery to real receiver | `tests/webhooks/test-webhook-delivery.sh` (already covered) | header anchor added |

## Details

### `test-pypi-simple-root-1377.sh`

Remote PyPI repo pointed at `https://pypi.org`. Asserts `/pypi/<remote>/simple/` returns HTTP 200 with non-empty HTML containing at least one `<a ...>` anchor (`grep -oE '<a [^>]*>' | wc -l >= 1`). This was the exact regression: before #1391, `simple_root` only queried the local artifacts table and Remote repos returned `<html><body></body></html>`. A second fetch exercises the proxy_service cache that #1391 wired up under `cache_path="simple/"`.

Reachability gate (curl --max-time 10 against pypi.org) runs first so an offline CI runner produces one clean skip rather than a failure cascade.

### `test-npm-scoped-tarball-1377.sh`

Remote npm repo pointed at `https://registry.npmjs.org`. Walks the full client wire for `@types/node`:

1. `GET /npm/<remote>/@types/node` -> 200 with `.name == "@types/node"`
2. Parse `dist-tags.latest` (or fall back to `versions | keys[0]`) to pick a real version + extract its `dist.tarball` URL
3. `GET /npm/<remote>/@types/node/-/node-<version>.tgz` -> 200 + file size >= 256 bytes

A regression that drops `@scope/pkg` -> `@scope%2Fpkg` encoding or routes scoped paths to the unscoped fallback fails step 1 or 3. The `>= 256 bytes` floor catches the "200 but empty body" misclassification class.

Same reachability gate as the pypi test.

### `tests/webhooks/test-webhook-delivery.sh` (header-only)

The existing test already implements the regression bar for #1367: create a webhook subscribed to `repository_created`, create a repo to trigger the EventBus event, verify the local mock receiver records the delivery within 30s. The change here is a comment anchor referencing #1367 and `aktest#188` (the env-var rename that unblocked 127.0.0.1 receivers) so future `grep #1367` finds it.

## Intentionally NOT covered as E2E

#1377 assertion (b), the PyPI simple-root XSS sanitisation against a hostile upstream, is covered by inline Rust unit tests added in `artifact-keeper#1391`:

```
backend/src/api/handlers/pypi::tests::
  test_parse_simple_root_projects_extracts_from_pep503_html
  test_parse_simple_root_projects_falls_back_to_href_when_text_missing
  test_parse_simple_root_projects_empty_when_no_anchors
  test_parse_simple_root_projects_accepts_single_quoted_hrefs
  test_parse_simple_root_projects_mixed_quote_styles
  test_parse_simple_root_projects_decodes_html_entities_in_text
  test_parse_simple_root_projects_decodes_html_entities_in_href_fallback
  test_simple_root_remote_proxies_and_caches_upstream_index
```

Driving a hostile upstream from bash would require a wiremock fixture serving crafted PEP 503 HTML with `<script>` payloads; the unit tests above already exercise the parser directly. The pypi-simple-root-1377 header documents this exclusion so it is auditable rather than silently dropped.

## Test plan

- [ ] `bash tests/pullthrough/test-pypi-simple-root-1377.sh` against a v1.2.0-rc backend with egress to pypi.org -> all tests pass
- [ ] Same script against pre-#1391 backend -> fails "Body contains at least one anchor tag" (proves the assertion is load-bearing)
- [ ] `bash tests/pullthrough/test-npm-scoped-tarball-1377.sh` against v1.2.0-rc with egress to registry.npmjs.org -> all tests pass
- [ ] `bash tests/webhooks/test-webhook-delivery.sh` against a deploy that has `UPSTREAM_ALLOW_PRIVATE_IPS=1` (post aktest#188) -> all tests pass
- [ ] Same script against pre-aktest#188 helm values -> fails at "Create webhook subscribed to repository_created" (proves #1367 regression bar)

Do not merge until the above test plan has been walked against rc.3.

Closes #192. Refs artifact-keeper#1377, artifact-keeper#1391, artifact-keeper#1367, artifact-keeper-test#188.