### PR TITLE
fix(release-gate): warm up Trivy DB before parsing UpdatedAt (closes #197)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -754,6 +754,21 @@ jobs:
             exit 43
           fi
 
+          # Warm up the Trivy vulnerability DB before reading its
+          # UpdatedAt. Trivy 0.62 downloads the DB lazily on first scan,
+          # not at pod startup, so `trivy --version` immediately after
+          # rollout returns only `Version: <x>` with no `UpdatedAt:`
+          # line, which the parser below cannot handle (#197). Using
+          # `image --download-db-only` is idempotent: it no-ops if the
+          # DB is already present and within the upstream
+          # download-interval window.
+          echo "Warming up Trivy vulnerability DB..."
+          kubectl -n "$NS" exec "$POD" -c trivy -- \
+            trivy image --download-db-only --quiet >/dev/null 2>&1 \
+            || kubectl -n "$NS" exec "$POD" -- \
+                 trivy image --download-db-only --quiet >/dev/null 2>&1 \
+            || echo "::warning::trivy image --download-db-only returned non-zero; will inspect --version anyway"
+
           # trivy --version emits "Vulnerability DB: ... UpdatedAt: 2026-04-30 ..."
           # in older versions and a YAML-ish block in newer versions.
           # Parse both shapes.
@@ -771,11 +786,20 @@ jobs:
           # Extract UpdatedAt timestamp. Format varies:
           #   "  UpdatedAt: 2026-04-30 12:34:56.789 +0000 UTC"
           #   "    UpdatedAt 2026-04-30 12:34:56.789 +0000 UTC"
-          DB_DATE=$(echo "$VER_OUT" | grep -iE 'UpdatedAt' | head -n1 \
+          #
+          # Pipeline hardening (#197): grep's no-match exit code (1)
+          # used to propagate via `set -o pipefail` and the workflow
+          # shell's implicit `set -e`, killing the script before the
+          # `if [ -z "$DB_DATE" ]` guard below could surface a clean
+          # exit 43. The `|| true` here keeps `DB_DATE` empty on
+          # no-match so the guard does its job.
+          DB_DATE=$( { echo "$VER_OUT" | grep -iE 'UpdatedAt' || true; } | head -n1 \
             | sed -E 's/.*UpdatedAt[: ]+([0-9-]+ [0-9:.]+).*/\1/' \
             | awk '{print $1" "$2}')
           if [ -z "$DB_DATE" ] || ! date -d "$DB_DATE" +%s >/dev/null 2>&1; then
-            echo "::error::Could not parse Trivy DB UpdatedAt from --version output"
+            echo "::error::Could not parse Trivy DB UpdatedAt from --version output."
+            echo "::error::Likely cause: Trivy DB download failed during warmup, or trivy --version output format changed."
+            echo "::error::Raw version output above for diagnosis."
             exit 43
           fi
 


### PR DESCRIPTION
## Summary

The pinned-cve-gate pre-flight has been failing on every release-gate run since at least 2026-05-19 with `exit code 1` instead of the documented `exit 43` for unreachable DB. Root cause is two bugs:

1. **Trivy 0.62 downloads the DB lazily.** `trivy --version` immediately after pod rollout returns only `Version: 0.62.1` with no `UpdatedAt:` line. The parser had nothing to find.
2. **Pipeline death on grep-no-match.** `grep | head | sed | awk` propagated grep's exit 1 through `set -o pipefail` plus the workflow shell's implicit `set -e`, killing the script before the `if [ -z "$DB_DATE" ]` guard could surface a clean exit 43.

## Changes

`.github/workflows/release-gate.yml` (pre-flight step only):

- Warm up the DB with `trivy image --download-db-only --quiet` before inspecting `--version`. Idempotent: no-ops when the DB is fresh.
- Wrap the `grep -iE 'UpdatedAt'` in `|| true` so no-match falls through to the existing `[ -z "$DB_DATE" ]` guard, which produces an actionable exit 43 with diagnostic context.

## Evidence of failure

Release-gate run [26487615730](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/26487615730), job [pinned-cve-gate](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/26487615730/job/77998623168). Actual stdout of the pre-flight (post-cleanup noise stripped):

```
trivy --version output:
Version: 0.62.1

##[error]Process completed with exit code 1.
```

Deploy job log confirms Trivy itself rolled out fine:

```
deployment "artifact-keeper-trivy" successfully rolled out
deployment.apps/artifact-keeper-trivy condition met
```

## Scope

This PR fixes ONLY the pinned-cve-gate pre-flight. The other 17 failing suites in the same run are real backend bugs and are tracked separately as artifact-keeper#1435 through artifact-keeper#1446. The release gate as a whole will remain red until those backend issues are fixed and a new image is deployed.

## Test plan

- [ ] Manual workflow_dispatch of Release Gate after merge; verify the pre-flight either passes or fails with a clean `exit 42`/`exit 43` and a useful error
- [ ] Verify the warmup step doesn't add more than ~30s to the pre-flight in steady state (DB already cached in pod ephemeral volume)
- [ ] Smoke-self-test workflow still green

Closes #197