### PR TITLE
fix(values): disable rate limiting in the release-gate deploy

### DIFF
--- a/helm/values-smoke-with-deps.yaml
+++ b/helm/values-smoke-with-deps.yaml
@@ -72,6 +72,12 @@ backend:
     ADMIN_PASSWORD: TestRunner!2026secure
     ACCOUNT_LOCKOUT_THRESHOLD: "0"
     RATE_LIMIT_EXEMPT_USERNAMES: "admin"
+    # Release-gate runs 20+ suites against ONE shared backend; per-user/IP and
+    # global auth/API windows trip 429 across a full suite run (e.g. the totp
+    # backup-code single-use test gets 429 instead of 401/consume). The gate tests
+    # functional correctness, not rate-limiting (the rate-limit suite skips here),
+    # so disable the limiter for the test deploy.
+    RATE_LIMIT_ENABLED: "false"
   persistence:
     size: 2Gi
   scanWorkspace:

--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -31,6 +31,12 @@ backend:
     # See values-test.yaml for rationale (iac#97). Parallel test pods exhaust
     # the default 120/min auth rate-limit on shared admin bootstrap.
     RATE_LIMIT_EXEMPT_USERNAMES: "admin"
+    # Release-gate runs 20+ suites against ONE shared backend; per-user/IP and
+    # global auth/API windows trip 429 across a full suite run (e.g. the totp
+    # backup-code single-use test gets 429 instead of 401/consume). The gate tests
+    # functional correctness, not rate-limiting (the rate-limit suite skips here),
+    # so disable the limiter for the test deploy.
+    RATE_LIMIT_ENABLED: "false"
     # Allow private-IP webhook URLs in the test deploy. Webhook tests now
     # bind a mock receiver on 0.0.0.0:PORT inside the test pod and POST the
     # runner pod's RFC1918 IP as the webhook target (artifact-keeper-test

--- a/helm/values-test.yaml
+++ b/helm/values-test.yaml
@@ -37,6 +37,12 @@ backend:
     # bootstrap flow doesn't compete with itself across parallel pods. Per-test
     # users that the suites create are still rate-limited normally.
     RATE_LIMIT_EXEMPT_USERNAMES: "admin"
+    # Release-gate runs 20+ suites against ONE shared backend; per-user/IP and
+    # global auth/API windows trip 429 across a full suite run (e.g. the totp
+    # backup-code single-use test gets 429 instead of 401/consume). The gate tests
+    # functional correctness, not rate-limiting (the rate-limit suite skips here),
+    # so disable the limiter for the test deploy.
+    RATE_LIMIT_ENABLED: "false"
     # Allow private-IP webhook URLs. Webhook tests run a mock receiver on
     # 127.0.0.1:18772 in the test pod and register webhooks pointing at
     # that address. The backend's opt-in private-IP SSRF allowlist (from


### PR DESCRIPTION
Under the gate's 20+ parallel suites hitting one shared backend, auth/API rate windows trip **429** across a full suite run. E.g. `test-totp-backup-codes`: a backup-code verify returns 429 instead of 401/consume → the test mis-accounts it as 'code accepted after exhaustion' (a *false* single-use failure — the invariant is correct and passes single-threaded). `RATE_LIMIT_EXEMPT_USERNAMES=admin` doesn't cover test-created non-admin users.

Fix: `RATE_LIMIT_ENABLED=false` in the test overlays. Verified locally: backend healthy, and the rate-limit suite skips gracefully (it's not exercised in the gate anyway). Part of the post-#1829 release-gate cleanup.