### PR TITLE
fix(release-gate): rename UPSTREAM_ALLOW_PRIVATE_IPS to WEBHOOK_ALLOW_PRIVATE_IPS (closes #203)

### DIFF
--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -31,13 +31,17 @@ backend:
     # See values-test.yaml for rationale (iac#97). Parallel test pods exhaust
     # the default 120/min auth rate-limit on shared admin bootstrap.
     RATE_LIMIT_EXEMPT_USERNAMES: "admin"
-    # Allow private-IP webhook URLs in the test deploy. See values-test.yaml
-    # for the full rationale -- webhook tests run a mock receiver on
-    # 127.0.0.1 in the test pod, which the artifact-keeper#1201 opt-in
-    # SSRF allowlist rejects by default. The backend env var is
-    # UPSTREAM_ALLOW_PRIVATE_IPS, not WEBHOOK_ALLOW_PRIVATE_IPS (the latter
-    # was the placeholder name PR #187 used and the backend never read).
-    UPSTREAM_ALLOW_PRIVATE_IPS: "1"
+    # Allow private-IP webhook URLs in the test deploy. Webhook tests now
+    # bind a mock receiver on 0.0.0.0:PORT inside the test pod and POST the
+    # runner pod's RFC1918 IP as the webhook target (artifact-keeper-test
+    # #199, PR #201). Backend artifact-keeper#1435 split the SSRF env vars
+    # so this toggle scopes ONLY to webhook URL validation; remote-proxy
+    # upstream validation stays default-deny so the security suite's SSRF
+    # tests continue to assert RFC1918 is rejected for remote proxies.
+    # The old name UPSTREAM_ALLOW_PRIVATE_IPS still relaxes remote-proxy
+    # validation -- DO NOT set it here or security-tests SSRF assertions
+    # will silently pass.
+    WEBHOOK_ALLOW_PRIVATE_IPS: "1"
     # NOTE: TRIVY_URL and SCAN_WORKSPACE_PATH were previously set here, but
     # the chart's backend-deployment.yaml auto-injects them when
     # trivy.enabled=true. Setting them here too produces duplicate env keys


### PR DESCRIPTION
## Summary

Companion to artifact-keeper#1455. The backend bundle splits the SSRF allowlist env vars so test deploys can relax RFC1918 for the webhook surface without also defeating the security suite's SSRF assertions on remote-proxy upstream URLs.

## Change

`helm/values-test-full.yaml`: rename the relaxation env var from `UPSTREAM_ALLOW_PRIVATE_IPS=1` to `WEBHOOK_ALLOW_PRIVATE_IPS=1`. Updated the surrounding comment block to explain the new contract.

## Coordination

This PR + artifact-keeper#1455 are interdependent:

| Order | Effect |
|---|---|
| Only #1455 merges | webhook-tests + security SSRF tests both regress to old failure modes (security tests silently pass; webhook tests fail because new env-var name isn't set) |
| Only this PR merges | webhook-tests fail on the OLD backend because UPSTREAM_ALLOW_PRIVATE_IPS unset (the old behavior tied both surfaces together) |
| Both merged within minutes of each other | gate run picks up both changes simultaneously, webhook-tests AND security SSRF tests both green |

Recommended: merge artifact-keeper#1455 first, then this PR immediately. The next gate trigger will see both.

## Test plan

- [x] YAML validates
- [ ] After both PRs merge + dev image rebuild + gate trigger: webhook-tests green AND security-tests SSRF subsuite green (default-deny restored for remote proxies)

Closes #203