### PR TITLE
fix(gate): accept 503 saturation, fix harness bugs, add capability-exemption allowlist

### DIFF
--- a/tests/admin/test-user-password-ops.sh
+++ b/tests/admin/test-user-password-ops.sh
@@ -35,7 +35,25 @@ TEST_EMAIL="${TEST_USERNAME}@e2e.local"
 # than embedding string literals. Each must satisfy the backend's
 # documented min-length/complexity policy (>=12 chars + mixed case +
 # digit + symbol).
-_rand_alnum() { LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 12; }
+# Broken-pipe-safe random alnum generator.
+#
+# The previous form `tr -dc ... </dev/urandom | head -c 12` aborts this script
+# under `set -euo pipefail`: head closes the pipe after 12 bytes, tr keeps
+# reading the infinite /dev/urandom and dies with SIGPIPE ("tr: write error:
+# Broken pipe", exit 141). pipefail propagates that 141 and set -e exits the
+# whole script BEFORE any assertion runs.
+#
+# Fix: read a bounded chunk of random bytes first, then run tr to completion
+# (no reader closes the pipe early), and slice the first 12 alnum chars with
+# bash parameter expansion. 256 raw bytes yield ~60 alnum chars on average, so
+# 12 is always available; the while-loop is a belt-and-suspenders guard.
+_rand_alnum() {
+  local out=""
+  while [ "${#out}" -lt 12 ]; do
+    out="${out}$(LC_ALL=C tr -dc 'A-Za-z0-9' < <(head -c 256 /dev/urandom))"
+  done
+  printf '%s' "${out:0:12}"
+}
 PASS_INITIAL="$(_rand_alnum)_${RUN_ID:0:8}_Aa1!"
 PASS_CHANGED="$(_rand_alnum)_${RUN_ID:0:8}_Bb2!"
 TEST_USER_ID=""

--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -876,6 +876,78 @@ skip() {
   echo "  SKIP: ${reason} (${duration}s)"
 }
 
+## ---------------------------------------------------------------------------
+## Capability-exemption allowlist (RELEASE_GATE only)
+## ---------------------------------------------------------------------------
+##
+## `skip_suite` under RELEASE_GATE=1 is a HARD FAIL by design: a silently
+## skipped suite is the silent-success class (#870/#871/#888) we want to
+## catch loudly. That default stays in force for everything NOT listed here.
+##
+## A handful of suites, however, skip because a capability is genuinely NOT
+## provisioned / NOT shipped in the gate deploy. That is an environment fact,
+## not a backend defect, so hard-failing the gate on it is wrong. Each entry
+## below is a capability that has been verified to be a not-provisioned /
+## not-shipped condition (NOT a real bug), with the tracking issue that owns
+## the provisioning (or shipping) work.
+##
+## Format of each row: "<capability_key>|<match_substring>|<tracking_issue>"
+##   - capability_key:  stable identifier emitted in the EXEMPT line and logs
+##   - match_substring: matched (substring, case-sensitive) against the exact
+##                      skip_suite REASON the suite passes. Keep it distinctive
+##                      enough that it cannot accidentally match an unrelated
+##                      skip that might hide a real bug.
+##   - tracking_issue:  the GitHub issue (this repo) tracking the exemption /
+##                      provisioning. #211 owns the allowlist itself.
+##
+## CRITICAL: only add a row here for a capability that is genuinely
+## not-provisioned or not-shipped. Never add a row to silence a skip that
+## could mask a real backend bug. When in doubt, leave it hard-failing.
+##
+## Deliberately NOT exempted:
+##   - formats/test-pypi-native-client.sh twine 401: the test already sends
+##     valid Basic credentials (byte-identical to the curl -u upload that
+##     PASSES in the same gate run). A 401 there is not a not-provisioned
+##     capability, so it stays a hard failure pending backend triage.
+_CAPABILITY_EXEMPTIONS=(
+  # security: per-repo scan-config (auto-scan-on-upload) endpoint not shipped
+  "scan_config_autoscan|scan-config endpoint not mounted (HTTP 404); auto-scan-on-upload feature not shipped|211"
+  # security: scan-schedules (scheduled-scan) endpoint not shipped
+  "scan_schedules|scan-schedules endpoint not mounted (HTTP 404); scheduled-scan feature not shipped|211"
+  # security: Dependency-Track not deployed in gate namespace (see #200)
+  "dependency_track|DEPENDENCY_TRACK_API_KEY and/or DEPENDENCY_TRACK_URL not set|200"
+  "dependency_track|/api/v1/integrations/dependency-track not mounted (HTTP 404); backend pre-dates DTrack wiring|200"
+  # security: OpenSCAP sidecar not provisioned in gate deploy
+  "openscap|openscap service not configured|211"
+  # platform: no WASM plugin fixture loaded against the gate backend
+  "wasm_plugin_fixture|plugin list is empty; no plugin loaded against this backend deploy|211"
+  "wasm_plugin_fixture|no plugin list endpoint responded; backend deploy may not include the plugin overlay|211"
+  # mesh: run-now sync trigger endpoint not shipped (sync worker, TODO #78.4)
+  "mesh_run_now|sync run-now endpoint not shipped (HTTP 404)|211"
+)
+
+## _match_capability_exemption REASON
+##
+## If REASON matches an allowlisted capability, echo "<key> <issue>" and
+## return 0. Otherwise return 1. Matching is a plain substring test against
+## the exact reason string, so the match_substring must appear verbatim.
+_match_capability_exemption() {
+  local reason="$1"
+  local row key sub issue
+  for row in "${_CAPABILITY_EXEMPTIONS[@]}"; do
+    key="${row%%|*}"
+    sub="${row#*|}"; sub="${sub%|*}"
+    issue="${row##*|}"
+    case "$reason" in
+      *"$sub"*)
+        echo "${key} ${issue}"
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
 ## skip_suite REASON
 ##
 ## Emit a JUnit testcase with <skipped/> for the SUITE itself, then exit
