### PR TITLE
fix(gate): webhook RFC1918 SSRF tests expect allow when WEBHOOK_ALLOW_PRIVATE_IPS set

### DIFF
--- a/tests/webhooks/test-webhook-ssrf-prevention.sh
+++ b/tests/webhooks/test-webhook-ssrf-prevention.sh
@@ -9,12 +9,43 @@
 # data, scan internal services, or steal IAM credentials from the
 # instance metadata service.
 #
-# The load-bearing assertion of this suite is therefore:
+# The load-bearing assertions of this suite split into two groups:
 #
-#   POST /api/v1/webhooks with a private / loopback / metadata URL must
-#   be rejected with a 4xx response. Anything in 2xx is a critical
-#   security regression: the webhook is now stored and the backend will
-#   happily fan out events to internal targets at delivery time.
+#   1. HARD-BLOCKED classes -- cloud metadata (169.254.169.254 and the
+#      well-known metadata hostnames), loopback (127.0.0.0/8, ::1,
+#      localhost), link-local 169.254.0.0/16, the unspecified address
+#      0.0.0.0, and non-http(s) schemes (file://, gopher://). POST
+#      /api/v1/webhooks with any of these must be rejected with a 4xx.
+#      These are never unblocked by any toggle (backend
+#      validation::is_hard_blocked_ipv4 / BLOCKED_HOSTS / scheme check),
+#      so a 2xx here is a critical security regression: the webhook is
+#      stored and the backend will fan out events to an internal target
+#      at delivery time.
+#
+#   2. RFC1918 private space (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16).
+#      Whether these are rejected is configuration-dependent. Backend
+#      issue #1435 split the single SSRF toggle into per-surface env
+#      vars: WEBHOOK_ALLOW_PRIVATE_IPS gates RFC1918 for the webhook
+#      delivery path, UPSTREAM_ALLOW_PRIVATE_IPS gates it for the
+#      remote-proxy path. The release-gate test cluster sets
+#      WEBHOOK_ALLOW_PRIVATE_IPS=1 (helm/values-test-full.yaml, renamed
+#      from the older single-var name in test-repo #204) BECAUSE the
+#      webhook mock receiver binds inside the runner pod and the webhook
+#      target is the pod's own RFC1918 IP. On the webhook surface in this
+#      cluster, RFC1918 is therefore INTENTIONALLY ALLOWED, so a correct
+#      create returns 2xx, not 4xx. We assert success for these three.
+#
+#      This is a test-side calibration only: it does NOT weaken SSRF
+#      protection. The remote-proxy SSRF suite still asserts RFC1918 is
+#      rejected (UPSTREAM_ALLOW_PRIVATE_IPS is deliberately NOT set), and
+#      metadata / loopback / link-local stay hard-blocked on the webhook
+#      surface regardless of WEBHOOK_ALLOW_PRIVATE_IPS.
+#
+#      Note (backend #1478, "B4"): before that fix, an RFC1918 webhook
+#      create returned an ambiguous 500 when AK_WEBHOOK_SECRET_KEY was
+#      unset. It now returns a clean 2xx (the URL passes SSRF validation
+#      and the secret-less create succeeds), so "expect 2xx" is the
+#      correct, unambiguous post-#1478 assertion.
 #
 # We test each address class separately so a regression on only one class
 # (say, cloud-metadata 169.254.x but not RFC1918) is visible in the
@@ -134,6 +165,82 @@ attempt_ssrf() {
 }
 
 # -------------------------------------------------------------------------
