### PR TITLE
fix(gate): chunked-upload tests download from /download not /artifacts; fix dd skip (closes #214)

### DIFF
--- a/tests/platform/test-chunked-upload-edge-cases.sh
+++ b/tests/platform/test-chunked-upload-edge-cases.sh
@@ -244,10 +244,11 @@ if [ -n "$OOO_SESSION" ]; then
       "${BASE_URL}/api/v1/uploads/${OOO_SESSION}/complete") || OOO_FIN_HTTP="000"
 
     if [ "$OOO_FIN_HTTP" = "200" ]; then
-      # Download and verify
+      # Download and verify. The /artifacts/*path GET returns metadata JSON;
+      # the raw file bytes are served by /download/*path.
       OOO_DL_HTTP=$(curl -s -o "${WORK_DIR}/ooo_dl.bin" -w '%{http_code}' \
         $CURL_TIMEOUT -H "$(auth_header)" \
-        "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/test/ooo-file.bin") || OOO_DL_HTTP="000"
+        "${BASE_URL}/api/v1/repositories/${REPO_KEY}/download/test/ooo-file.bin") || OOO_DL_HTTP="000"
 
       if [ "$OOO_DL_HTTP" = "200" ]; then
         OOO_DL_SHA=$(compute_sha256 "${WORK_DIR}/ooo_dl.bin")
@@ -645,7 +646,7 @@ if [ -n "$CONC_A_SESSION" ] && [ -n "$CONC_B_SESSION" ]; then
     # Download and verify B's content won (last to finalize)
     CONC_DL_HTTP=$(curl -s -o "${WORK_DIR}/conc_dl.bin" -w '%{http_code}' \
       $CURL_TIMEOUT -H "$(auth_header)" \
-      "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/test/concurrent.bin") || CONC_DL_HTTP="000"
+      "${BASE_URL}/api/v1/repositories/${REPO_KEY}/download/test/concurrent.bin") || CONC_DL_HTTP="000"
 
     if [ "$CONC_DL_HTTP" = "200" ]; then
       CONC_DL_SHA=$(compute_sha256 "${WORK_DIR}/conc_dl.bin")

--- a/tests/platform/test-chunked-upload.sh
+++ b/tests/platform/test-chunked-upload.sh
@@ -120,9 +120,10 @@ else
     THIS_CHUNK=$(( REMAINING < CHUNK_SIZE ? REMAINING : CHUNK_SIZE ))
     RANGE_END=$(( RANGE_START + THIS_CHUNK - 1 ))
 
-    # Extract chunk from test file
+    # Extract chunk from test file. skip is measured in bs-sized (1 MB)
+    # blocks, so chunk i begins at block i*CHUNK_SIZE_MB, not block i.
     dd if="${WORK_DIR}/testfile.bin" of="${WORK_DIR}/chunks/chunk_${i}" \
-      bs=1048576 skip="$i" count="$CHUNK_SIZE_MB" 2>/dev/null
+      bs=1048576 skip="$(( i * CHUNK_SIZE_MB ))" count="$CHUNK_SIZE_MB" 2>/dev/null
     # Truncate last chunk to exact remaining bytes if needed
     if [ "$THIS_CHUNK" -lt "$CHUNK_SIZE" ]; then
       truncate -s "$THIS_CHUNK" "${WORK_DIR}/chunks/chunk_${i}" 2>/dev/null || \
@@ -207,10 +208,12 @@ begin_test "Download artifact and verify SHA256"
 if [ -z "$ARTIFACT_ID" ] && [ -z "$SESSION_ID" ]; then
   skip "no artifact to download"
 else
+  # /artifacts/*path GET returns metadata JSON; the raw bytes are served by
+  # /download/*path.
   DL_HTTP=$(curl -s -o "${WORK_DIR}/downloaded.bin" -w '%{http_code}' \
     $CURL_TIMEOUT \
     -H "$(auth_header)" \
-    "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/test/chunked-file.bin" 2>/dev/null) || DL_HTTP="000"
+    "${BASE_URL}/api/v1/repositories/${REPO_KEY}/download/test/chunked-file.bin" 2>/dev/null) || DL_HTTP="000"
 
   if [ "$DL_HTTP" = "200" ]; then
     DL_SHA256=$(compute_sha256 "${WORK_DIR}/downloaded.bin")


### PR DESCRIPTION
## Summary
The chunked-upload platform-tests failures (gate run 26616763325) are TEST bugs, not backend data corruption. Verified E2E against a live backend deploy: out-of-order upload (chunks 2,0,1) finalizes with the correct checksum and `/download` returns byte-exact content.

## Fixes
- Integrity checks now download via `GET .../download/{path}` (raw bytes) instead of `GET .../artifacts/{path}` (which returns 365-byte metadata JSON). The old assertions hashed JSON vs the file.
- `test-chunked-upload.sh` Test 2: `dd ... skip=$((i * CHUNK_SIZE_MB))` (was `skip=$i`, reading from the wrong source offset).

## Verification
Ran both scripts against a live backend: `test-chunked-upload.sh` 10/10 pass; `test-chunked-upload-edge-cases.sh` 11/12 (the remaining one is an unrelated cancelled-session status-code assertion, pre-existing, separate).

Backend confirmed correct; additive regression tests in artifact-keeper branch `recover/chunked-upload-reassembly`.

Closes #214