@@ -888,6 +960,13 @@ skip() {
 ## into a hard FAIL: a skipped gate is a silent-success class
 ## (#870/#871/#888) we want to catch loudly. Local-dev runs that don't
 ## set RELEASE_GATE keep the graceful skip.
+##
+## Exception: if the reason matches the documented capability-exemption
+## allowlist (_CAPABILITY_EXEMPTIONS above), the suite is a known
+## not-provisioned/not-shipped capability rather than a code defect. It is
+## reported as EXEMPT (a JUnit <skipped/>, exit 0) instead of hard-failing.
+## Any reason that does NOT match the allowlist still hard-fails, preserving
+## the silent-success protection.
 skip_suite() {
   local reason="${1:-suite skipped}"
   local duration=0
@@ -896,6 +975,29 @@ skip_suite() {
   fi
 
   if [ "${RELEASE_GATE:-0}" = "1" ]; then
+    local _exempt_match
+    if _exempt_match=$(_match_capability_exemption "$reason"); then
+      local cap="${_exempt_match%% *}"
+      local issue="${_exempt_match##* }"
+      echo "  EXEMPT: ${cap} (tracked by #${issue})"
+      echo "          capability not provisioned/shipped in gate deploy; not a backend defect (reason: ${reason})"
+      local xml_name
+      xml_name=$(_xml_escape "preflight")
+      local xml_suite
+      xml_suite=$(_xml_escape "$_SUITE_NAME")
+      local xml_reason
+      xml_reason=$(_xml_escape "EXEMPT ${cap} (tracked by #${issue}): ${reason}")
+      cat > "${JUNIT_OUTPUT_DIR}/${_SUITE_NAME}.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="${xml_suite}" tests="1" failures="0" skipped="1" time="${duration}">
+  <testcase name="${xml_name}" classname="${xml_suite}" time="${duration}">
+    <skipped message="${xml_reason}"/>
+  </testcase>
+</testsuite>
+EOF
+      exit 0
+    fi
+
     echo "  FAIL: skip_suite called with RELEASE_GATE=1 (reason: ${reason})"
     echo "        a skipped suite in release-gate is silent-success; failing the gate"
     local xml_name

--- a/tests/mesh/test-sync-filter-application.sh
+++ b/tests/mesh/test-sync-filter-application.sh
@@ -115,6 +115,13 @@ else
     pass
   elif [ "$status" = "503" ] || [ "$status" = "501" ]; then
     skip "sync worker not running in this env (artifact-keeper-fzj)"
+  elif [ "$status" = "404" ]; then
+    # The run-now sync trigger is the unshipped sync worker (TODO #78.4,
+    # artifact-keeper-fzj). A 404 means the endpoint is not shipped on this
+    # backend, which is a not-provisioned capability rather than a defect.
+    # Route through skip_suite so the capability-exemption allowlist
+    # (mesh_run_now, tracked by #211) handles it under RELEASE_GATE.
+    skip_suite "sync run-now endpoint not shipped (HTTP 404); sync worker (TODO #78.4, artifact-keeper-fzj) not present on this backend"
   else
     fail "expected 200/202 from run-now, got ${status}"
   fi

--- a/tests/stress/test-auth-saturation.sh
+++ b/tests/stress/test-auth-saturation.sh
@@ -4,7 +4,13 @@
 # Measures how the auth endpoint degrades under increasing concurrent load.
 # Sends parallel login requests in waves (5, 10, 20, 40) and records
 # success rate and p95 response time at each level. Fails if the backend
-# returns 5xx or stops responding entirely (as opposed to clean 429s).
+# returns a genuine server fault (500/502/504) or stops responding entirely.
+#
+# 503 Service Unavailable is NOT a failure here: per backend #1437 it is the
+# intended saturation/overload response. When the bcrypt-permit concurrency
+# cap is saturated, the auth path sheds load with 503 (correct backpressure)
+# instead of running the request and crashing. 429 (rate-limit) and 503
+# (saturation) are both treated as the backend correctly protecting itself.
 #
 # This test characterizes backend capacity, not correctness. It answers:
 # "How many concurrent auth requests can the backend handle?"
@@ -54,6 +60,7 @@ summarize_wave() {
   local total=0
   local success=0
   local rate_limited=0
+  local saturated=0
   local server_error=0
   local timeout=0
   local max_ms=0
@@ -69,6 +76,13 @@ summarize_wave() {
       success=$(( success + 1 ))
     elif [ "$code" = "429" ]; then
       rate_limited=$(( rate_limited + 1 ))
+    elif [ "$code" = "503" ]; then
+      # 503 is the INTENDED overload/saturation response (backend #1437):
+      # when the bcrypt concurrency permit cap is saturated, the auth path
+      # sheds load with 503 Service Unavailable rather than crashing. This
+      # is correct backpressure, so 503 is counted separately from a genuine
+      # server fault (500/502/504), which still indicates the backend broke.
+      saturated=$(( saturated + 1 ))
     elif [ "$code" -ge 500 ] 2>/dev/null; then
       server_error=$(( server_error + 1 ))
     elif [ "$code" = "000" ]; then
@@ -76,7 +90,7 @@ summarize_wave() {
     fi
   done
 
-  echo "${total} ${success} ${rate_limited} ${server_error} ${timeout} ${max_ms}"
+  echo "${total} ${success} ${rate_limited} ${saturated} ${server_error} ${timeout} ${max_ms}"
 }
 
 # ---------------------------------------------------------------------------
@@ -85,8 +99,8 @@ summarize_wave() {
 
 begin_test "Auth under 5 concurrent requests"
 fire_auth_wave 5
-read total success rate_limited server_error timeout max_ms <<< "$(summarize_wave "${RESULTS_DIR}/wave-5")"
-echo "  5 concurrent: ${success}/${total} success, ${rate_limited} rate-limited, ${server_error} 5xx, ${timeout} timeout, max ${max_ms}ms"
+read total success rate_limited saturated server_error timeout max_ms <<< "$(summarize_wave "${RESULTS_DIR}/wave-5")"
+echo "  5 concurrent: ${success}/${total} success, ${rate_limited} rate-limited, ${saturated} 503-saturation, ${server_error} 5xx-fault, ${timeout} timeout, max ${max_ms}ms"
 if [ "$success" -ge 4 ]; then
   pass
 else
@@ -101,14 +115,14 @@ sleep 2
 
 begin_test "Auth under 10 concurrent requests"
 fire_auth_wave 10
-read total success rate_limited server_error timeout max_ms <<< "$(summarize_wave "${RESULTS_DIR}/wave-10")"
-echo "  10 concurrent: ${success}/${total} success, ${rate_limited} rate-limited, ${server_error} 5xx, ${timeout} timeout, max ${max_ms}ms"
+read total success rate_limited saturated server_error timeout max_ms <<< "$(summarize_wave "${RESULTS_DIR}/wave-10")"
+echo "  10 concurrent: ${success}/${total} success, ${rate_limited} rate-limited, ${saturated} 503-saturation, ${server_error} 5xx-fault, ${timeout} timeout, max ${max_ms}ms"
 if [ "$success" -ge 7 ]; then
   pass
-elif [ "$(( success + rate_limited ))" -ge 8 ]; then
-  pass  # 429 is acceptable, backend is protecting itself
+elif [ "$(( success + rate_limited + saturated ))" -ge 8 ]; then
+  pass  # 429 rate-limit and 503 saturation are acceptable: backend protecting itself
 else
-  fail "expected >= 7/10 success (or 429) at concurrency 10, got ${success} success + ${rate_limited} rate-limited"
+  fail "expected >= 7/10 success (or 429/503 backpressure) at concurrency 10, got ${success} success + ${rate_limited} rate-limited + ${saturated} saturated"
 fi
 
 # ---------------------------------------------------------------------------
@@ -119,13 +133,15 @@ sleep 3
 
 begin_test "Auth under 20 concurrent requests"
 fire_auth_wave 20
-read total success rate_limited server_error timeout max_ms <<< "$(summarize_wave "${RESULTS_DIR}/wave-20")"
-echo "  20 concurrent: ${success}/${total} success, ${rate_limited} rate-limited, ${server_error} 5xx, ${timeout} timeout, max ${max_ms}ms"
-# At 20 concurrent, we expect some degradation. Key metric: no 5xx or total timeouts
+read total success rate_limited saturated server_error timeout max_ms <<< "$(summarize_wave "${RESULTS_DIR}/wave-20")"
+echo "  20 concurrent: ${success}/${total} success, ${rate_limited} rate-limited, ${saturated} 503-saturation, ${server_error} 5xx-fault, ${timeout} timeout, max ${max_ms}ms"
+# At 20 concurrent, we expect some degradation. Key metric: no genuine server
+# faults (500/502/504) or total timeouts. 503 saturation is acceptable
+# backpressure (backend #1437) and is NOT counted as a server fault here.
 if [ "$server_error" -le 2 ] && [ "$timeout" -le 2 ]; then
   pass
 else
-  fail "backend returned ${server_error} 5xx errors and ${timeout} timeouts at concurrency 20"
+  fail "backend returned ${server_error} 5xx faults (excl. 503) and ${timeout} timeouts at concurrency 20"
 fi
 
 # ---------------------------------------------------------------------------
@@ -136,14 +152,25 @@ sleep 5
 
 begin_test "Auth under 40 concurrent requests (capacity limit)"
 fire_auth_wave 40
-read total success rate_limited server_error timeout max_ms <<< "$(summarize_wave "${RESULTS_DIR}/wave-40")"
-echo "  40 concurrent: ${success}/${total} success, ${rate_limited} rate-limited, ${server_error} 5xx, ${timeout} timeout, max ${max_ms}ms"
-# At 40 concurrent bcrypt on a 1-core pod, timeouts are expected (CPU saturation).
-# The key assertion: zero 5xx errors (backend doesn't crash under load).
+read total success rate_limited saturated server_error timeout max_ms <<< "$(summarize_wave "${RESULTS_DIR}/wave-40")"
+echo "  40 concurrent: ${success}/${total} success, ${rate_limited} rate-limited, ${saturated} 503-saturation, ${server_error} 5xx-fault, ${timeout} timeout, max ${max_ms}ms"
+# At 40 concurrent bcrypt on a 1-core pod, the backend sheds load. Per backend
+# #1437, the INTENDED saturation response is 503 Service Unavailable: when the
+# bcrypt-permit cap is saturated, the auth path returns 503 (correct
+# backpressure) rather than running the request and crashing. So 503 is a
+# valid, expected response under this load and is NOT a failure.
+#
+# The key assertion is still that the backend does not break: zero genuine
+# server faults (500 Internal Server Error / 502 Bad Gateway / 504 Gateway
+# Timeout). Those indicate a crash, panic, or upstream failure, which 503 does
+# not. Timeouts (client-side, code 000) remain acceptable here (CPU saturation).
 if [ "$server_error" -eq 0 ]; then
+  if [ "$saturated" -gt 0 ]; then
+    echo "  ${saturated}/${total} requests returned 503 (intended saturation backpressure per backend #1437)"
+  fi
   pass
 else
-  fail "backend returned ${server_error} 5xx errors at concurrency 40 (timeouts are acceptable, 5xx is not)"
+  fail "backend returned ${server_error} genuine 5xx faults (500/502/504) at concurrency 40; 503 saturation and client timeouts are acceptable, a server fault is not (${saturated} requests were 503)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/webhooks/test-webhook-deadletter.sh
+++ b/tests/webhooks/test-webhook-deadletter.sh
@@ -133,7 +133,13 @@ if [ "$SUITE_BLOCKED" = "true" ] || [ -z "$WEBHOOK_ID" ]; then
   skip "no webhook id"
 else
   if test_resp=$(api_post "/api/v1/webhooks/${WEBHOOK_ID}/test" "" 2>/dev/null); then
-    success_field=$(echo "$test_resp" | jq -r '.success // "missing"')
+    # NOTE: do not use `.success // "missing"`. jq's `//` operator treats a
+    # boolean `false` as an absent value, so `.success // "missing"` returns
+    # "missing" for a correct `{"success": false}` response. The backend
+    # returns the right payload (TestWebhookResponse { success: false,
+    # status_code: 500, ... }); the old jq path mis-extracted it. Branch on
+    # has("success") so a genuine false is read as "false".
+    success_field=$(echo "$test_resp" | jq -r 'if has("success") then (.success | tostring) else "missing" end')
     status_field=$(echo "$test_resp" | jq -r '.status_code // empty')
     if [ "$success_field" = "false" ] && [ "$status_field" = "500" ]; then
       pass


### PR DESCRIPTION
## Summary

Two kinds of change, both test-side. No backend changes. From release-gate run 26616763325.

1. Genuine test-harness fixes (3 bugs in the test scripts themselves).
2. A documented capability-exemption allowlist so suites that skip because a capability is genuinely not provisioned/not shipped in the gate deploy stop hard-failing the gate, while every other skip keeps hard-failing (silent-success protection preserved).

Closes #212. Implements the allowlist tracked by #211.

## Part 1: test-harness fixes

### T8 stress: `tests/stress/test-auth-saturation.sh` (accept 503 saturation)
The test counted any 5xx (including 503) as a failure at concurrency 40. Per backend #1437, 503 Service Unavailable is the INTENDED overload/saturation response: when the bcrypt-permit concurrency cap is saturated, the auth path sheds load with 503 rather than running the request and crashing. That is correct backpressure.

Fix: `summarize_wave` now tracks 503 in a separate `saturated` bucket, distinct from genuine server faults (500/502/504). The wave-40 assertion still requires zero genuine 5xx faults (a crash/panic/upstream failure), but 503 is reported and accepted. Wave 10 also treats 503 (alongside 429) as the backend protecting itself. This does NOT weaken the real assertion: a 500/502/504 still fails the suite.

### webhook deadletter: `tests/webhooks/test-webhook-deadletter.sh` (jq false-swallow)
The `/test` step asserted `success=false`/`status=500` but read `success='missing'`. The backend returns the correct `TestWebhookResponse { success: false, status_code: 500, ... }`. The bug was `jq -r '.success // "missing"'`: jq's `//` operator treats a boolean `false` as an absent value, so a correct `false` fell through to `"missing"`.

Fix: branch on `has("success")` and stringify, so `false` reads as `"false"`, `true` as `"true"`, and a truly-absent field as `"missing"`. Verified all three cases.

### admin user-password-ops: `tests/admin/test-user-password-ops.sh` (broken-pipe abort)
The suite aborted with `tr: write error: Broken pipe` before any assertion ran. The fixture generator `tr -dc ... </dev/urandom | head -c 12` dies under `set -euo pipefail`: `head` closes the pipe after 12 bytes, `tr` keeps reading the infinite `/dev/urandom` and exits 141 (SIGPIPE), `pipefail` propagates 141 and `set -e` exits the whole script.

Fix: read a bounded 256-byte chunk first, run `tr` to completion (no early-closing reader), and slice the first 12 alnum chars with bash parameter expansion, looping as a guard. Verified the script now reaches its assertions and the generated passwords still satisfy the complexity policy.

### twine 401: `tests/formats/test-pypi-native-client.sh` (deliberately NOT changed)
Investigated and left hard-failing. The test already passes valid credentials (`TWINE_USERNAME`/`TWINE_PASSWORD`). Verified locally that twine emits a Basic header byte-identical to the curl `-u` upload that PASSES in the same gate run against the same backend, and pip read with the same credentials also passes. A 401 from twine but not curl, with identical valid credentials, is neither a test-config defect nor a not-provisioned capability; it points to backend behavior (lockout / bcrypt-permit interaction). Per "when in doubt, leave it hard-failing", no change and no exemption.

## Part 2: documented capability-exemption allowlist

`skip_suite` under `RELEASE_GATE=1` is a hard fail by design (silent-success protection, #870/#871/#888). That stays in force for everything not on the allowlist. Added a small explicit table in `tests/lib/common.sh` mapping a capability key to a distinctive substring of the skip reason and a tracking issue. When a skip reason matches, the suite emits `EXEMPT: <capability> (tracked by #N)`, writes a JUnit `<skipped/>` (not a failure), and exits 0.

| Capability key | Suite / reason | Why genuinely not-provisioned/not-shipped | Tracking |
|----------------|----------------|-------------------------------------------|----------|
| `scan_config_autoscan` | security/test-auto-scan-on-upload: scan-config 404 (POST and PUT) | auto-scan-on-upload feature not shipped on the gate backend image | #211 |
| `scan_schedules` | security/test-scheduled-scan: scan-schedules 404 | scheduled-scan feature not shipped on the gate backend image | #211 |
| `dependency_track` | security/test-dependencytrack-integration: env unset, or integration route 404 | Dependency-Track is not deployed in the gate namespace | #200 |
| `openscap` | security/test-openscap-scanner: `openscap_enabled=false` and `OPENSCAP_URL` unset | OpenSCAP sidecar not provisioned in the gate deploy | #211 |
| `wasm_plugin_fixture` | platform/test-wasm-plugin-roundtrip: empty plugin list / no plugin endpoint | no WASM plugin fixture loaded against the gate backend (`plugins.enabled`) | #211 |
| `mesh_run_now` | mesh/test-sync-filter-application: sync run-now 404 | unshipped sync worker (TODO #78.4, artifact-keeper-fzj) | #211 |

`mesh/test-sync-filter-application.sh` was updated so a genuine 404 on `POST /sync-policies/{id}/run` routes through `skip_suite` (matching `mesh_run_now`) instead of `fail`; all other statuses keep their prior handling (200/202 pass, 503/501 graceful skip, anything else fails).

### Safety: no real-bug assertion weakened
- Match substrings are distinctive enough not to catch unrelated skips.
- Anything not on the allowlist still hard-fails under RELEASE_GATE (verified: "could not create repo" and a twine-style "401" both still exit 1).
- Each exempted reason already only fires on a clean not-shipped/not-provisioned signal (404 after both POST and PUT, env unset, empty plugin list, disabled-and-unset scanner) with all other status codes still failing in the originating suites.

## Test plan
- [x] `bash -n` on all 5 edited scripts (common.sh, test-auth-saturation.sh, test-webhook-deadletter.sh, test-user-password-ops.sh, test-sync-filter-application.sh)
- [x] jq `has("success")` fix returns false/true/missing correctly
- [x] broken-pipe-safe `_rand_alnum` reaches assertions under `set -euo pipefail`
- [x] exemption matcher: all 6 capability keys exempt (EXEMPT + exit 0); non-allowlisted skips still hard-fail (exit 1); local-dev (no RELEASE_GATE) still graceful-skips
- [x] exempt JUnit XML is valid and marked `failures=0 skipped=1`
- [ ] Full release-gate run confirms the 5 previously-hard-failing skip_suites now report EXEMPT and the three harness fixes pass