+# expect_webhook_allowed <label> <url>
+#
+# The inverse of attempt_ssrf for the RFC1918 private-space cases on the
+# webhook surface. In the release-gate test cluster the webhook target is
+# the runner pod's own RFC1918 IP and WEBHOOK_ALLOW_PRIVATE_IPS=1 is set
+# (helm/values-test-full.yaml), so an RFC1918 webhook URL is INTENTIONALLY
+# accepted. Behavior:
+#
+#   - 2xx with an .id field        -> PASS. RFC1918 allowed as configured;
+#                                     record the id for cleanup.
+#   - 2xx without an .id field     -> PASS, but no id to clean up.
+#   - 4xx (validation rejection)   -> FAIL. WEBHOOK_ALLOW_PRIVATE_IPS is
+#                                     expected to be set in this cluster;
+#                                     a reject means the toggle is not
+#                                     wired through to the webhook
+#                                     validator (regression of #1435), or
+#                                     the env var was not set on the
+#                                     deploy. Either way the suite's other
+#                                     webhook tests (mock receiver on the
+#                                     pod RFC1918 IP) would also be broken.
+#   - 501 / "not implemented"      -> SKIP. Endpoint absent in this build.
+#   - 5xx                          -> FAIL. After #1478 (B4) a secret-less
+#                                     create must not 500; a 500 here means
+#                                     that regression is back.
+#
+# This asserts a configuration outcome, NOT a relaxation of SSRF defense:
+# metadata / loopback / link-local stay hard-blocked (see attempt_ssrf
+# cases below) and the remote-proxy SSRF suite still rejects RFC1918.
+# -------------------------------------------------------------------------
+
+expect_webhook_allowed() {
+  local label="$1"
+  local url="$2"
+  local name="ssrf-allowed-${label}-${RUN_ID}"
+
+  local payload
+  payload=$(jq -n --arg name "$name" --arg url "$url" \
+    '{name: $name, url: $url, events: ["artifact_uploaded"]}')
+
+  local tmp status body
+  tmp=$(mktemp)
+  status=$(curl -s -o "$tmp" -w '%{http_code}' \
+    --max-time 10 \
+    -H "$(auth_header)" \
+    -H "Content-Type: application/json" \
+    -X POST \
+    -d "$payload" \
+    "${BASE_URL}/api/v1/webhooks" 2>/dev/null) || status="000"
+  body=$(cat "$tmp" 2>/dev/null || true)
+  rm -f "$tmp"
+
+  case "$status" in
+    2??)
+      local created_id
+      created_id=$(echo "$body" | jq -r '.id // empty' 2>/dev/null) || created_id=""
+      if [ -n "$created_id" ] && [ "$created_id" != "null" ]; then
+        CREATED_IDS+=("$created_id")
+      fi
+      pass
+      ;;
+    501)
+      skip "endpoint not implemented (HTTP 501)"
+      ;;
+    4??)
+      fail "RFC1918 webhook URL '${url}' (${label}) was rejected with HTTP ${status}, but WEBHOOK_ALLOW_PRIVATE_IPS is expected to be set on the test cluster so the webhook surface allows RFC1918 (backend #1435). Check helm/values-test-full.yaml and the backend webhook validator wiring." "${body:0:400}"
+      ;;
+    000)
+      fail "network failure contacting ${BASE_URL}/api/v1/webhooks (curl returned 000) for label='${label}'"
+      ;;
+    *)
+      fail "unexpected HTTP ${status} for url='${url}' (${label}); expected 2xx success (RFC1918 allowed on webhook surface). A 5xx here may be a regression of the #1478 secret-less-create fix." "${body:0:400}"
+      ;;
+  esac
+}
+
+# -------------------------------------------------------------------------
 # Cloud metadata services. 169.254.169.254 is the long-standing AWS /
 # GCP / Azure / DigitalOcean / Oracle Cloud metadata IP. A webhook
 # pointed at it can exfiltrate short-lived IAM credentials, instance
@@ -181,18 +288,26 @@ begin_test "Reject 'localhost' hostname"
 attempt_ssrf "localhost-name" "http://localhost:8080/"
 
 # -------------------------------------------------------------------------
-# RFC1918 private space. One representative per /8 so the JUnit row
-# tells the on-call which block leaked if any of them does.
+# RFC1918 private space. One representative per block. On the WEBHOOK
+# surface these are INTENTIONALLY ALLOWED in the release-gate test cluster
+# (WEBHOOK_ALLOW_PRIVATE_IPS=1 in helm/values-test-full.yaml, because the
+# webhook mock receiver binds the runner pod's own RFC1918 IP), so we
+# assert the create SUCCEEDS rather than 4xx-rejects. Backend issue #1435
+# scoped this toggle to the webhook validator only; the remote-proxy SSRF
+# suite still rejects RFC1918 (UPSTREAM_ALLOW_PRIVATE_IPS unset). Backend
+# #1478 (B4) made the secret-less create return a clean 2xx instead of an
+# ambiguous 500. We keep one representative per block so a partial
+# regression (e.g. 172.16/12 wired but 10/8 not) is still visible per-row.
 # -------------------------------------------------------------------------
 
-begin_test "Reject RFC1918 10.0.0.0/8 (10.0.0.1)"
-attempt_ssrf "rfc1918-10" "http://10.0.0.1/"
+begin_test "Allow RFC1918 10.0.0.0/8 (10.0.0.1) on webhook surface (WEBHOOK_ALLOW_PRIVATE_IPS)"
+expect_webhook_allowed "rfc1918-10" "http://10.0.0.1/"
 
-begin_test "Reject RFC1918 172.16.0.0/12 (172.16.0.1)"
-attempt_ssrf "rfc1918-172" "http://172.16.0.1/"
+begin_test "Allow RFC1918 172.16.0.0/12 (172.16.0.1) on webhook surface (WEBHOOK_ALLOW_PRIVATE_IPS)"
+expect_webhook_allowed "rfc1918-172" "http://172.16.0.1/"
 
-begin_test "Reject RFC1918 192.168.0.0/16 (192.168.1.1)"
-attempt_ssrf "rfc1918-192" "http://192.168.1.1/"
+begin_test "Allow RFC1918 192.168.0.0/16 (192.168.1.1) on webhook surface (WEBHOOK_ALLOW_PRIVATE_IPS)"
+expect_webhook_allowed "rfc1918-192" "http://192.168.1.1/"
 
 # -------------------------------------------------------------------------
 # 0.0.0.0. Treated as "all addresses on the local host" by most network


