### PR TITLE
test(repos+security+api): E2E reproducer tests for #1366 #1368 #1373 #1374 #1376

### DIFF
--- a/tests/api/test-json-validation-400-1368.sh
+++ b/tests/api/test-json-validation-400-1368.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# test-json-validation-400-1368.sh -- Malformed JSON returns 400 VALIDATION_ERROR
+#
+# Reproducer / regression test for artifact-keeper#1368.
+#
+# Background
+#   Axum's stock Json<T> extractor rejects malformed request bodies with HTTP
+#   422 and an opaque text/plain message. Our public API contract is:
+#     "any client error returns 400 with {code: 'VALIDATION_ERROR', message: ...}"
+#   This is what every other 400 in the codebase emits (AppError::Validation
+#   maps to (BAD_REQUEST, "VALIDATION_ERROR") in backend/src/error.rs).
+#
+#   PR #1381 introduced `crate::api::extractors::Json<T>`, a drop-in wrapper
+#   around axum::Json that converts any JsonRejection into AppError::Validation
+#   so the response envelope is consistent. The repositories handlers were
+#   swapped to the new extractor.
+#
+# What this script catches
+#   - A regression that re-imports `axum::Json` in a handler that previously
+#     used the wrapper -- the symptom is 422 returning instead of 400.
+#   - A regression that breaks the AppError::Validation -> 400 mapping --
+#     the symptom is 422 OR a body without the VALIDATION_ERROR code.
+#   - A wrapper-internal regression that drops the JSON error envelope --
+#     the symptom is 400 but the body no longer contains
+#     {"code": "VALIDATION_ERROR"}.
+#
+#   The release-gate's existing `virtual-repo-malformed-input` test only
+#   asserts the status code. This script tightens the assertion to include
+#   the response body's `code` field, which is what the issue #1368 customer
+#   was missing on the SDK side.
+#
+# Sibling test: tests/repos/test-virtual-repo-malformed-input.sh runs a wider
+# set of malformed-body shapes but does not assert on the body envelope.
+# That test catches "status changed from 400"; this one catches "envelope
+# changed from VALIDATION_ERROR".
+#
+# Requires: curl, jq
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "json-validation-400-1368"
+auth_admin
+
+LOCAL_A="test-jv-a-${RUN_ID}"
+LOCAL_B="test-jv-b-${RUN_ID}"
+VIRTUAL_KEY="test-jv-virt-${RUN_ID}"
+
+# -------------------------------------------------------------------------
+# Setup -- real backing repos so a 4xx on the malformed PUT is a body /
+# envelope reject, never a 404 / 400 from the path resolution layer.
+# -------------------------------------------------------------------------
+
+begin_test "Setup: create local repo A"
+if create_local_repo "$LOCAL_A" "generic"; then
+  pass
+else
+  fail "could not create local repo A"
+fi
+
+begin_test "Setup: create local repo B"
+if create_local_repo "$LOCAL_B" "generic"; then
+  pass
+else
+  fail "could not create local repo B"
+fi
+
+begin_test "Setup: create virtual repo with members A,B"
+if create_virtual_repo "$VIRTUAL_KEY" "generic" "${LOCAL_A},${LOCAL_B}"; then
+  pass
+else
+  fail "could not create virtual repo with members"
+fi
+
+# Settle until both members are visible so the malformed PUT below is fired
+# at a fully-realised path.
+deadline=$(( $(date +%s) + 10 ))
+until [ "$(api_get "/api/v1/repositories/${VIRTUAL_KEY}/members" 2>/dev/null | jq '.members | length // 0')" = "2" ] || [ "$(date +%s)" -ge "$deadline" ]; do
+  sleep 0.2
+done
+
+MEMBERS_PATH="/api/v1/repositories/${VIRTUAL_KEY}/members"
+
+# -------------------------------------------------------------------------
+# Helper: PUT a literal body, capture both status and body. Echo
+#   "<status>\t<body>"
+# so callers can split deterministically. Use --data-binary so payloads
+# stay byte-exact (no curl-injected newlines on JSON-unfriendly input).
+# -------------------------------------------------------------------------
+
+put_with_body() {
+  local path="$1"
+  local body="$2"
+  local out
+  out=$(mktemp)
+  local args=(-s -o "$out" -w '%{http_code}' --max-time 60 --connect-timeout 10
+              -X PUT
+              -H "$(auth_header)"
+              -H "Content-Type: application/json")
+  if [ -n "$body" ]; then
+    args+=(--data-binary "$body")
+  fi
+  args+=("${BASE_URL}${path}")
+  local code
+  code=$(curl "${args[@]}") || code="000"
+  local resp
+  resp=$(cat "$out" 2>/dev/null || echo "")
+  rm -f "$out"
+  printf '%s\t%s\n' "$code" "$resp"
+}
+
+# assert_400_validation_error <status> <body> <label>
+#   - status must be exactly 400 (not 422, the pre-fix shape).
+#   - body must parse as JSON.
+#   - body.code must equal "VALIDATION_ERROR".
+#
+# These three predicates are the load-bearing #1368 contract; verifying only
+# the status (the existing virtual-repo-malformed-input does that) lets a
+# regression sneak through where the body envelope changes to something an
+# SDK can't deserialise.
+assert_400_validation_error() {
+  local status="$1"
+  local body="$2"
+  local label="$3"
+
+  if [ "$status" != "400" ]; then
+    fail "${label}: expected status 400 (VALIDATION_ERROR contract), got ${status}" \
+"response body (first 300 bytes): ${body:0:300}
+note: HTTP 422 here is the pre-#1381 regression shape (axum's default JsonRejection mapping)."
+    return 1
+  fi
+
+  if ! echo "$body" | jq -e . >/dev/null 2>&1; then
+    fail "${label}: status was 400 but body is not JSON" \
+"response body (first 300 bytes): ${body:0:300}
+note: even error responses must be JSON so SDK clients can deserialise the envelope."
+    return 1
+  fi
+
+  local code
+  code=$(echo "$body" | jq -r '.code // empty' 2>/dev/null || echo "")
+  if [ "$code" != "VALIDATION_ERROR" ]; then
+    fail "${label}: body missing code='VALIDATION_ERROR' envelope" \
+"actual code: '${code}'
+response body (first 300 bytes): ${body:0:300}
+contract: AppError::Validation maps to {status: 400, code: 'VALIDATION_ERROR'} in backend/src/error.rs"
+    return 1
+  fi
+
+  return 0
+}
+
+# -------------------------------------------------------------------------
+# Case 1: PUT /members with member array element missing required member_key.
+#
+# This is the exact shape called out in #1368: the array element has a
+# priority but no member_key. axum's stock extractor rejects this with 422;
+# the wrapper from #1381 must convert it to 400 + VALIDATION_ERROR.
+# -------------------------------------------------------------------------
+
+begin_test "PUT /members missing member_key returns 400 with code=VALIDATION_ERROR"
+PAYLOAD='{"members":[{"priority":1}]}'
+result=$(put_with_body "$MEMBERS_PATH" "$PAYLOAD")
+status="${result%%$'\t'*}"
+body="${result#*$'\t'}"
+assert_400_validation_error "$status" "$body" "PUT ${MEMBERS_PATH} missing member_key" && pass
+
+# -------------------------------------------------------------------------
+# Case 2: PUT /members with priority sent as a JSON string. This is the
+# type-mismatch path of the JsonRejection class -- a different code path
+# inside axum than the missing-field case above. The wrapper must coerce
+# this branch too.
+# -------------------------------------------------------------------------
+
+begin_test "PUT /members priority=string returns 400 with code=VALIDATION_ERROR"
+PAYLOAD_TYPE_MISMATCH=$(jq -n \
+  --arg a "$LOCAL_A" \
+  '{members: [{member_key: $a, priority: "high"}]}')
+result=$(put_with_body "$MEMBERS_PATH" "$PAYLOAD_TYPE_MISMATCH")
+status="${result%%$'\t'*}"
+body="${result#*$'\t'}"
+assert_400_validation_error "$status" "$body" "PUT ${MEMBERS_PATH} priority as string" && pass
+
+# -------------------------------------------------------------------------
+# Case 3: syntactically malformed JSON. This is the third major JsonRejection
+# branch (serde_json::Error rather than missing-field / type-mismatch).
+# Important to assert it explicitly because the wrapper has to forward
+# parser errors with the same envelope.
+# -------------------------------------------------------------------------
+
+begin_test "PUT /members with malformed JSON returns 400 with code=VALIDATION_ERROR"
+result=$(put_with_body "$MEMBERS_PATH" '{')
+status="${result%%$'\t'*}"
+body="${result#*$'\t'}"
+assert_400_validation_error "$status" "$body" "PUT ${MEMBERS_PATH} malformed JSON" && pass
+
+# -------------------------------------------------------------------------
+# Case 4: empty body. axum's default rejection class for "missing Content"
+# is yet another arm of JsonRejection; verify the wrapper catches it too so
+# the envelope is consistent across all four major rejection arms.
+# -------------------------------------------------------------------------
+
+begin_test "PUT /members with empty body returns 400 with code=VALIDATION_ERROR"
+result=$(put_with_body "$MEMBERS_PATH" "")
+status="${result%%$'\t'*}"
+body="${result#*$'\t'}"
+assert_400_validation_error "$status" "$body" "PUT ${MEMBERS_PATH} empty body" && pass
+
+# -------------------------------------------------------------------------
+# Cleanup
+# -------------------------------------------------------------------------
+
+api_delete "/api/v1/repositories/${VIRTUAL_KEY}" > /dev/null 2>&1 || true
+api_delete "/api/v1/repositories/${LOCAL_B}" > /dev/null 2>&1 || true
+api_delete "/api/v1/repositories/${LOCAL_A}" > /dev/null 2>&1 || true
+
+end_suite

