### PR TITLE
fix(gate): update migration-job tests to current CreateMigrationRequest shape

### DIFF
--- a/tests/lifecycle/test-migrations-assess.sh
+++ b/tests/lifecycle/test-migrations-assess.sh
@@ -49,7 +49,9 @@ begin_suite "migrations-assess"
 auth_admin
 
 CONNECTION_NAME="mig-conn-ass-${RUN_ID}"
-JOB_NAME="mig-job-ass-${RUN_ID}"
+# Note: migration jobs no longer carry a `name` field in the backend
+# contract (migration.rs CreateMigrationRequest / MigrationJobResponse),
+# so there is no JOB_NAME to set or assert on.
 CONNECTIONS_BASE="/api/v1/migrations/connections"
 JOBS_BASE="/api/v1/migrations"
 
@@ -146,14 +148,18 @@ fi
 CONN_ID="${CONNECTION_IDS[0]}"
 
 begin_test "Create migration job to assess"
+# Backend contract (migration.rs `CreateMigrationRequest`, authoritative):
+# {source_connection_id, job_type?, config}. The old
+# {name, connection_id, source_path, target_repo} shape now 422s with
+# "missing field source_connection_id". The job is created with the
+# default job_type "full" (status pending); POST /{id}/assess then flips
+# it to job_type "assessment" / status "assessing" on the backend side.
 JOB_PAYLOAD=$(jq -nc \
-  --arg name "$JOB_NAME" \
   --arg cid "$CONN_ID" \
   '{
-    name: $name,
-    connection_id: $cid,
-    source_path: "example-repo",
-    target_repo: "migration-target"
+    source_connection_id: $cid,
+    job_type: "full",
+    config: {}
   }')
 
 RESP=$(migrations_request POST "$JOBS_BASE" "$JOB_PAYLOAD")

--- a/tests/lifecycle/test-migrations-lifecycle-transitions.sh
+++ b/tests/lifecycle/test-migrations-lifecycle-transitions.sh
@@ -52,7 +52,9 @@ begin_suite "migrations-lifecycle-transitions"
 auth_admin
 
 CONNECTION_NAME="mig-conn-tx-${RUN_ID}"
-JOB_NAME="mig-job-tx-${RUN_ID}"
+# Note: migration jobs no longer carry a `name` field in the backend
+# contract (migration.rs CreateMigrationRequest / MigrationJobResponse),
+# so there is no JOB_NAME to set or assert on.
 CONNECTIONS_BASE="/api/v1/migrations/connections"
 JOBS_BASE="/api/v1/migrations"
 
@@ -163,14 +165,17 @@ fi
 CONN_ID="${CONNECTION_IDS[0]}"
 
 begin_test "Create migration job for state-machine chain"
+# Backend contract (migration.rs `CreateMigrationRequest`, authoritative):
+# {source_connection_id, job_type?, config}. The old
+# {name, connection_id, source_path, target_repo} shape now 422s with
+# "missing field source_connection_id". A freshly created job lands in
+# the "pending" state, which is what the transition tests below depend on.
 JOB_PAYLOAD=$(jq -nc \
-  --arg name "$JOB_NAME" \
   --arg cid "$CONN_ID" \
   '{
-    name: $name,
-    connection_id: $cid,
-    source_path: "example-repo",
-    target_repo: "migration-target"
+    source_connection_id: $cid,
+    job_type: "full",
+    config: {}
   }')
 
 RESP=$(migrations_request POST "$JOBS_BASE" "$JOB_PAYLOAD")

--- a/tests/lifecycle/test-migrations-lifecycle.sh
+++ b/tests/lifecycle/test-migrations-lifecycle.sh
@@ -48,7 +48,9 @@ begin_suite "migrations-lifecycle"
 auth_admin
 
 CONNECTION_NAME="mig-conn-${RUN_ID}"
-JOB_NAME="mig-job-${RUN_ID}"
+# Note: migration jobs no longer carry a `name` field in the backend
+# contract (migration.rs CreateMigrationRequest / MigrationJobResponse),
+# so there is no JOB_NAME to set or assert on.
 CONNECTIONS_BASE="/api/v1/migrations/connections"
 JOBS_BASE="/api/v1/migrations"
 