### PR DESCRIPTION
## Summary

Recalibrates the three RFC1918 cases in `tests/webhooks/test-webhook-ssrf-prevention.sh` to expect the webhook create to SUCCEED, matching the test-cluster configuration. The hard-blocked SSRF cases (cloud metadata, loopback, link-local, 0.0.0.0, non-http schemes) are unchanged and still assert 4xx reject. This is a documented test-side calibration; no SSRF protection is weakened.

Closes #209

## Why the old assertions were wrong

The suite asserted that RFC1918 webhook URLs (10.0.0.1, 172.16.0.1, 192.168.1.1) are rejected with 4xx. Three upstream changes invalidated that for the release-gate cluster:

- **Backend #1435** split the single SSRF private-IP toggle into per-surface env vars: `UPSTREAM_ALLOW_PRIVATE_IPS` (remote-proxy path) and `WEBHOOK_ALLOW_PRIVATE_IPS` (webhook delivery path). In `backend/src/api/validation.rs`, `validate_outbound_webhook_url` runs with `OutboundUrlContext::Webhook`, whose env var is `WEBHOOK_ALLOW_PRIVATE_IPS`; `private_ip_allowed()` consults that toggle for `v4.is_private()` addresses.
- **Test-repo #204** renamed the toggle in `helm/values-test-full.yaml` to `WEBHOOK_ALLOW_PRIVATE_IPS: "1"`. It is set on purpose: the webhook mock receiver binds inside the runner pod and the webhook target is the pod's own RFC1918 IP (#199, #201). So RFC1918 is intentionally allowed on the webhook surface in this cluster.
- **Backend #1478 (B4)** fixed webhook-create returning an ambiguous 500 when `AK_WEBHOOK_SECRET_KEY` is unset. SSRF URL validation runs first (`create_webhook` calls `validate_webhook_url` before any secret handling), so an RFC1918 URL now passes validation and the secret-less create returns a clean 2xx instead of a 500.

## Exact behavior verified against the backend

Read `backend/src/api/validation.rs` in `artifact-keeper`:

- `is_hard_blocked_ipv4` (loopback, link-local, unspecified/0.0.0.0, broadcast, and `CLOUD_METADATA_IPS`) is checked FIRST in `is_blocked_ipv4` and returns block regardless of the toggle. So 169.254.x, 127.x, 0.0.0.0 stay rejected.
- RFC1918 (`v4.is_private()`) is blocked only when `private_ip_allowed(ip, Webhook)` is false; with `WEBHOOK_ALLOW_PRIVATE_IPS=1` it returns true, so 10/8, 172.16/12, 192.168/16 are allowed on the webhook surface.
- `BLOCKED_HOSTS` includes `localhost` and the metadata hostnames; the scheme guard rejects anything other than http/https. So `localhost`, `metadata.google.internal`, `file://`, `gopher://` stay rejected by hostname/scheme, never reaching the IP toggle.
- IPv6 loopback (`::1`), unspecified, and link-local are blocked unconditionally in `is_blocked_ipv6`.

## Exactly what changed

Added an `expect_webhook_allowed` helper (mirror of `attempt_ssrf` that asserts 2xx and records the created id for cleanup) and switched three assertions to use it:

| Case | Before | After |
|------|--------|-------|
| `rfc1918-10` (`http://10.0.0.1/`) | expect 4xx reject | expect 2xx success |
| `rfc1918-172` (`http://172.16.0.1/`) | expect 4xx reject | expect 2xx success |
| `rfc1918-192` (`http://192.168.1.1/`) | expect 4xx reject | expect 2xx success |

Left unchanged (still asserting 4xx reject): cloud metadata `169.254.169.254` and `metadata.google.internal`; link-local `169.254.169.250`; loopback `127.0.0.1`, `127.1.2.3`, `[::1]`, `localhost`; unspecified `0.0.0.0`; non-http schemes `file://`, `gopher://`. The header doc block was expanded to explain the two assertion groups and the calibration rationale.

## Not a weakening of SSRF protection

- The remote-proxy SSRF suite still asserts RFC1918 is rejected; `UPSTREAM_ALLOW_PRIVATE_IPS` is deliberately not set in the test cluster.
- All metadata / loopback / link-local / unspecified / scheme cases on the webhook surface remain rejected and unchanged. Per the task guidance, any case that could be loopback vs RFC1918 was left asserting reject.

## Test plan

- [x] `bash -n tests/webhooks/test-webhook-ssrf-prevention.sh` passes
- [ ] Release-gate run on the test cluster (`WEBHOOK_ALLOW_PRIVATE_IPS=1`): the three RFC1918 cases pass as allow; all hard-block cases still pass as reject