--- a/tests/repos/test-virtual-members-router-1366.sh
+++ b/tests/repos/test-virtual-members-router-1366.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# test-virtual-members-router-1366.sh -- Virtual repo /members sub-router shape
+#
+# Reproducer / regression test for artifact-keeper#1366.
+#
+# Background
+#   Release-gate Full Suite for v1.2.0-rc.2 reported 22 failures all rooted at
+#   HTTP 404 on /api/v1/repositories/{key}/members and the sibling /cache-ttl
+#   route. The hypothesis was that #1281 (reject virtual-repo create with no
+#   members at 400) had unmounted the /members sub-router as a side effect.
+#
+#   Investigation on the same source commit could not reproduce the 404 -- the
+#   handlers were still wired and the OpenAPI doc still listed the four
+#   expected paths. The merged PR #1387 therefore lands regression-only tests
+#   that pin the sub-router shape: GET / POST / PUT / DELETE on
+#   /api/v1/repositories/{key}/members must all be reachable (2xx, never 404)
+#   against a freshly-created virtual repo.
+#
+#   This script is the E2E side of those regression tests: it talks to a real
+#   backend, creates a virtual repo with two members, then walks each HTTP
+#   verb on the /members sub-router and asserts none of them returns 404
+#   "route not found". Bodies are valid so a 4xx that does fire indicates a
+#   real handler problem rather than a payload issue.
+#
+# What this script catches
+#   - Sub-router fully unmounted (every verb -> 404) -- the #1366 hypothesis.
+#   - Sub-router partially unmounted (one verb -> 404 while others work).
+#   - Path-spec regression where the {key} parameter no longer resolves and
+#     all verbs collapse onto a different route that returns 405 / 404.
+#
+# What this script does NOT catch
+#   - Payload-shape regressions (covered by test-virtual-repo-malformed-input
+#     for the 400 + VALIDATION_ERROR envelope).
+#   - Member-priority semantics (covered by test-virtual-repo-member-bulk-update).
+#
+# Requires: curl, jq
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "virtual-members-router-1366"
+auth_admin
+
+LOCAL_A="test-vmr-a-${RUN_ID}"
+LOCAL_B="test-vmr-b-${RUN_ID}"
+VIRTUAL_KEY="test-vmr-virt-${RUN_ID}"
+
+# Echo "<METHOD> <PATH> [body]" -> HTTP status. Captures the body to a temp
+# file so a failing assertion can surface a snippet via fail()'s CDATA arg.
+verb_status() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  local out
+  out=$(mktemp)
+  local args=(-s -o "$out" -w '%{http_code}' --max-time 60 --connect-timeout 10
+              -X "$method"
+              -H "$(auth_header)"
+              -H "Content-Type: application/json")
+  if [ -n "$body" ]; then
+    args+=(--data-binary "$body")
+  fi
+  args+=("${BASE_URL}${path}")
+  local code
+  code=$(curl "${args[@]}") || code="000"
+  # Caller can read the body via $RESP_BODY_FILE; expose deterministically.
+  RESP_BODY_FILE="$out"
+  echo "$code"
+}
+
+# Assert that STATUS is anything but 404. Captures the response body so the
+# failure message names the actual code. Used to pin "the route exists" --
+# the load-bearing assertion against #1366.
+assert_not_404() {
+  local status="$1"
+  local label="$2"
+  if [ "$status" = "404" ]; then
+    local snippet="<empty>"
+    if [ -n "${RESP_BODY_FILE:-}" ] && [ -f "$RESP_BODY_FILE" ]; then
+      snippet=$(head -c 300 "$RESP_BODY_FILE" 2>/dev/null || echo "")
+    fi
+    fail "${label}: route returned 404 (sub-router unmounted -- #1366 reproducing)" \
+"endpoint: ${label}
+response body (first 300 bytes): ${snippet}"
+    return 1
+  fi
+  return 0
+}
+
+# -------------------------------------------------------------------------
+# Setup
+# -------------------------------------------------------------------------
+
+begin_test "Setup: create local repo A"
+if create_local_repo "$LOCAL_A" "generic"; then
+  pass
+else
+  fail "could not create local repo A"
+fi
+
+begin_test "Setup: create local repo B"
+if create_local_repo "$LOCAL_B" "generic"; then
+  pass
+else
+  fail "could not create local repo B"
+fi
+
+begin_test "Setup: create virtual repo with members A,B"
+if create_virtual_repo "$VIRTUAL_KEY" "generic" "${LOCAL_A},${LOCAL_B}"; then
+  pass
+else
+  fail "could not create virtual repo with members"
+fi
+
+# Settle: wait for both members to appear so the verb walk below runs against
+# a fully-realised virtual repo (avoids racing the POST helper inside
+# create_virtual_repo).
+deadline=$(( $(date +%s) + 10 ))
+until [ "$(api_get "/api/v1/repositories/${VIRTUAL_KEY}/members" 2>/dev/null | jq '.members | length // 0')" = "2" ] || [ "$(date +%s)" -ge "$deadline" ]; do
+  sleep 0.2
+done
+
+MEMBERS_PATH="/api/v1/repositories/${VIRTUAL_KEY}/members"
+
+# -------------------------------------------------------------------------
+# GET /members -- must be 2xx, never 404. This is the read path that the
+# release-gate Full Suite for v1.2.0-rc.2 saw collapse to 404.
+# -------------------------------------------------------------------------
+
+begin_test "GET /members returns 2xx (route mounted)"
+status=$(verb_status GET "$MEMBERS_PATH")
+if assert_not_404 "$status" "GET ${MEMBERS_PATH}"; then
+  assert_http_2xx "$status" "expected 2xx on GET /members, got ${status}" && pass
+fi
+rm -f "${RESP_BODY_FILE:-}"
+
+# -------------------------------------------------------------------------
+# POST /members -- add a third member (we reuse A; the handler is idempotent
+# enough that a duplicate add either succeeds, returns 409 Conflict, or 400
+# Validation; any of those means the route exists. The load-bearing
+# assertion is "not 404".)
+# -------------------------------------------------------------------------
+
+begin_test "POST /members returns non-404 (route mounted)"
+POST_PAYLOAD=$(jq -n --arg k "$LOCAL_A" '{member_key: $k, priority: 99}')
+status=$(verb_status POST "$MEMBERS_PATH" "$POST_PAYLOAD")
+if assert_not_404 "$status" "POST ${MEMBERS_PATH}"; then
+  # Accept 2xx (added) or 4xx other than 404 (duplicate / validation). The
+  # bug we care about is route-level 404; a payload-level 4xx is fine.
+  if [[ "$status" =~ ^[24][0-9][0-9]$ ]]; then
+    pass
+  else
+    fail "POST /members returned unexpected ${status} (route exists but handler errored)"
+  fi
+fi
+rm -f "${RESP_BODY_FILE:-}"
+
+# -------------------------------------------------------------------------
+# PUT /members -- bulk priority swap. Valid payload so a non-2xx response
+# would be a handler regression rather than a payload issue.
+# -------------------------------------------------------------------------
+
+begin_test "PUT /members returns non-404 (route mounted)"
+PUT_PAYLOAD=$(jq -n \
+  --arg a "$LOCAL_A" \
+  --arg b "$LOCAL_B" \
+  '{members: [
+     {member_key: $a, priority: 1},
+     {member_key: $b, priority: 2}
+   ]}')
+status=$(verb_status PUT "$MEMBERS_PATH" "$PUT_PAYLOAD")
+if assert_not_404 "$status" "PUT ${MEMBERS_PATH}"; then
+  assert_http_2xx "$status" "expected 2xx on PUT /members with valid payload, got ${status}" && pass
+fi
+rm -f "${RESP_BODY_FILE:-}"
+
+# -------------------------------------------------------------------------
+# DELETE /members/{member_key} -- remove member B. The leaf-path variant is
+# the documented removal verb; pin both that path and the parent /members
+# path are reachable. Per #1387 the bug claim was specifically about the
+# sub-router so both flavours are tested.
+# -------------------------------------------------------------------------
+
+begin_test "DELETE /members/{member_key} returns non-404 (route mounted)"
+status=$(verb_status DELETE "${MEMBERS_PATH}/${LOCAL_B}")
+if assert_not_404 "$status" "DELETE ${MEMBERS_PATH}/${LOCAL_B}"; then
+  assert_http_2xx "$status" "expected 2xx on DELETE /members/${LOCAL_B}, got ${status}" && pass
+fi
+rm -f "${RESP_BODY_FILE:-}"
+
+# Verify the remaining member is exactly A (single survivor) -- this also
+# re-exercises GET /members after a mutation, which would catch a sub-router
+# that 404s only after the first write call.
+begin_test "GET /members after DELETE still returns 2xx and reflects removal"
+status=$(verb_status GET "$MEMBERS_PATH")
+if assert_not_404 "$status" "GET ${MEMBERS_PATH} (post-DELETE)"; then
+  if assert_http_2xx "$status" "expected 2xx on GET /members after DELETE, got ${status}"; then
+    count=$(jq '.members | length // 0' < "$RESP_BODY_FILE" 2>/dev/null || echo 0)
+    remaining=$(jq -r '.members[0].member_repo_key // empty' < "$RESP_BODY_FILE" 2>/dev/null || echo "")
+    if [ "$count" = "1" ] && [ "$remaining" = "$LOCAL_A" ]; then
+      pass
+    else
+      fail "GET /members after DELETE: expected 1 member (${LOCAL_A}); got count=${count} first='${remaining}'"
+    fi
+  fi
+fi
+rm -f "${RESP_BODY_FILE:-}"
+
+# -------------------------------------------------------------------------
+# Cleanup
+# -------------------------------------------------------------------------
+
+api_delete "/api/v1/repositories/${VIRTUAL_KEY}" > /dev/null 2>&1 || true
+api_delete "/api/v1/repositories/${LOCAL_B}" > /dev/null 2>&1 || true
+api_delete "/api/v1/repositories/${LOCAL_A}" > /dev/null 2>&1 || true
+
+end_suite

