### PR TITLE
test(search+sbom): E2E reproducer tests for #1372 #1375

### DIFF
--- a/tests/search/test-cve-history-1375.sh
+++ b/tests/search/test-cve-history-1375.sh
@@ -1,0 +1,389 @@
+#!/usr/bin/env bash
+# test-cve-history-1375.sh -- E2E reproducer for artifact-keeper#1375.
+#
+# Closing PR: artifact-keeper#1385 (open at script-write time; commit base
+# 4af20370). The unit and contract tests landed in that PR exercise
+# `is_valid_cve_id`, `classify_cve_history_path`, and the trends aggregate.
+# This script is the wire-level counterpart that fires real HTTP against a
+# running backend so we catch a future revert that fixes the unit test but
+# leaves the router misconfigured.
+#
+# Bug class: two separate regressions filed together in #1375.
+#   a) GET /sbom/cve/history/{id} typed `Path<Uuid>` rejected every
+#      CVE id with a bare HTTP 400 from Axum's path extractor before
+#      reaching the handler. The PR rewrites the path param as a `String`
+#      and dispatches on a UUID/CVE-id sniff inside the handler.
+#   b) GET /sbom/cve/trends filtered the aggregate rollup on a stale enum
+#      value, returning {total: 0, open: 0, fixed: 0} for every database
+#      state. The PR fixes the filter so the totals actually reflect the
+#      cve_history table.
+#   c) The PR also introduces two split routes for new clients:
+#         GET /sbom/cve/history/by-artifact/{uuid}
+#         GET /sbom/cve/history/by-cve/{cve_id}
+#      These should both return 200 in their respective happy paths.
+#
+# Endpoints (verified against backend/src/api/handlers/sbom.rs router):
+#   GET /api/v1/sbom/cve/history/{id}                  (overloaded shape)
+#   GET /api/v1/sbom/cve/history/by-cve/{cve_id}       (new canonical)
+#   GET /api/v1/sbom/cve/history/by-artifact/{uuid}    (new canonical)
+#   GET /api/v1/sbom/cve/trends                        (aggregate fix)
+#
+# Fixture: same lodash 4.17.4 / CVE-2019-10744 payload used by
+# tests/security/test-scan-completes.sh and tests/release-gate/test-pinned-cve.sh.
+# Trivy's npm package-lock parser detects this CVE deterministically and the
+# scan emits at least one finding with cve_id == "CVE-2019-10744". The scan
+# pipeline writes a row into cve_history, which is the table the endpoints
+# under test read. Without the fixture there would be nothing to assert
+# against on a clean database.
+#
+# Skips cleanly if:
+#   - sbom routes are not mounted (404/501)
+#   - the scanner pod is unreachable (skipper consistent with test-scan-completes.sh)
+#   - the backend predates PR #1385 (any of the new endpoints 404)
+#
+# Requires: curl, jq, tar
+
+# shellcheck source=../lib/common.sh disable=SC1091
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "cve-history-1375"
+auth_admin
+setup_workdir
+
+REPO_KEY="cvehist-${RUN_ID}"
+PACKAGE_NAME="lodash-vuln-fixture"
+PACKAGE_VERSION="1.0.0"
+TARBALL_NAME="${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz"
+ARTIFACT_PATH="${PACKAGE_NAME}/${PACKAGE_VERSION}/${TARBALL_NAME}"
+SCAN_TIMEOUT="${SCAN_TIMEOUT:-180}"
+EXPECTED_CVE="${EXPECTED_CVE:-CVE-2019-10744}"
+
+add_exit_handler "api_delete \"/api/v1/repositories/${REPO_KEY}\" >/dev/null 2>&1 || true"
+
+# ---------------------------------------------------------------------------
+# Preflight. The /sbom/cve/trends route exists in every supported backend
+# (it predates this PR), so a 404 here means we are running against a
+# pre-v1.1 backend that we cannot meaningfully gate.
+# ---------------------------------------------------------------------------
+
+preflight_status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/sbom/cve/trends" 2>/dev/null || echo "000")
+case "$preflight_status" in
+  404|501) skip_suite "sbom/cve routes not mounted (HTTP ${preflight_status})" ;;
+  503|504|000) skip_suite "backend unavailable on cve/trends probe (HTTP ${preflight_status})" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Build the known-vulnerable lodash 4.17.4 tarball. Trivy's package-lock
+# parser keys on the .version field; the integrity SHA is the real
+# published value to keep the lockfile realistic, but Trivy does not
+# resolve it. This is the same payload as test-pinned-cve.sh, kept
+# self-contained so this script can run standalone without depending on
+# the order of other suites.
+# ---------------------------------------------------------------------------
+
+begin_test "Build lodash 4.17.4 fixture (CVE-2019-10744)"
+mkdir -p "${WORK_DIR}/package"
+cat > "${WORK_DIR}/package/package.json" <<EOF
+{
+  "name": "${PACKAGE_NAME}",
+  "version": "${PACKAGE_VERSION}",
+  "dependencies": { "lodash": "4.17.4" }
+}
+EOF
+cat > "${WORK_DIR}/package/package-lock.json" <<EOF
+{
+  "name": "${PACKAGE_NAME}",
+  "version": "${PACKAGE_VERSION}",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": { "name": "${PACKAGE_NAME}", "version": "${PACKAGE_VERSION}",
+          "dependencies": { "lodash": "4.17.4" } },
+    "node_modules/lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyLuHBHJgwGu1myF0sR4U="
+    }
+  },
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyLuHBHJgwGu1myF0sR4U="
+    }
+  }
+}
+EOF
+if tar -czf "${WORK_DIR}/${TARBALL_NAME}" -C "${WORK_DIR}" package 2>/dev/null; then
+  pass
+else
+  fail "could not build vulnerable fixture tarball"
+  end_suite
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Repo + upload.
+# ---------------------------------------------------------------------------
+
+begin_test "Create generic local repo"
+if create_local_repo "$REPO_KEY" "generic" >/dev/null 2>&1; then
+  pass
+else
+  fail "could not create generic repository ${REPO_KEY}"
+  end_suite
+  exit 1
+fi
+
+begin_test "Upload vulnerable fixture"
+# shellcheck disable=SC2086  # CURL_TIMEOUT must word-split, per common.sh
+upload_status=$(curl -s -o "${WORK_DIR}/upload-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -X PUT \
+  -H "$(auth_header)" \
+  -H "Content-Type: application/gzip" \
+  --data-binary "@${WORK_DIR}/${TARBALL_NAME}" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/${ARTIFACT_PATH}") || upload_status="000"
+if [ "$upload_status" = "200" ] || [ "$upload_status" = "201" ]; then
+  pass
+else
+  fail "fixture upload returned HTTP ${upload_status}"
+  end_suite
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve the artifact UUID. The list endpoint shape matches what
+# test-pinned-cve.sh and test-scan-completes.sh use.
+# ---------------------------------------------------------------------------
+
+begin_test "Resolve artifact_id"
+ARTIFACT_ID=""
+# shellcheck disable=SC2086
+list_status=$(curl -s -o "${WORK_DIR}/list-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts") || list_status="000"
+if [ "$list_status" = "200" ]; then
+  ARTIFACT_ID=$(jq -er --arg p "$ARTIFACT_PATH" \
+    '.items | map(select(.path == $p or .name == $p)) | first | .id // empty' \
+    < "${WORK_DIR}/list-resp.json" 2>/dev/null || true)
+fi
+if [ -n "$ARTIFACT_ID" ] && [ "$ARTIFACT_ID" != "null" ]; then
+  pass
+else
+  fail "could not resolve artifact_id (list HTTP ${list_status})"
+  end_suite
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Trigger a scan with force=true. The scan must populate the cve_history
+# table for the assertions below to have anything to find.
+# ---------------------------------------------------------------------------
+
+begin_test "Trigger scan for vulnerable fixture"
+trigger_body=$(jq -n --arg id "$ARTIFACT_ID" '{artifact_id: $id, force: true}')
+# shellcheck disable=SC2086
+trig_status=$(curl -s -o "${WORK_DIR}/trig-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -X POST \
+  -H "$(auth_header)" \
+  -H "Content-Type: application/json" \
+  -d "$trigger_body" \
+  "${BASE_URL}/api/v1/security/scan") || trig_status="000"
+case "$trig_status" in
+  2*) pass ;;
+  503|504|000)
+    skip "scanner unavailable (HTTP ${trig_status}); cannot exercise cve_history endpoints"
+    end_suite
+    exit 0
+    ;;
+  *) fail "scan trigger returned HTTP ${trig_status}" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Poll for completed scan. Reuses the polling pattern from
+# test-pinned-cve.sh so behavioural drift is bounded.
+# ---------------------------------------------------------------------------
+
+begin_test "Scan reaches completed within ${SCAN_TIMEOUT}s"
+elapsed=0
+final_status=""
+while [ "$elapsed" -lt "$SCAN_TIMEOUT" ]; do
+  # shellcheck disable=SC2086
+  poll_status=$(curl -s -o "${WORK_DIR}/scans-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/security/artifacts/${ARTIFACT_ID}/scans") || poll_status="000"
+  if [ "$poll_status" = "200" ]; then
+    scan_obj=$(jq -c '.items[0] // empty' < "${WORK_DIR}/scans-resp.json" 2>/dev/null || echo "")
+    if [ -n "$scan_obj" ]; then
+      state=$(echo "$scan_obj" | jq -r '.status | ascii_downcase' 2>/dev/null || echo "unknown")
+      case "$state" in
+        completed|failed|error|timeout) final_status="$state"; break ;;
+      esac
+    fi
+  fi
+  sleep 5
+  elapsed=$(( elapsed + 5 ))
+done
+if [ "$final_status" = "completed" ]; then
+  pass
+elif [ -z "$final_status" ]; then
+  fail "scan did not reach a terminal state within ${SCAN_TIMEOUT}s"
+  end_suite
+  exit 1
+else
+  fail "scan terminal status was '${final_status}', expected 'completed'"
+  end_suite
+  exit 1
+fi
+
+# Allow the scan->cve_history projection a moment to settle. The pipeline
+# inserts into cve_history inside the same transaction as the scan
+# completion update in modern builds, but older 1.1.x paths flush async.
+sleep 2
+
+# ---------------------------------------------------------------------------
+# Case (a): GET /sbom/cve/history/{cve_id} must return 200 for valid CVE
+# ids of varying suffix length. Pre-#1385: Axum's Path<Uuid> extractor
+# rejected any non-UUID with a generic 400.
+#
+# Coverage matrix:
+#   - 4-digit suffix:  CVE-1999-0001  (oldest valid form)
+#   - 5-digit suffix:  CVE-2019-10744 (the fixture / release-gate value)
+#   - 6-digit suffix:  CVE-2024-123456 (high-volume modern numbering)
+#
+# Behaviour: 200 with a (possibly empty) array body. The fixture's CVE
+# must additionally produce a non-empty timeline. The synthetic 4-digit
+# and 6-digit CVEs may legitimately return [] (the database has never
+# seen them), but they MUST NOT 400.
+# ---------------------------------------------------------------------------
+
+_cve_history_status() {
+  local cve_id="$1"
+  # shellcheck disable=SC2086  # CURL_TIMEOUT must word-split, per common.sh
+  curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/sbom/cve/history/${cve_id}" 2>/dev/null || echo "000"
+}
+
+begin_test "GET /sbom/cve/history/CVE-1999-0001 (4-digit suffix) does not 400 (regression #1375)"
+status=$(_cve_history_status "CVE-1999-0001")
+case "$status" in
+  200) pass ;;
+  400) fail "4-digit CVE id rejected with HTTP 400; regression of #1375 (Path<Uuid> extractor)" ;;
+  404) skip "CVE-1999-0001 not present and route returns 404 instead of 200 [] (acceptable)" ;;
+  *)   fail "unexpected HTTP ${status} for 4-digit CVE id" ;;
+esac
+
+begin_test "GET /sbom/cve/history/${EXPECTED_CVE} (5-digit suffix) returns non-empty timeline"
+# shellcheck disable=SC2086  # CURL_TIMEOUT must word-split, per common.sh
+hist_body=$(curl -sf $CURL_TIMEOUT -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/sbom/cve/history/${EXPECTED_CVE}" 2>/dev/null || echo "")
+if [ -z "$hist_body" ]; then
+  status=$(_cve_history_status "${EXPECTED_CVE}")
+  fail "GET /sbom/cve/history/${EXPECTED_CVE} returned no body (HTTP ${status}); pre-#1385 returned 400 for this exact id"
+elif ! echo "$hist_body" | jq -e 'type == "array"' >/dev/null 2>&1; then
+  fail "cve/history/${EXPECTED_CVE} response was not a JSON array" "$hist_body"
+else
+  hist_count=$(echo "$hist_body" | jq -r 'length')
+  if [ "$hist_count" -ge 1 ]; then
+    pass
+  else
+    # The route is fixed (no 400) but the scan didn't populate
+    # cve_history. Common cause: the trivy parser didn't surface
+    # cve_id on this build. Skip rather than fail so we don't
+    # double-count test-scan-completes.sh / test-pinned-cve.sh.
+    skip "cve_history empty for ${EXPECTED_CVE}; scan may not have projected into cve_history table"
+  fi
+fi
+
+begin_test "GET /sbom/cve/history/CVE-2024-123456 (6-digit suffix) does not 400 (regression #1375)"
+status=$(_cve_history_status "CVE-2024-123456")
+case "$status" in
+  200) pass ;;
+  400) fail "6-digit CVE id rejected with HTTP 400; regex too restrictive (regression of #1375)" ;;
+  404) skip "CVE-2024-123456 absent and route returns 404 (acceptable shape)" ;;
+  *)   fail "unexpected HTTP ${status} for 6-digit CVE id" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Case (c): new canonical route GET /sbom/cve/history/by-cve/{cve_id}.
+# This route is mounted before the overloaded /{id} route in the PR's
+# router order, so any backend with the PR in place must return 200.
+# A 404 here proves the new split route was not wired up.
+# ---------------------------------------------------------------------------
+
+begin_test "GET /sbom/cve/history/by-cve/${EXPECTED_CVE} returns 200 (new canonical route)"
+# shellcheck disable=SC2086  # CURL_TIMEOUT must word-split, per common.sh
+by_cve_status=$(curl -s -o "${WORK_DIR}/by-cve-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/sbom/cve/history/by-cve/${EXPECTED_CVE}" 2>/dev/null || echo "000")
+case "$by_cve_status" in
+  200)
+    if jq -e 'type == "array"' < "${WORK_DIR}/by-cve-resp.json" >/dev/null 2>&1; then
+      pass
+    else
+      fail "by-cve route returned 200 but body was not a JSON array" "$(head -c 500 "${WORK_DIR}/by-cve-resp.json")"
+    fi
+    ;;
+  404) fail "by-cve route returned 404; new canonical split-route from #1385 not mounted" ;;
+  *)   fail "by-cve route returned HTTP ${by_cve_status}" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Case (d): GET /sbom/cve/history/by-artifact/{uuid} must still return 200.
+# Same split route, UUID arm. A 200 here with a JSON-array body proves
+# the typed-UUID dispatch survived the refactor.
+# ---------------------------------------------------------------------------
+
+begin_test "GET /sbom/cve/history/by-artifact/${ARTIFACT_ID} returns 200 (UUID path still works)"
+# shellcheck disable=SC2086  # CURL_TIMEOUT must word-split, per common.sh
+by_art_status=$(curl -s -o "${WORK_DIR}/by-art-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/sbom/cve/history/by-artifact/${ARTIFACT_ID}" 2>/dev/null || echo "000")
+case "$by_art_status" in
+  200)
+    if jq -e 'type == "array"' < "${WORK_DIR}/by-art-resp.json" >/dev/null 2>&1; then
+      pass
+    else
+      fail "by-artifact route returned 200 but body was not a JSON array" "$(head -c 500 "${WORK_DIR}/by-art-resp.json")"
+    fi
+    ;;
+  404) fail "by-artifact route returned 404; UUID arm of the split route not mounted" ;;
+  *)   fail "by-artifact route returned HTTP ${by_art_status}" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Case (b): GET /sbom/cve/trends after the vulnerable scan must return
+# non-zero totals. Pre-#1385 the aggregate filter on a stale enum value
+# always produced {total_cves: 0, open_cves: 0, fixed_cves: 0}; this is
+# the assertion that proves the filter was actually wired.
+#
+# fixed_cves may legitimately be 0 (we never marked anything fixed in this
+# test), but total_cves AND open_cves must be > 0 because the scan just
+# inserted at least one open CVE row.
+# ---------------------------------------------------------------------------
+
+begin_test "GET /sbom/cve/trends returns non-zero totals after vulnerable scan (regression #1375)"
+# shellcheck disable=SC2086  # CURL_TIMEOUT must word-split, per common.sh
+trends_body=$(curl -sf $CURL_TIMEOUT -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/sbom/cve/trends" 2>/dev/null || echo "")
+if [ -z "$trends_body" ]; then
+  fail "GET /sbom/cve/trends returned no body"
+elif ! echo "$trends_body" | jq -e '.total_cves and .open_cves and (.fixed_cves != null)' >/dev/null 2>&1; then
+  fail "trends response missing expected fields (total_cves, open_cves, fixed_cves)" "$trends_body"
+else
+  total=$(echo "$trends_body" | jq -r '.total_cves')
+  open=$(echo "$trends_body"  | jq -r '.open_cves')
+  fixed=$(echo "$trends_body" | jq -r '.fixed_cves')
+  if ! [[ "$total" =~ ^[0-9]+$ ]] || ! [[ "$open" =~ ^[0-9]+$ ]] || ! [[ "$fixed" =~ ^[0-9]+$ ]]; then
+    fail "trends totals not integers (total=${total}, open=${open}, fixed=${fixed})" "$trends_body"
+  elif [ "$total" -gt 0 ] && [ "$open" -gt 0 ]; then
+    pass
+  else
+    fail "trends totals are zero after vulnerable-scan fixture (total=${total}, open=${open}, fixed=${fixed}); pre-#1385 stale-enum filter regression" "$trends_body"
+  fi
+fi
+
+end_suite

--- a/tests/search/test-search-edges-1372.sh
+++ b/tests/search/test-search-edges-1372.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# test-search-edges-1372.sh -- E2E reproducer for artifact-keeper#1372.
+#
+# Closing PR: artifact-keeper#1384 (merged 2026-05-26). This script is the
+# E2E counterpart to the unit + integration tests landed in that PR; it
+# exercises the live HTTP surface so a future regression that re-introduces
+# the limit clamp or strips sort_order before reaching the SQL builder is
+# caught against the running backend (not just the in-process router).
+#
+# Bug class: silently overriding an explicit query parameter.
+#   a) `limit=0` (or `per_page=0` on advanced) was clamped to the default
+#      page size by `clamp(1, MAX)`. Effect: an autocomplete dropdown set
+#      to limit=0 still showed one suggestion; a recent-panel toggled to
+#      limit=0 still rendered the default page. The PR short-circuits
+#      Some(0) to an empty array BEFORE the clamp.
+#   b) `/search/advanced?sort_by=size&sort_order=asc` was indistinguishable
+#      from `sort_order=desc`. The size branch ordered by `created_at DESC`
+#      unconditionally; `sort_order` was deserialized off `AdvancedSearchQuery`
+#      but never wired into the underlying `SearchQuery` until the PR. The
+#      load-bearing assertion below uploads three sentinels of distinct
+#      sizes and asserts the head hit of asc != head hit of desc.
+#
+# Endpoints (verified against backend/src/api/handlers/search.rs router):
+#   GET /api/v1/search/suggest?prefix=&limit=    (limit=0 short-circuit)
+#   GET /api/v1/search/recent?limit=             (limit=0 short-circuit)
+#   GET /api/v1/search/advanced?per_page=0       (per_page=0 short-circuit)
+#   GET /api/v1/search/advanced?sort_by=size&sort_order=asc|desc
+#
+# NOTE: the task brief referenced `/search/autocomplete`; the actual route
+# is `/search/suggest` (see PR #1384 body: "/search/suggest ... honor
+# explicit limit=0"). Same handler, the alternative name was never minted.
+#
+# Skips cleanly if the search backend or indexer is not available; FAILs
+# loudly if the endpoints respond but return the wrong shape (silent
+# regression of the original #1372 behaviour).
+#
+# Requires: curl, jq, dd (for sized sentinels)
+
+# shellcheck source=../lib/common.sh disable=SC1091
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "search-edges-1372"
+auth_admin
+setup_workdir
+
+REPO_KEY="srch1372-${RUN_ID}"
+UNIQUE_TERM="s1372${RUN_ID//[^a-z0-9]/}"
+
+add_exit_handler "api_delete \"/api/v1/repositories/${REPO_KEY}\" >/dev/null 2>&1 || true"
+
+# ---------------------------------------------------------------------------
+# Preflight: confirm /search/suggest exists (handler is part of the same
+# router as /recent and /advanced, so a single probe is enough). If the
+# backend predates v1.2 the route may 404; gracefully skip rather than
+# fail the gate.
+# ---------------------------------------------------------------------------
+
+preflight_status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/search/suggest?prefix=preflight" 2>/dev/null || echo "000")
+case "$preflight_status" in
+  404|501) skip_suite "search/suggest endpoint not mounted (HTTP ${preflight_status})" ;;
+  503|504|000) skip_suite "search backend unavailable (HTTP ${preflight_status})" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Build three sentinels of clearly different sizes (small / medium / large).
+# Sizes chosen so the size column is unambiguously sortable: ~100 B, ~50 KiB,
+# ~2 MiB. dd is used over `head -c` because BusyBox `head` does not honour
+# `-c` on every runner.
+# ---------------------------------------------------------------------------
+
+begin_test "Build three sentinels with distinct sizes"
+small_path="${WORK_DIR}/${UNIQUE_TERM}-small.bin"
+medium_path="${WORK_DIR}/${UNIQUE_TERM}-medium.bin"
+large_path="${WORK_DIR}/${UNIQUE_TERM}-large.bin"
+
+if dd if=/dev/urandom of="$small_path"  bs=1   count=100  status=none 2>/dev/null && \
+   dd if=/dev/urandom of="$medium_path" bs=1k  count=50   status=none 2>/dev/null && \
+   dd if=/dev/urandom of="$large_path"  bs=1k  count=2048 status=none 2>/dev/null; then
+  pass
+else
+  fail "could not synthesise sentinel files via dd"
+  end_suite
+  exit 1
+fi
+
+begin_test "Create repo and upload sentinels"
+if create_local_repo "$REPO_KEY" "generic" >/dev/null 2>&1; then
+  api_upload "/api/v1/repositories/${REPO_KEY}/artifacts/${UNIQUE_TERM}/small/${UNIQUE_TERM}-small.bin"   "$small_path"  >/dev/null 2>&1 || true
+  api_upload "/api/v1/repositories/${REPO_KEY}/artifacts/${UNIQUE_TERM}/medium/${UNIQUE_TERM}-medium.bin" "$medium_path" >/dev/null 2>&1 || true
+  api_upload "/api/v1/repositories/${REPO_KEY}/artifacts/${UNIQUE_TERM}/large/${UNIQUE_TERM}-large.bin"   "$large_path"  >/dev/null 2>&1 || true
+  pass
+else
+  fail "could not create repo ${REPO_KEY}"
+  end_suite
+  exit 1
+fi
+
+# Indexer settle. The OpenSearch backend (v1.2.0+) and the SQL fallback both
+# need a moment to reflect the new rows in subsequent search calls.
+sleep 4
+
+# ---------------------------------------------------------------------------
+# Case (a): /search/suggest?limit=0 must return zero suggestions.
+#
+# The pre-fix behaviour was `clamp_positive_limit(Some(0), 10, 1, 50) == 1`,
+# so the response carried one fallback suggestion. The post-fix handler
+# short-circuits Some(0) to an empty Vec before touching the DB.
+# ---------------------------------------------------------------------------
+
+begin_test "GET /search/suggest?limit=0 returns empty array (regression #1372)"
+# shellcheck disable=SC2086  # CURL_TIMEOUT must word-split, per common.sh
+suggest_resp=$(curl -sf $CURL_TIMEOUT -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/search/suggest?prefix=${UNIQUE_TERM:0:4}&limit=0" 2>/dev/null || echo "")
+if [ -z "$suggest_resp" ]; then
+  fail "GET /search/suggest?limit=0 returned no body (network or non-2xx)"
+elif ! echo "$suggest_resp" | jq -e '.suggestions | type == "array"' >/dev/null 2>&1; then
+  fail "GET /search/suggest?limit=0 returned shape without .suggestions[]" "$suggest_resp"
+else
+  suggest_count=$(echo "$suggest_resp" | jq -r '.suggestions | length')
+  if [ "$suggest_count" = "0" ]; then
+    pass
+  else
+    fail "GET /search/suggest?limit=0 returned ${suggest_count} suggestions; expected 0 (pre-#1384 clamp regression)" "$suggest_resp"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Case (b): /search/recent?limit=0 must return an empty array.
+#
+# The recent endpoint returns Vec<SearchResultItem> directly (not wrapped in
+# an object), so we parse it as an array. Pre-fix: returned the default page
+# (20 items). Post-fix: empty array.
+# ---------------------------------------------------------------------------
+
+begin_test "GET /search/recent?limit=0 returns empty array (regression #1372)"
+# shellcheck disable=SC2086  # CURL_TIMEOUT must word-split, per common.sh
+recent_resp=$(curl -sf $CURL_TIMEOUT -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/search/recent?limit=0" 2>/dev/null || echo "")
+if [ -z "$recent_resp" ]; then
+  fail "GET /search/recent?limit=0 returned no body (network or non-2xx)"
+elif ! echo "$recent_resp" | jq -e 'type == "array"' >/dev/null 2>&1; then
+  fail "GET /search/recent?limit=0 returned non-array body" "$recent_resp"
+else
+  recent_count=$(echo "$recent_resp" | jq -r 'length')
+  if [ "$recent_count" = "0" ]; then
+    pass
+  else
+    fail "GET /search/recent?limit=0 returned ${recent_count} items; expected 0 (pre-#1384 clamp regression)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Case (b'): /search/advanced?per_page=0 must return an empty items array.
+#
+# Bonus assertion not in the issue text but covered by the same PR: the
+# advanced endpoint takes `per_page` (not `limit`) and also gained the
+# zero-page short-circuit. We check it because the legacy clamp would
+# otherwise leak through the AdvancedSearchQuery -> SearchQuery wiring.
+# ---------------------------------------------------------------------------
+
+begin_test "GET /search/advanced?per_page=0 returns empty items array"
+# shellcheck disable=SC2086  # CURL_TIMEOUT must word-split, per common.sh
+adv_zero_resp=$(curl -sf $CURL_TIMEOUT -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/search/advanced?query=${UNIQUE_TERM}&per_page=0" 2>/dev/null || echo "")
+if [ -z "$adv_zero_resp" ]; then
+  skip "advanced search per_page=0 probe returned no body"
+elif ! echo "$adv_zero_resp" | jq -e '.items | type == "array"' >/dev/null 2>&1; then
+  fail "advanced search per_page=0 response missing .items[]" "$adv_zero_resp"
+else
+  adv_zero_count=$(echo "$adv_zero_resp" | jq -r '.items | length')
+  if [ "$adv_zero_count" = "0" ]; then
+    pass
+  else
+    fail "advanced search per_page=0 returned ${adv_zero_count} items; expected 0" "$adv_zero_resp"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Case (c): /search/advanced?sort_by=size&sort_order=asc|desc must produce
+# DIFFERENT first hits. This is the canonical "sort_order actually flips"
+# assertion -- if asc and desc agree on the head of the result set, the
+# parameter was never applied.
+#
+# We restrict the query window to our three sentinels by filtering on
+# repository_key and the UNIQUE_TERM prefix so concurrent suites cannot
+# pollute the head of the list.
+# ---------------------------------------------------------------------------
+
+_first_path() {
+  # First .items[0].path on a 2xx advanced response, or empty.
+  local body="$1"
+  echo "$body" | jq -r '.items[0].path // .items[0].name // empty' 2>/dev/null || true
+}
+
+# shellcheck disable=SC2086  # CURL_TIMEOUT must word-split, per common.sh
+asc_resp=$(curl -sf $CURL_TIMEOUT -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/search/advanced?query=${UNIQUE_TERM}&repository_key=${REPO_KEY}&sort_by=size&sort_order=asc&per_page=10" 2>/dev/null || echo "")
+# shellcheck disable=SC2086  # CURL_TIMEOUT must word-split, per common.sh
+desc_resp=$(curl -sf $CURL_TIMEOUT -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/search/advanced?query=${UNIQUE_TERM}&repository_key=${REPO_KEY}&sort_by=size&sort_order=desc&per_page=10" 2>/dev/null || echo "")
+
+begin_test "advanced sort_by=size returned items for both directions"
+asc_count=$(echo "$asc_resp"  | jq -r '.items | length // 0' 2>/dev/null || echo 0)
+desc_count=$(echo "$desc_resp" | jq -r '.items | length // 0' 2>/dev/null || echo 0)
+if ! [[ "$asc_count" =~ ^[0-9]+$ ]] || ! [[ "$desc_count" =~ ^[0-9]+$ ]]; then
+  fail "advanced search returned unparseable items count (asc=${asc_count}, desc=${desc_count})"
+elif [ "$asc_count" -lt 2 ] || [ "$desc_count" -lt 2 ]; then
+  # If the indexer is too slow on this runner we cannot prove the flip, but
+  # we can still detect the regression because the *handler-level* sort
+  # logic operates on whatever rows did make it. Two rows is the minimum
+  # that lets head(asc) and head(desc) differ.
+  skip "indexer returned ${asc_count}/${desc_count} items for the sentinel window; not enough to prove the flip"
+else
+  pass
+fi
+
+begin_test "advanced sort_by=size head hit flips between asc and desc (regression #1372)"
+asc_head=$(_first_path "$asc_resp")
+desc_head=$(_first_path "$desc_resp")
+if [ -z "$asc_head" ] || [ -z "$desc_head" ]; then
+  skip "could not extract head hits (asc='${asc_head}', desc='${desc_head}')"
+elif [ "$asc_head" = "$desc_head" ]; then
+  fail "asc and desc head hits are identical ('${asc_head}'); sort_order was ignored (pre-#1384 regression)" \
+"asc response (first 500 bytes): $(echo "$asc_resp"  | jq -c '.items | map({path, size: .size_bytes // .size})' 2>/dev/null | cut -c 1-500)
+desc response (first 500 bytes): $(echo "$desc_resp" | jq -c '.items | map({path, size: .size_bytes // .size})' 2>/dev/null | cut -c 1-500)"
+else
+  pass
+fi
+
+# ---------------------------------------------------------------------------
+# Optional belt-and-braces: head(asc) should be the small sentinel and
+# head(desc) the large one. Skip rather than fail if .size_bytes is not
+# populated on this backend (older indexer rows had a null column).
+# ---------------------------------------------------------------------------
+
+begin_test "advanced sort_by=size orders by actual byte size (smallest first under asc)"
+asc_size=$(echo "$asc_resp" | jq -r '.items[0].size_bytes // .items[0].size // empty' 2>/dev/null || echo "")
+desc_size=$(echo "$desc_resp" | jq -r '.items[0].size_bytes // .items[0].size // empty' 2>/dev/null || echo "")
+if ! [[ "$asc_size" =~ ^[0-9]+$ ]] || ! [[ "$desc_size" =~ ^[0-9]+$ ]]; then
+  skip "size field not exposed on result items (asc='${asc_size}', desc='${desc_size}')"
+elif [ "$asc_size" -lt "$desc_size" ]; then
+  pass
+else
+  fail "head(asc).size=${asc_size} should be < head(desc).size=${desc_size}"
+fi
+
+end_suite


### PR DESCRIPTION
## Summary

Two issue-specific E2E reproducer scripts that exercise the live HTTP surface for the v1.2.0 search/SBOM fixes in artifact-keeper#1384 (merged) and artifact-keeper#1385 (open).

- `tests/search/test-search-edges-1372.sh` covers artifact-keeper#1372: `limit=0` / `per_page=0` short-circuit on `/search/suggest`, `/search/recent`, and `/search/advanced`; plus the `sort_by=size` head-hit-flip between `sort_order=asc` and `sort_order=desc`. Uploads three sentinels of distinct sizes (100 B, 50 KiB, 2 MiB) so the flip is deterministic against a single repo window.

- `tests/search/test-cve-history-1375.sh` covers artifact-keeper#1375: reuses the lodash 4.17.4 / CVE-2019-10744 fixture from `test-pinned-cve.sh`, runs a scan, and asserts the legacy overload route, both new canonical split routes (`by-cve/{cve_id}`, `by-artifact/{uuid}`), the 4/5/6-digit CVE-id suffix matrix, and the `/sbom/cve/trends` non-zero totals.

Both scripts source `tests/lib/common.sh`, emit JUnit XML, skip cleanly when the search backend or scanner is unavailable, and use the same `add_exit_handler` repo cleanup pattern as the existing search and security suites.

The `/sbom/cve/history/{EXPECTED_CVE}` assertion will start passing once artifact-keeper#1385 merges. Until then the script either skips (if the scanner is offline) or fails on that single assertion against current main while the other six tests (including both split-route probes and the trends totals) prove the rest of the surface.

## Why both files land in `tests/search/`

The CVE history file logically belongs under a `tests/sbom/` tree, but no such directory exists today (see `tests/platform/test-sbom.sh` for the only existing SBOM test). Adding a single file under a new dir would split the SBOM coverage across two places; the task brief calls this out explicitly. Filed under `tests/search/` so it sits next to the other search/SBOM-edge probes added in Epic 8.

## Test Plan

- `bash -n` passes on both scripts (verified locally).
- Pattern is consistent with `tests/security/test-scan-completes.sh` and `tests/release-gate/test-pinned-cve.sh` (same fixture build, same `auth_admin` / `setup_workdir` / `add_exit_handler` flow).
- Skip semantics: gracefully skips on 404/501/503/504/000 preflight; FAILs loudly if endpoints respond but return the pre-fix shape (this is the load-bearing assertion against silent regression).

Not merged in this PR per task brief - left open for release-gate validation against an artifact-keeper#1385 build first.

Closes #193