@@ -252,14 +254,19 @@ esac
 # ---------------------------------------------------------------------------
 
 begin_test "Create migration job"
+# Backend contract (artifact-keeper backend/src/api/handlers/migration.rs
+# `CreateMigrationRequest`, authoritative): the request body requires
+# `source_connection_id` (the created connection's UUID), an optional
+# `job_type` (one of full|incremental|assessment, default "full"), and a
+# `config` object (`MigrationConfig`, every field defaults, so `{}` is
+# valid). The old {name, connection_id, source_path, target_repo} shape
+# was removed and now returns HTTP 422 "missing field source_connection_id".
 JOB_PAYLOAD=$(jq -nc \
-  --arg name "$JOB_NAME" \
   --arg cid "$CONN_ID" \
   '{
-    name: $name,
-    connection_id: $cid,
-    source_path: "example-repo",
-    target_repo: "migration-target"
+    source_connection_id: $cid,
+    job_type: "full",
+    config: {}
   }')
 
 RESP=$(migrations_request POST "$JOBS_BASE" "$JOB_PAYLOAD")
@@ -284,16 +291,21 @@ fi
 # ---------------------------------------------------------------------------
 
 if [ -n "$JOB_ID" ]; then
-  begin_test "GET migration job by id"
+  begin_test "GET migration job by id round-trips connection + type"
   RESP=$(migrations_request GET "${JOBS_BASE}/${JOB_ID}")
   STATUS=$(echo "$RESP" | head -1)
   BODY=$(echo "$RESP" | tail -n +2)
   if [ "$STATUS" = "200" ]; then
-    GOT_NAME=$(echo "$BODY" | jq -r '.name // .job.name // empty')
-    if [ "$GOT_NAME" = "$JOB_NAME" ]; then
+    # The MigrationJobResponse (migration.rs) does NOT carry a `name`
+    # field; it returns `source_connection_id` and `job_type`. Assert on
+    # those: the job must reference the connection we created and report
+    # the job type we requested.
+    GOT_CID=$(echo "$BODY" | jq -r '.source_connection_id // .job.source_connection_id // empty')
+    GOT_TYPE=$(echo "$BODY" | jq -r '.job_type // .job.job_type // empty')
+    if [ "$GOT_CID" = "$CONN_ID" ] && [ "$GOT_TYPE" = "full" ]; then
       pass
     else
-      fail "GET job name mismatch: expected '${JOB_NAME}', got '${GOT_NAME}'"
+      fail "GET job mismatch: expected source_connection_id='${CONN_ID}' job_type='full', got source_connection_id='${GOT_CID}' job_type='${GOT_TYPE}'"
     fi
   else
     fail "GET job expected 200, got ${STATUS}"

--- a/tests/lifecycle/test-migrations-report.sh
+++ b/tests/lifecycle/test-migrations-report.sh
@@ -39,7 +39,9 @@ begin_suite "migrations-report"
 auth_admin
 
 CONNECTION_NAME="mig-conn-rep-${RUN_ID}"
-JOB_NAME="mig-job-rep-${RUN_ID}"
+# Note: migration jobs no longer carry a `name` field in the backend
+# contract (migration.rs CreateMigrationRequest / MigrationJobResponse),
+# so there is no JOB_NAME to set or assert on.
 CONNECTIONS_BASE="/api/v1/migrations/connections"
 JOBS_BASE="/api/v1/migrations"
 
@@ -137,14 +139,16 @@ fi
 CONN_ID="${CONNECTION_IDS[0]}"
 
 begin_test "Create migration job (will be driven to terminal state)"
+# Backend contract (migration.rs `CreateMigrationRequest`, authoritative):
+# {source_connection_id, job_type?, config}. The old
+# {name, connection_id, source_path, target_repo} shape now 422s with
+# "missing field source_connection_id".
 JOB_PAYLOAD=$(jq -nc \
-  --arg name "$JOB_NAME" \
   --arg cid "$CONN_ID" \
   '{
-    name: $name,
-    connection_id: $cid,
-    source_path: "example-repo",
-    target_repo: "migration-target"
+    source_connection_id: $cid,
+    job_type: "full",
+    config: {}
   }')
 
 RESP=$(migrations_request POST "$JOBS_BASE" "$JOB_PAYLOAD")