--- a/tests/security/test-policy-put-multi-field-1374.sh
+++ b/tests/security/test-policy-put-multi-field-1374.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# test-policy-put-multi-field-1374.sh -- Security policy PUT persists every field
+#
+# Reproducer / regression test for artifact-keeper#1374.
+#
+# Background
+#   PUT /api/v1/security/policies/{id} previously persisted only the first
+#   changed field in a multi-field patch. A request with
+#   {max_severity, is_enabled} updated max_severity but is_enabled came back
+#   as empty / unchanged on a follow-up GET because the update handler
+#   applied only the first non-None field from the patch DTO.
+#
+#   PR #1386 switches the update path to a read-modify-write pattern: load
+#   the existing row, apply the patch struct fully, write the merged row
+#   back. The response shape is now consistent: is_enabled is always
+#   returned as a JSON boolean, never absent / empty-string.
+#
+# What this script catches
+#   - The exact #1374 symptom: PUT with {max_severity, is_enabled} where the
+#     GET-after-PUT shows the original is_enabled value (the second field
+#     was silently dropped on the write).
+#   - A regression that drops the boolean from the PUT response body (the
+#     "empty string" form the release-gate observed in bash).
+#   - A regression on the inverse direction: PUT with is_enabled only must
+#     also persist (separate code path in the service layer).
+#
+# What this script does NOT cover
+#   - The full matrix of single-field PUTs (covered in the backend's
+#     security.rs unit tests).
+#   - Validation envelope on malformed PUT bodies (covered by
+#     test-json-validation-400 for the broader API contract).
+#
+# Requires: curl, jq
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "policy-put-multi-field-1374"
+auth_admin
+
+POLICY_NAME="test-1374-policy-${RUN_ID}"
+
+# -------------------------------------------------------------------------
+# Create a policy with known initial values. We do NOT bind it to a
+# repository so the test is decoupled from repo lifecycle.
+#
+# Initial state:
+#   max_severity   = "high"
+#   block_unscanned = false
+#   block_on_fail  = false
+#   is_enabled     = true   (default per backend after create)
+#
+# We then PUT {max_severity: "critical", is_enabled: false} and assert the
+# GET-after-PUT shows BOTH fields persisted (the bug was that only the
+# first listed field stuck).
+# -------------------------------------------------------------------------
+
+begin_test "Create initial policy"
+CREATE_PAYLOAD=$(jq -n --arg name "$POLICY_NAME" '{
+  name: $name,
+  max_severity: "high",
+  block_unscanned: false,
+  block_on_fail: false,
+  min_staging_hours: null,
+  max_artifact_age_days: null
+}')
+if create_resp=$(api_post "/api/v1/security/policies" "$CREATE_PAYLOAD" 2>/dev/null); then
+  POLICY_ID=$(echo "$create_resp" | jq -r '.id // empty')
+  if [ -n "$POLICY_ID" ] && [ "$POLICY_ID" != "null" ]; then
+    pass
+  else
+    fail "policy created but response lacked id" "response: ${create_resp:0:300}"
+  fi
+else
+  fail "could not create policy" "endpoint: POST /api/v1/security/policies"
+fi
+
+# Capture initial state. is_enabled defaults to true on create per the
+# service layer; pin it so we know what value the PUT is flipping.
+begin_test "Read initial policy state"
+if [ -z "${POLICY_ID:-}" ]; then
+  skip "no policy ID from previous step"
+else
+  if initial_resp=$(api_get "/api/v1/security/policies/${POLICY_ID}" 2>/dev/null); then
+    initial_max_severity=$(echo "$initial_resp" | jq -r '.max_severity // empty')
+    initial_is_enabled=$(echo "$initial_resp" | jq -r '.is_enabled // empty')
+    # is_enabled must be a real JSON boolean -- not absent, not "" -- in the
+    # GET response. Pin the contract here so a regression on the *response*
+    # shape fails loudly rather than silently breaking the assertion below.
+    if [ "$initial_max_severity" = "high" ] && \
+       { [ "$initial_is_enabled" = "true" ] || [ "$initial_is_enabled" = "false" ]; }; then
+      pass
+    else
+      fail "initial GET shape unexpected" \
+"max_severity='${initial_max_severity}' is_enabled='${initial_is_enabled}' (expected high + true/false)
+response: ${initial_resp:0:300}"
+    fi
+  else
+    fail "could not GET initial policy state"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# PUT a two-field patch. This is the exact #1374 trigger shape: a patch
+# with max_severity AND is_enabled where the bug would persist only the
+# first of the two.
+#
+# We flip is_enabled to the OPPOSITE of its initial value so a "silent drop"
+# regression is observable from the bash side (initial false stays false,
+# initial true stays true).
+# -------------------------------------------------------------------------
+
+begin_test "PUT {max_severity, is_enabled} returns 2xx"
+if [ -z "${POLICY_ID:-}" ]; then
+  skip "no policy ID"
+else
+  # Flip is_enabled. If initial was true -> patch to false, and vice versa.
+  if [ "$initial_is_enabled" = "true" ]; then
+    target_is_enabled="false"
+  else
+    target_is_enabled="true"
+  fi
+
+  PUT_PAYLOAD=$(jq -n --arg sev "critical" --argjson en "$target_is_enabled" '{
+    max_severity: $sev,
+    is_enabled: $en
+  }')
+  put_status=$(curl -s -o "/tmp/put-resp-${RUN_ID}.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -X PUT \
+    -H "$(auth_header)" \
+    -H "Content-Type: application/json" \
+    -d "$PUT_PAYLOAD" \
+    "${BASE_URL}/api/v1/security/policies/${POLICY_ID}") || put_status="000"
+
+  if [[ "$put_status" =~ ^2[0-9][0-9]$ ]]; then
+    pass
+  else
+    body=$(head -c 300 "/tmp/put-resp-${RUN_ID}.json" 2>/dev/null || echo "<empty>")
+    fail "PUT returned HTTP ${put_status} (expected 2xx)" "body: ${body}"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Load-bearing assertion: GET-after-PUT shows BOTH fields persisted.
+#
+# This is the regression boundary. Before #1386 the bug would leave one of:
+#   - is_enabled at its initial value (the field was silently dropped)
+#   - is_enabled as empty string / absent (the "bash sees empty" symptom)
+# Both of those forms must fail the assertion below.
+# -------------------------------------------------------------------------
+
+begin_test "GET after PUT shows BOTH max_severity AND is_enabled persisted (#1374)"
+if [ -z "${POLICY_ID:-}" ] || [ -z "${target_is_enabled:-}" ]; then
+  skip "no policy ID or PUT step skipped"
+else
+  if after_resp=$(api_get "/api/v1/security/policies/${POLICY_ID}" 2>/dev/null); then
+    after_max_severity=$(echo "$after_resp" | jq -r '.max_severity // empty')
+    after_is_enabled=$(echo "$after_resp" | jq -r '.is_enabled // empty')
+
+    # Two predicates must both hold:
+    #   (a) max_severity is "critical" (the first patched field).
+    #   (b) is_enabled equals target_is_enabled (the second patched field --
+    #       the one the bug used to drop).
+    max_severity_ok=0
+    is_enabled_ok=0
+    is_enabled_concrete=0
+
+    [ "$after_max_severity" = "critical" ] && max_severity_ok=1
+    [ "$after_is_enabled" = "$target_is_enabled" ] && is_enabled_ok=1
+    # Per #1386 the response must always emit is_enabled as a JSON boolean;
+    # an empty string or absent field is itself a contract regression. We
+    # check that "true" or "false" appears (jq -r serialises real booleans
+    # as those literals).
+    if [ "$after_is_enabled" = "true" ] || [ "$after_is_enabled" = "false" ]; then
+      is_enabled_concrete=1
+    fi
+
+    if [ "$max_severity_ok" = "1" ] && \
+       [ "$is_enabled_ok" = "1" ] && \
+       [ "$is_enabled_concrete" = "1" ]; then
+      pass
+    else
+      fail "GET-after-PUT missing or stale field(s)" \
+"max_severity (expected 'critical', got '${after_max_severity}') ok=${max_severity_ok}
+is_enabled  (expected '${target_is_enabled}',   got '${after_is_enabled}')  ok=${is_enabled_ok} concrete=${is_enabled_concrete}
+This is the #1374 symptom: the second field in a multi-field PUT was
+silently dropped, or returned as empty/absent in the response envelope.
+response: ${after_resp:0:300}"
+    fi
+  else
+    fail "could not GET policy after PUT"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Inverse direction: PUT only is_enabled (no max_severity in body). The
+# fix path uses a read-modify-write so a single-field PUT must leave the
+# other fields untouched while still persisting the bool. This catches a
+# regression that breaks the COALESCE on the SQL side.
+# -------------------------------------------------------------------------
+
+begin_test "PUT {is_enabled} alone persists without disturbing max_severity"
+if [ -z "${POLICY_ID:-}" ] || [ -z "${target_is_enabled:-}" ]; then
+  skip "no policy ID or prior step skipped"
+else
+  # Flip back to the original value, this time alone.
+  if [ "$target_is_enabled" = "true" ]; then
+    second_target="false"
+  else
+    second_target="true"
+  fi
+  SECOND_PAYLOAD=$(jq -n --argjson en "$second_target" '{is_enabled: $en}')
+  second_status=$(curl -s -o "/tmp/put-resp2-${RUN_ID}.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -X PUT \
+    -H "$(auth_header)" \
+    -H "Content-Type: application/json" \
+    -d "$SECOND_PAYLOAD" \
+    "${BASE_URL}/api/v1/security/policies/${POLICY_ID}") || second_status="000"
+  if [[ "$second_status" =~ ^2[0-9][0-9]$ ]]; then
+    if final_resp=$(api_get "/api/v1/security/policies/${POLICY_ID}" 2>/dev/null); then
+      final_max_severity=$(echo "$final_resp" | jq -r '.max_severity // empty')
+      final_is_enabled=$(echo "$final_resp" | jq -r '.is_enabled // empty')
+      if [ "$final_max_severity" = "critical" ] && \
+         [ "$final_is_enabled" = "$second_target" ]; then
+        pass
+      else
+        fail "single-field PUT either disturbed max_severity or failed to persist is_enabled" \
+"expected max_severity='critical' is_enabled='${second_target}'
+got      max_severity='${final_max_severity}' is_enabled='${final_is_enabled}'"
+      fi
+    else
+      fail "could not GET policy after single-field PUT"
+    fi
+  else
+    body=$(head -c 300 "/tmp/put-resp2-${RUN_ID}.json" 2>/dev/null || echo "<empty>")
+    fail "single-field PUT returned HTTP ${second_status}" "body: ${body}"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Cleanup
+# -------------------------------------------------------------------------
+
+if [ -n "${POLICY_ID:-}" ]; then
+  api_delete "/api/v1/security/policies/${POLICY_ID}" > /dev/null 2>&1 || true
+fi
+rm -f "/tmp/put-resp-${RUN_ID}.json" "/tmp/put-resp2-${RUN_ID}.json" 2>/dev/null || true
+
+end_suite

--- a/tests/security/test-quality-gate-promotion-order-1376.sh
+++ b/tests/security/test-quality-gate-promotion-order-1376.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# test-quality-gate-promotion-order-1376.sh -- Gate evaluation precedes staging-source check
+#
+# Reproducer / regression test for artifact-keeper#1376.
+#
+# Background
+#   The promotion handler previously validated "source must be a staging
+#   repository" BEFORE evaluating the quality gate. Any non-staging promotion
+#   400'd on shape grounds without the gate ever firing, including
+#   gate-blocking tests that intentionally set up non-staging sources to
+#   exercise gate rejection.
+#
+#   PR #1382 splits validate_promotion_repos into two helpers and reorders
+#   the promotion handler so artifact lookup runs first, then quality-gate
+#   evaluation, then the staging-source shape check. Result: gate violations
+#   surface with HTTP 409 (gate-rejection) instead of HTTP 400 ("must be
+#   staging repository").
+#
+#   The follow-up commit on the same PR also pins:
+#     - exactly ONE evaluate_quality_gate call per promotion request
+#       (the previous handler called it twice, opening a TOCTOU window).
+#     - gate-block precedes approval-required: a gate-violating artifact
+#       in an approval-required repo returns 409, not the 200
+#       "approval required" hint.
+#
+# What this script catches
+#   - The exact #1376 symptom: a gate-violating promotion from a non-staging
+#     source returns 400 ("must be staging") instead of 409 (gate block).
+#   - A regression that re-collapses validate_promotion_repos so the
+#     staging shape check fires first again.
+#   - A regression that surfaces gate rejections as 400 instead of 409 /
+#     422 (the AppError::Conflict mapping documented in
+#     backend/src/error.rs).
+#
+# What this script does NOT cover
+#   - Promotion-from-staging happy path (covered by test-promotion-flow).
+#   - Gate warn vs block branching (covered by backend unit tests of
+#     classify_gate_evaluation).
+#
+# Requires: curl, jq
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "quality-gate-promotion-order-1376"
+auth_admin
+setup_workdir
+
+# We intentionally make the SOURCE a non-staging (local) repo. The pre-#1382
+# code would 400 on that shape before ever evaluating the gate. The fix path
+# must still surface the gate-violation 409 here because gate evaluation
+# now runs first.
+SOURCE_KEY="test-1376-src-${RUN_ID}"
+TARGET_KEY="test-1376-tgt-${RUN_ID}"
+GATE_NAME="test-1376-gate-${RUN_ID}"
+
+# -------------------------------------------------------------------------
+# Setup: two LOCAL repos. The intentionally-non-staging source is what
+# distinguishes #1376 from the happy promotion path; the bug used to mask
+# the gate response with a staging-shape 400.
+# -------------------------------------------------------------------------
+
+begin_test "Create LOCAL source repo (intentionally non-staging)"
+SOURCE_REPO_ID=""
+src_payload="{\"key\":\"${SOURCE_KEY}\",\"name\":\"${SOURCE_KEY}\",\"format\":\"generic\",\"repo_type\":\"local\"}"
+if src_resp=$(api_post "/api/v1/repositories" "$src_payload" 2>/dev/null); then
+  SOURCE_REPO_ID=$(echo "$src_resp" | jq -r '.id // empty')
+  if [ -z "$SOURCE_REPO_ID" ] || [ "$SOURCE_REPO_ID" = "null" ]; then
+    if src_resp=$(api_get "/api/v1/repositories/${SOURCE_KEY}" 2>/dev/null); then
+      SOURCE_REPO_ID=$(echo "$src_resp" | jq -r '.id // empty')
+    fi
+  fi
+  if [ -n "$SOURCE_REPO_ID" ] && [ "$SOURCE_REPO_ID" != "null" ]; then
+    pass
+  else
+    fail "could not resolve source repo id"
+  fi
+else
+  fail "could not create source repo"
+fi
+
+begin_test "Create target release repo"
+if create_repo "$TARGET_KEY" "generic" "local"; then
+  pass
+else
+  fail "could not create target repo"
+fi
+
+# -------------------------------------------------------------------------
+# Configure a quality gate scoped to the source repo. The gate is
+# configured to BLOCK on any critical issue. We pin action="block" because
+# the GateOutcome classifier maps action == "block" to Block (409); anything
+# else collapses to Warn (200 + violations attached). See
+# classify_gate_evaluation in backend/src/api/handlers/promotion.rs.
+# -------------------------------------------------------------------------
+
+begin_test "Create quality gate (action=block, max_critical_issues=0)"
+GATE_ID=""
+if [ -z "$SOURCE_REPO_ID" ]; then
+  skip "no source repo id"
+else
+  GATE_PAYLOAD=$(jq -n \
+    --arg name "$GATE_NAME" \
+    --arg repo_id "$SOURCE_REPO_ID" \
+    '{
+      name: $name,
+      description: "Block on any critical issue (regression test for #1376)",
+      repository_id: $repo_id,
+      max_critical_issues: 0,
+      enforce_on_promotion: true,
+      action: "block"
+    }')
+  if gate_resp=$(api_post "/api/v1/quality/gates" "$GATE_PAYLOAD" 2>/dev/null); then
+    GATE_ID=$(echo "$gate_resp" | jq -r '.id // empty')
+    if [ -n "$GATE_ID" ] && [ "$GATE_ID" != "null" ]; then
+      pass
+    else
+      fail "gate created but response lacked id" "response: ${gate_resp:0:300}"
+    fi
+  else
+    fail "could not create quality gate"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Upload an artifact to the source repo. We don't need a vulnerable payload
+# here -- the gate evaluation in evaluate_quality_gate fires on the
+# (artifact_id, repository_id) tuple, and the violating condition can be
+# either real findings or a missing health score. For release-gate purposes
+# the "no health score" path is the more deterministic violation.
+# -------------------------------------------------------------------------
+
+begin_test "Upload artifact to source repo"
+echo "promotion-test-content-${RUN_ID}" > "${WORK_DIR}/app.jar"
+if api_upload "/api/v1/repositories/${SOURCE_KEY}/artifacts/com/app/app.jar" \
+    "${WORK_DIR}/app.jar" > /dev/null 2>&1; then
+  pass
+else
+  fail "upload to source repo failed"
+fi
+
+# Settle then resolve the artifact_id. Multiple shapes are accepted because
+# the artifacts-list endpoint's array vs items-wrapped variant differs by
+# version; mirroring the promotion-flow test's resolution logic.
+sleep 2
+
+begin_test "Resolve artifact_id from source repo"
+ARTIFACT_ID=""
+if list_resp=$(api_get "/api/v1/repositories/${SOURCE_KEY}/artifacts" 2>/dev/null); then
+  ARTIFACT_ID=$(echo "$list_resp" | jq -r '
+    if type == "array" then .[0].id // .[0].artifact_id // empty
+    elif .items then .items[0].id // .items[0].artifact_id // empty
+    else .id // .artifact_id // empty
+    end' 2>/dev/null) || true
+  if [ -n "$ARTIFACT_ID" ] && [ "$ARTIFACT_ID" != "null" ]; then
+    pass
+  else
+    fail "could not resolve artifact_id" "response: ${list_resp:0:300}"
+  fi
+else
+  fail "could not list source repo artifacts"
+fi
+
+# -------------------------------------------------------------------------
+# Attempt to promote the artifact. The source is intentionally NOT a
+# staging repo. Under the pre-#1382 handler this would 400 with "Source
+# repository must be a staging repository" -- the gate would never fire.
+#
+# Under the post-#1382 handler, the gate evaluation runs first; if it
+# blocks, the response is 409 (AppError::Conflict from gate_block_error).
+#
+# Load-bearing assertion: the response status is NOT 400 with the
+# "must be staging" message. We accept any of:
+#   - 409 Conflict  -- gate blocked the promotion (the intended shape)
+#   - 422 Unprocessable -- alternate gate-violation mapping
+#   - 403 Forbidden -- alternate policy-rejection mapping
+# We deliberately list these because the issue's closing note ("gate-
+# rejection code (409) not staging-shape 400") allows any non-400 code
+# that signals gate enforcement.
+# -------------------------------------------------------------------------
+
+begin_test "Promotion of gate-violating artifact does NOT return staging-shape 400 (#1376)"
+if [ -z "${ARTIFACT_ID:-}" ]; then
+  skip "no artifact id"
+else
+  PROMO_PAYLOAD="{\"target_repository\":\"${TARGET_KEY}\"}"
+  status=$(curl -s -o "${WORK_DIR}/promo-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -X POST \
+    -H "$(auth_header)" \
+    -H "Content-Type: application/json" \
+    -d "$PROMO_PAYLOAD" \
+    "${BASE_URL}/api/v1/promotion/repositories/${SOURCE_KEY}/artifacts/${ARTIFACT_ID}/promote") || status="000"
+
+  body=$(cat "${WORK_DIR}/promo-resp.json" 2>/dev/null || echo "")
+
+  case "$status" in
+    409|422|403)
+      # Expected: gate fired before the staging-shape check.
+      # Tighten: the body must NOT contain "must be a staging repository"
+      # because that is the exact pre-fix message and would indicate the
+      # status is right but the underlying reason is still the shape check.
+      if echo "$body" | grep -qi "staging repository"; then
+        fail "status was ${status} but body still references 'staging repository' -- gate did not fire" \
+"body: ${body:0:300}
+This means the staging-shape check is still running before the gate -- the exact #1376 regression."
+      else
+        pass
+      fi
+      ;;
+    400)
+      # The smoking gun for #1376 reproducing: the handler 400'd with a
+      # staging-shape message, never evaluating the gate. Match against the
+      # error message so the failure output is unambiguous.
+      if echo "$body" | grep -qi "staging repository"; then
+        fail "promotion returned 400 'staging repository' -- gate never evaluated (#1376 reproducing)" \
+"This is the exact pre-#1382 regression. The promotion handler validated
+source-must-be-staging BEFORE evaluating the quality gate, so any
+non-staging promotion 400'd on shape grounds without the gate firing.
+body: ${body:0:300}"
+      else
+        # 400 for a different reason (e.g. validation on a different field)
+        # is still a regression -- the gate must surface a gate-specific
+        # code (409/422/403), not 400.
+        fail "promotion returned 400 (non-staging-shape) -- gate enforcement should yield 409/422/403" \
+"body: ${body:0:300}"
+      fi
+      ;;
+    200)
+      # If the promotion succeeded, the gate did not block. This is acceptable
+      # ONLY if the gate evaluation produced no violations (e.g. the artifact
+      # never accumulated health-score data so the gate had nothing to
+      # evaluate, which maps to GateOutcome::NotEvaluated). In that case the
+      # rest of the promotion flow ran and would have hit the staging-shape
+      # check -- so a 200 here means the handler order is also wrong.
+      fail "promotion returned 200 but source is non-staging; staging-shape check should still apply when gate does not block" \
+"body: ${body:0:300}
+Either the gate evaluation is missing entirely, or the staging-shape
+check is also being skipped. Both forms are regressions."
+      ;;
+    000)
+      fail "promotion request failed at the network layer (curl exit non-zero)"
+      ;;
+    *)
+      fail "promotion returned unexpected HTTP ${status}" "body: ${body:0:300}"
+      ;;
+  esac
+fi
+
+# -------------------------------------------------------------------------
+# Sanity check: the gate is wired and reachable. If this fails, the test
+# above was meaningless because there was no gate to evaluate. We pin this
+# explicitly so a missing gate fixture turns into a loud failure rather
+# than a silently-skipped assertion.
+# -------------------------------------------------------------------------
+
+begin_test "Quality gate is reachable via list endpoint (sanity)"
+if [ -z "${GATE_ID:-}" ]; then
+  skip "no gate id"
+else
+  if list_resp=$(api_get "/api/v1/quality/gates" 2>/dev/null); then
+    if echo "$list_resp" | jq -e --arg id "$GATE_ID" '
+        if type == "array" then any(.[]; .id == $id)
+        elif .items then any(.items[]; .id == $id)
+        else false end' > /dev/null 2>&1; then
+      pass
+    else
+      fail "gate ${GATE_ID} not present in /api/v1/quality/gates list" "list: ${list_resp:0:500}"
+    fi
+  else
+    fail "could not list quality gates"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Cleanup
+# -------------------------------------------------------------------------
+
+if [ -n "${GATE_ID:-}" ]; then
+  api_delete "/api/v1/quality/gates/${GATE_ID}" > /dev/null 2>&1 || true
+fi
+api_delete "/api/v1/repositories/${TARGET_KEY}" > /dev/null 2>&1 || true
+api_delete "/api/v1/repositories/${SOURCE_KEY}" > /dev/null 2>&1 || true
+
+end_suite

