### PR TITLE
fix(values): high-entropy JWT secrets for the #1829 startup gate

### DIFF
--- a/helm/values-smoke-with-deps.yaml
+++ b/helm/values-smoke-with-deps.yaml
@@ -198,7 +198,7 @@ ingress:
     secretName: smoke-tls-unused
 
 secrets:
-  jwtSecret: "test-jwt-secret-not-for-production"
+  jwtSecret: "ak-ci-nonprod-q7z6wharZXoYYW3BI1ZPSdbMDyXrXS6DiCajP8IPCHg4Bjgb"
 
 # Disabled subsystems: keep these off for now even in the "with-deps"
 # variant. NetworkPolicy default-deny would block the in-cluster

--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -144,7 +144,7 @@ trivy:
       memory: 2Gi
 
 secrets:
-  jwtSecret: "test-jwt-secret-not-for-production"
+  jwtSecret: "ak-ci-nonprod-q7z6wharZXoYYW3BI1ZPSdbMDyXrXS6DiCajP8IPCHg4Bjgb"
 
 # Disabled services: not needed for scanning test runs
 dependencyTrack:

--- a/helm/values-test.yaml
+++ b/helm/values-test.yaml
@@ -137,7 +137,7 @@ opensearch:
     size: 1Gi
 
 secrets:
-  jwtSecret: "test-jwt-secret-not-for-production"
+  jwtSecret: "ak-ci-nonprod-q7z6wharZXoYYW3BI1ZPSdbMDyXrXS6DiCajP8IPCHg4Bjgb"
 
 # Disabled services: not needed for basic test runs
 trivy:


### PR DESCRIPTION
## Problem
The backend (artifact-keeper#1829) rejects low-entropy JWT secrets at startup in **all** environments (needs ≥32 chars **and** ≥16 distinct chars). The test overlays use `test-jwt-secret-not-for-production` — 34 chars but only **15 distinct** — so the backend crash-loops:
```
Error: Config("JWT_SECRET is unsuitable: it has low entropy (too few distinct characters or an obvious pattern)...")
```
The `deploy` job's pod never reaches Ready, helm `--wait --timeout 10m` hits `context deadline exceeded`, and every matrix job that `needs: deploy` skips. (Pre-#1829 this passed, which is why it regressed silently — the release-gate doesn't dump pod logs.)

## Reproduced locally
kind cluster + `kind load` the `dev` image + `helm install` with `values-test.yaml` → backend `CrashLoopBackOff` with the error above. Swapping in a high-entropy secret → backend `1/1 Running`, `/readyz` 200.

## Fix
Replace the weak secret in `values-test.yaml`, `values-test-full.yaml`, and `values-smoke-with-deps.yaml` with a high-entropy, clearly non-production test secret (62 chars / 36 distinct). `values-smoke.yaml` already passes (17 distinct) and is unchanged.

Companion fix for the mesh overlays lives in artifact-keeper-iac (mesh-test-jwt-main/peer have the same problem).