--- a/tests/lifecycle/test-migrations-sse-stream.sh
+++ b/tests/lifecycle/test-migrations-sse-stream.sh
@@ -43,7 +43,9 @@ begin_suite "migrations-sse-stream"
 auth_admin
 
 CONNECTION_NAME="mig-conn-sse-${RUN_ID}"
-JOB_NAME="mig-job-sse-${RUN_ID}"
+# Note: migration jobs no longer carry a `name` field in the backend
+# contract (migration.rs CreateMigrationRequest / MigrationJobResponse),
+# so there is no JOB_NAME to set or assert on.
 CONNECTIONS_BASE="/api/v1/migrations/connections"
 JOBS_BASE="/api/v1/migrations"
 
@@ -141,14 +143,16 @@ fi
 CONN_ID="${CONNECTION_IDS[0]}"
 
 begin_test "Create migration job for SSE consumer"
+# Backend contract (migration.rs `CreateMigrationRequest`, authoritative):
+# {source_connection_id, job_type?, config}. The old
+# {name, connection_id, source_path, target_repo} shape now 422s with
+# "missing field source_connection_id".
 JOB_PAYLOAD=$(jq -nc \
-  --arg name "$JOB_NAME" \
   --arg cid "$CONN_ID" \
   '{
-    name: $name,
-    connection_id: $cid,
-    source_path: "example-repo",
-    target_repo: "migration-target"
+    source_connection_id: $cid,
+    job_type: "full",
+    config: {}
   }')
 
 RESP=$(migrations_request POST "$JOBS_BASE" "$JOB_PAYLOAD")


### PR DESCRIPTION
## Summary

The lifecycle migration-job create tests send a stale request body and fail with HTTP 422 `missing field source_connection_id` (x5 across the suite) in release-gate run 26613046674 (`lifecycle-tests`). This is a test-side calibration fix to match the current backend contract. No backend change.

## The bug

All five `tests/lifecycle/test-migrations-*.sh` scripts create a migration job with the OLD request shape:

```json
{ "name": "...", "connection_id": "<uuid>", "source_path": "example-repo", "target_repo": "migration-target" }
```

The backend rejects this with HTTP 422 `missing field source_connection_id`. Additionally `test-migrations-lifecycle.sh` asserted a job `.name` field on the GET-job response that the backend no longer returns.

## Current backend contract (authoritative)

From `artifact-keeper` `backend/src/api/handlers/migration.rs`:

```rust
pub struct CreateMigrationRequest {
    pub source_connection_id: Uuid,        // required
    pub job_type: Option<String>,          // full | incremental | assessment (snake_case), default "full"
    pub config: MigrationConfig,           // every field defaults; {} is valid
}
```

`MigrationJobResponse` returns `id`, `source_connection_id`, `status`, `job_type`, `config`, and progress counters. There is no `name` field.

Correct request body:

```json
{ "source_connection_id": "<conn id>", "job_type": "full", "config": {} }
```

## Changes

- All five scripts now send `{source_connection_id, job_type: "full", config: {}}` using the connection id returned by the create-connection step (which returns a bare `.id`; create-connection 500 was already fixed in #1439).
- Removed the now-dead `JOB_NAME` declarations (no `name` field in the contract).
- `test-migrations-lifecycle.sh` GET-job assertion now checks `source_connection_id` (round-trips the connection) and `job_type` instead of the removed `.name`.
- The cancel-state assertion is unchanged: it reads `.status`, which the backend still emits (`cancel_migration` sets `status = 'cancelled'`).
- The `/assess` flow is unchanged: jobs are created with the default `job_type "full"` / `status "pending"`, and `POST /{id}/assess` flips them to `assessment`/`assessing` on the backend side.

## Validation

- `bash -n` passes on all five edited scripts.
- jq assertions reasoned through against the documented `MigrationJobResponse` shape: the new create payload renders valid JSON, the GET-job assertion resolves `source_connection_id` + `job_type`, and the cancel-state check resolves `.status` -> `cancelled`.

Closes #207