--- a/tests/security/test-scan-dedup-short-circuit-1373.sh
+++ b/tests/security/test-scan-dedup-short-circuit-1373.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# test-scan-dedup-short-circuit-1373.sh -- scan dedup short-circuit on identical bytes
+#
+# Reproducer / regression test for artifact-keeper#1373.
+#
+# Background
+#   trigger_scan previously inserted a `running` placeholder for every call,
+#   even when the artifact already had a completed scan for the same checksum
+#   + scan_type. The worker then converted the placeholder to `completed`,
+#   leaving two completed rows behind for what should have been a single
+#   logical scan.
+#
+#   PR #1388 adds an explicit short-circuit BEFORE the placeholder insert:
+#   when the artifact already has a completed scan for these exact bytes +
+#   scanner combo (within the 30-day TTL window), trigger_scan returns the
+#   existing scan_id directly instead of starting a fresh scan.
+#
+# What this script catches
+#   - The exact #1373 symptom: the per-artifact scans list contains two
+#     `completed` rows after triggering the same scan twice on byte-identical
+#     content.
+#   - A regression that re-introduces the duplicate placeholder insert -- the
+#     second trigger_scan call would observe a different scan_id from the
+#     first (the new placeholder), and the list-after-second call would show
+#     count >= 2.
+#
+#   The fix has two observable contracts; this script asserts both:
+#     1. The two trigger_scan calls return the SAME scan_id.
+#     2. GET /api/v1/security/artifacts/{id}/scans returns exactly 1 completed
+#        row after both triggers.
+#
+# What this script does NOT cover
+#   - Cross-artifact reuse (where an identical-bytes scan exists on a
+#     DIFFERENT artifact): that path still inserts a copied row and is
+#     covered by backend/tests/scan_dedup_short_circuit_tests.rs.
+#   - 30-day TTL expiry of the reusable scan window: requires time travel
+#     fixtures that don't fit a release-gate E2E.
+#
+# Requires: curl, jq
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "scan-dedup-short-circuit-1373"
+auth_admin
+setup_workdir
+
+REPO_KEY="scan-dedup-${RUN_ID}"
+PACKAGE_NAME="dedup-fixture"
+PACKAGE_VERSION="1.0.0"
+TARBALL_NAME="${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz"
+
+# Two artifact paths so we can upload byte-identical content under two names.
+# Per the PR, the same-artifact short-circuit hinges on (artifact_id +
+# checksum + scan_type); the cross-artifact reuse path is separate. This
+# script focuses on the same-artifact path because that is the customer-
+# observable failure mode (re-triggering a scan from the UI on a single
+# artifact).
+ARTIFACT_PATH_A="${PACKAGE_NAME}/${PACKAGE_VERSION}/A/${TARBALL_NAME}"
+
+SCAN_TIMEOUT="${SCAN_TIMEOUT:-180}"
+ALLOW_SCANNER_SKIP="${ALLOW_SCANNER_SKIP:-0}"
+
+# -------------------------------------------------------------------------
+# Scanner-unavailable handling. The release-gate must fail if the scanner
+# can't run; local dev can opt in to graceful skip. Same contract as
+# test-scan-completes.sh.
+# -------------------------------------------------------------------------
+
+scanner_unavailable() {
+  local reason="$1"
+  if [ "$ALLOW_SCANNER_SKIP" = "1" ]; then
+    skip "scanner unavailable (${reason}); ALLOW_SCANNER_SKIP=1 honored for local dev"
+    end_suite
+    exit 0
+  fi
+  fail "scanner unavailable (${reason}); release-gate must fail when scanner cannot run"
+  end_suite
+  exit 1
+}
+
+# Cleanup trap that combines repo deletion with the workdir cleanup
+# setup_workdir installed. Wraps both so we don't clobber the parent trap.
+cleanup() {
+  local exit_code=$?
+  curl -sf $CURL_TIMEOUT -X DELETE -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/repositories/${REPO_KEY}" >/dev/null 2>&1 || true
+  exit "$exit_code"
+}
+add_exit_handler "cleanup"
+
+# -------------------------------------------------------------------------
+# Build a small fixture. We don't need a vulnerable payload here -- the
+# short-circuit decision is byte-identity + scan_type, independent of
+# findings count. A tiny tarball with a package.json is the cheapest input
+# the npm scanner_type accepts.
+# -------------------------------------------------------------------------
+
+begin_test "Build small fixture (byte-identical content)"
+mkdir -p "${WORK_DIR}/package"
+cat > "${WORK_DIR}/package/package.json" <<EOF
+{
+  "name": "${PACKAGE_NAME}",
+  "version": "${PACKAGE_VERSION}",
+  "description": "Dedup fixture for #1373 -- bytes must be stable across re-triggers"
+}
+EOF
+# Force a deterministic mtime so the tarball has a stable sha256 even if
+# this test races with itself across reruns.
+touch -t 202601010000.00 "${WORK_DIR}/package/package.json"
+if tar -czf "${WORK_DIR}/${TARBALL_NAME}" -C "${WORK_DIR}" package 2>/dev/null; then
+  pass
+else
+  fail "could not build fixture tarball"
+fi
+
+# -------------------------------------------------------------------------
+# Create repo + upload the fixture once. The artifact short-circuit hinges
+# on a single artifact_id receiving two trigger_scan calls.
+# -------------------------------------------------------------------------
+
+begin_test "Create generic local repository"
+if create_local_repo "$REPO_KEY" "generic"; then
+  pass
+else
+  fail "could not create repository ${REPO_KEY}"
+fi
+
+begin_test "Upload fixture (artifact A)"
+upload_status=$(curl -s -o "${WORK_DIR}/upload-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -X PUT \
+  -H "$(auth_header)" \
+  -H "Content-Type: application/gzip" \
+  --data-binary "@${WORK_DIR}/${TARBALL_NAME}" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/${ARTIFACT_PATH_A}") || upload_status="000"
+
+if [ "$upload_status" = "200" ] || [ "$upload_status" = "201" ]; then
+  pass
+elif [ "$upload_status" = "000" ]; then
+  scanner_unavailable "backend unreachable on upload"
+else
+  fail "upload returned ${upload_status}, expected 200/201"
+fi
+
+# Resolve artifact_id. Mirrors test-scan-completes.sh resolution path.
+begin_test "Resolve artifact_id for artifact A"
+artifact_lookup_status=$(curl -s -o "${WORK_DIR}/artifact-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  -H "Accept: application/json" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/${ARTIFACT_PATH_A}") \
+  || artifact_lookup_status="000"
+
+ARTIFACT_ID=""
+if [ "$artifact_lookup_status" = "200" ]; then
+  ARTIFACT_ID=$(jq -er '.id // .artifact_id // empty' < "${WORK_DIR}/artifact-resp.json" 2>/dev/null || true)
+fi
+if [ -z "$ARTIFACT_ID" ]; then
+  list_status=$(curl -s -o "${WORK_DIR}/list-resp.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" \
+    -H "Accept: application/json" \
+    "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts") \
+    || list_status="000"
+  if [ "$list_status" = "200" ]; then
+    ARTIFACT_ID=$(jq -er --arg p "$ARTIFACT_PATH_A" \
+      '.items | map(select(.path == $p or .name == $p)) | first | .id // .artifact_id // empty' \
+      < "${WORK_DIR}/list-resp.json" 2>/dev/null || true)
+  fi
+fi
+
+if [ -n "$ARTIFACT_ID" ] && [ "$ARTIFACT_ID" != "null" ]; then
+  pass
+else
+  fail "could not resolve artifact_id for ${ARTIFACT_PATH_A} (lookup HTTP ${artifact_lookup_status})"
+fi
+
+# -------------------------------------------------------------------------
+# Trigger #1. Capture the scan_id this returns. We wait for the scan to
+# reach a terminal state before triggering #2 because the short-circuit only
+# fires against a COMPLETED prior scan -- if the second trigger lands while
+# the first is still `running`, the backend takes a different code path
+# (the same-artifact race-recovery branch) which is a separate decision
+# tested in backend/tests/scan_dedup_short_circuit_tests.rs.
+# -------------------------------------------------------------------------
+
+begin_test "Trigger #1: POST /api/v1/security/scan returns 2xx"
+TRIGGER1_PAYLOAD=$(jq -n --arg id "$ARTIFACT_ID" '{artifact_id: $id}')
+trigger1_status=$(curl -s -o "${WORK_DIR}/trigger1.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -X POST \
+  -H "$(auth_header)" \
+  -H "Content-Type: application/json" \
+  -d "$TRIGGER1_PAYLOAD" \
+  "${BASE_URL}/api/v1/security/scan" 2>/dev/null) || trigger1_status="000"
+
+case "$trigger1_status" in
+  2*) pass ;;
+  000) scanner_unavailable "trigger #1 curl exit non-zero" ;;
+  503|504) scanner_unavailable "trigger #1 HTTP ${trigger1_status}" ;;
+  *) fail "trigger #1 returned HTTP ${trigger1_status}, expected 2xx" ;;
+esac
+
+# Wait for the first scan to be completed so trigger #2 will exercise the
+# short-circuit branch (not the race-recovery branch).
+begin_test "Wait for scan #1 to reach completed"
+SCAN_LIST_PATH="/api/v1/security/artifacts/${ARTIFACT_ID}/scans"
+elapsed=0
+poll_interval=5
+first_scan_id=""
+first_state=""
+network_fail_count=0
+
+while [ "$elapsed" -lt "$SCAN_TIMEOUT" ]; do
+  http_status=$(curl -s -o "${WORK_DIR}/scans1.json" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(auth_header)" \
+    -H "Accept: application/json" \
+    "${BASE_URL}${SCAN_LIST_PATH}") || http_status="000"
+
+  if [ "$http_status" = "200" ]; then
+    network_fail_count=0
+    state=$(jq -er '.items[0].status // empty | ascii_downcase' < "${WORK_DIR}/scans1.json" 2>/dev/null || echo "")
+    if [ "$state" = "completed" ]; then
+      first_state="$state"
+      first_scan_id=$(jq -er '.items[0].id // empty' < "${WORK_DIR}/scans1.json" 2>/dev/null || echo "")
+      break
+    fi
+  elif [ "$http_status" = "000" ] || [ "$http_status" = "502" ] || \
+       [ "$http_status" = "503" ] || [ "$http_status" = "504" ]; then
+    network_fail_count=$(( network_fail_count + 1 ))
+    if [ "$network_fail_count" -ge 6 ]; then
+      scanner_unavailable "scan-list HTTP ${http_status} for 6 consecutive polls"
+    fi
+  fi
+
+  sleep "$poll_interval"
+  elapsed=$(( elapsed + poll_interval ))
+done
+
+if [ "$first_state" = "completed" ] && [ -n "$first_scan_id" ]; then
+  pass
+else
+  fail "scan #1 did not reach 'completed' within ${SCAN_TIMEOUT}s (last state: '${first_state:-none}')"
+fi
+
+# -------------------------------------------------------------------------
+# Trigger #2: SAME artifact, SAME bytes. The short-circuit must fire: the
+# returned scan_id should equal first_scan_id, and the per-artifact list
+# should still show exactly one completed row.
+#
+# trigger_scan does not include the reused scan_id in its response body
+# (TriggerScanResponse is {message, artifacts_queued}), so we observe the
+# short-circuit indirectly: artifacts_queued > 0 would indicate a NEW scan
+# was started, and the list-after-trigger #2 would show count >= 2.
+# -------------------------------------------------------------------------
+
+begin_test "Trigger #2 on same artifact + same bytes"
+TRIGGER2_PAYLOAD=$(jq -n --arg id "$ARTIFACT_ID" '{artifact_id: $id}')
+trigger2_status=$(curl -s -o "${WORK_DIR}/trigger2.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -X POST \
+  -H "$(auth_header)" \
+  -H "Content-Type: application/json" \
+  -d "$TRIGGER2_PAYLOAD" \
+  "${BASE_URL}/api/v1/security/scan" 2>/dev/null) || trigger2_status="000"
+
+if [[ "$trigger2_status" =~ ^2[0-9][0-9]$ ]]; then
+  pass
+else
+  fail "trigger #2 returned HTTP ${trigger2_status}, expected 2xx"
+fi
+
+# Give the backend a moment to settle any inflight bookkeeping. If the bug
+# is reproducing, a duplicate placeholder will appear within ~1s of the
+# second trigger because the placeholder insert is synchronous.
+sleep 3
+
+# -------------------------------------------------------------------------
+# Load-bearing assertion #1: per-artifact list shows exactly 1 completed row.
+#
+# This is the symptom the customer saw: a second `completed` row appearing
+# for what should have been a single logical scan. Pin the count to exactly 1.
+# -------------------------------------------------------------------------
+
+begin_test "Per-artifact scans list has exactly 1 completed row (#1373 regression)"
+list_status=$(curl -s -o "${WORK_DIR}/scans2.json" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  -H "Accept: application/json" \
+  "${BASE_URL}${SCAN_LIST_PATH}") || list_status="000"
+
+if [ "$list_status" != "200" ]; then
+  fail "scan-list returned HTTP ${list_status}"
+else
+  completed_count=$(jq '[.items[] | select((.status | ascii_downcase) == "completed")] | length' \
+                    < "${WORK_DIR}/scans2.json" 2>/dev/null || echo "0")
+  total_count=$(jq '.items | length // 0' < "${WORK_DIR}/scans2.json" 2>/dev/null || echo "0")
+  if [ "$completed_count" = "1" ]; then
+    pass
+  else
+    snippet=$(jq -c '[.items[] | {id, status}]' < "${WORK_DIR}/scans2.json" 2>/dev/null | cut -c 1-500)
+    fail "expected exactly 1 completed scan for artifact ${ARTIFACT_ID}, got ${completed_count} (total rows: ${total_count})" \
+"This is the #1373 symptom: the second trigger_scan call inserted a new
+placeholder row that the worker promoted to 'completed', leaving 2+
+completed rows where the short-circuit should have returned the existing
+scan_id.
+
+scans (projected): ${snippet}
+endpoint: GET ${BASE_URL}${SCAN_LIST_PATH}
+first scan_id: ${first_scan_id}"
+  fi
+fi
+
+# -------------------------------------------------------------------------
+# Load-bearing assertion #2: the second-most-recent (if present) is the
+# same scan_id as the first. Asserting this on top of the count-of-1
+# assertion catches a regression where a placeholder is inserted then
+# garbage-collected (count=1 again, but with a different id than expected).
+#
+# If the list has only one row, the id check trivially holds.
+# -------------------------------------------------------------------------
+
+begin_test "Latest completed scan_id equals first scan_id (no duplicate placeholder)"
+latest_completed_id=$(jq -er '[.items[] | select((.status | ascii_downcase) == "completed")][0].id // empty' \
+                      < "${WORK_DIR}/scans2.json" 2>/dev/null || echo "")
+if [ -n "$latest_completed_id" ] && [ "$latest_completed_id" = "$first_scan_id" ]; then
+  pass
+else
+  fail "latest completed scan_id (${latest_completed_id:-<empty>}) does not match first scan_id (${first_scan_id})" \
+"The short-circuit must return the existing scan_id; a different id here
+means a fresh placeholder was inserted and promoted to 'completed' (the
+exact regression #1388 fixes)."
+fi
+
+end_suite


### PR DESCRIPTION
## Summary

Adds five E2E regression scripts pinning v1.2.0 bug fixes against the running release-gate backend. Each script targets the closing PR's load-bearing observable contract, not the unit-test surface the PR already covers in-tree. All five follow the existing harness contract (source `tests/lib/common.sh`, `RUN_ID` resource isolation, JUnit XML via `begin_suite`/`begin_test`/`pass`/`fail`/`end_suite`, clean backend state on exit).

## Coverage

| Script | Closing PR | Observable pinned |
|---|---|---|
| `tests/repos/test-virtual-members-router-1366.sh` | artifact-keeper#1387 (`8b5597cb`) | GET/POST/PUT/DELETE on `/api/v1/repositories/{key}/members` all return non-404 against a freshly-created virtual repo |
| `tests/api/test-json-validation-400-1368.sh` | artifact-keeper#1381 (`eefc864f`) | PUT virtual /members with four malformed body flavours returns `400` AND `body.code=="VALIDATION_ERROR"` (the SDK-visible envelope) |
| `tests/security/test-scan-dedup-short-circuit-1373.sh` | artifact-keeper#1388 (`c0e12e54`) | Re-trigger scan on byte-identical artifact yields exactly 1 completed row, latest id matches first id |
| `tests/security/test-policy-put-multi-field-1374.sh` | artifact-keeper#1386 (`cda6cecf`) | PUT `{max_severity, is_enabled}` shows BOTH fields persisted via GET, plus inverse single-field PUT path |
| `tests/security/test-quality-gate-promotion-order-1376.sh` | artifact-keeper#1382 (`860ebf61`) | Gate-violating promotion from non-staging source returns 409/422/403, not 400 "must be staging repository" |

## Why these, why now

Bugs #1366, #1368, #1373, #1374, #1376 all closed via PRs merged on 2026-05-26 against the v1.2.0 milestone. The backend PRs ship in-tree unit + integration tests, but the release-gate had no E2E pin against a running deployment. Without those, a future release that regresses any of these fixes would pass CI on the backend repo and the release-gate Full Suite would not catch it -- exactly the silent-regression class the release-gate exists to prevent.

Each script also tightens an assertion the existing release-gate would otherwise miss:

- **#1368**: the existing `test-virtual-repo-malformed-input.sh` only asserts status code; the new test pins the `body.code=="VALIDATION_ERROR"` envelope. A regression that flips the 400 body to a different shape would silently break SDK clients.
- **#1373**: no existing test verifies dedup; `test-scan-completes.sh` only checks one scan completes. A regression that re-introduces the duplicate placeholder insert would not be visible without the count-of-1 assertion.
- **#1374**: tightens beyond the backend's `test_update_policy_request_partial_*` unit tests by exercising the end-to-end persistence path against a real PostgreSQL.
- **#1376**: pins the handler ordering specifically through the response code -- the unit tests in `promotion.rs` test the split validators, but only an E2E sees the full handler shape.

## Verification

- [x] `bash -n` clean on all five scripts
- [x] Each script sources `tests/lib/common.sh` and uses `RUN_ID` consistently
- [x] Each script registers cleanup (either via `add_exit_handler` or explicit `api_delete` at the end)
- [ ] Local docker-compose exec deferred to release-gate `workflow_dispatch`; the new scripts are not yet wired into a release-gate job (intentional for this PR -- separate change to add them once they have run green at least once in a manual dispatch)

## Refs

- artifact-keeper#1366 / #1387 -- virtual-repo /members sub-router shape
- artifact-keeper#1368 / #1381 -- JSON extractor 400 + VALIDATION_ERROR envelope
- artifact-keeper#1373 / #1388 -- scan dedup short-circuit on identical bytes
- artifact-keeper#1374 / #1386 -- policy PUT multi-field persistence
- artifact-keeper#1376 / #1382 -- quality-gate evaluation precedes staging shape check