### PR TITLE
test: isolate admin-password-recovery to a dedicated admin (fix cross-suite 401 cascades)

### DIFF
--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -687,6 +687,129 @@ create_test_user_with_retry() {
   return 1
 }
 
+# ---------------------------------------------------------------------------
+# create_dedicated_admin / cleanup_dedicated_admin
+#
+# Release-gate flake fix (shared-admin credential poisoning):
+#   The gate runs ~25 suites in parallel, ALL authenticating as the same
+#   global admin (ADMIN_USER/ADMIN_PASS). Any suite that mutates the shared
+#   admin's own auth state -- changes its password, flips its roles,
+#   deactivates it, or revokes its tokens -- trips the backend's credential
+#   invalidation (services/auth/credential_invalidations.rs). That
+#   invalidates the admin's JWT process-wide, so EVERY other concurrently
+#   running suite's ADMIN_TOKEN starts returning "401 Invalid or expired
+#   token" -> non-deterministic 401 cascades across the whole gate.
+#
+#   A suite that needs to exercise admin-self mutations (password recovery,
+#   role flip, self-deactivation) must do so on a THROWAWAY admin identity,
+#   never on the shared one. create_dedicated_admin mints such a user using
+#   the global admin token (which it does NOT mutate), and echoes the new
+#   admin's UUID on stdout. The throwaway admin is created with
+#   is_admin:true so it has the same admin authority as the shared admin and
+#   can hit admin-only routes / be used wherever the shared admin was.
+#
+#   The caller's global ADMIN_TOKEN is unaffected throughout: we only POST
+#   /users (create) and never touch /users/{global_admin_id}.
+#
+# Output / contract (mirrors create_test_user_with_retry):
+#   - echoes the new admin's UUID on stdout, returns 0 on success
+#   - echoes "" and a diagnostic to stderr, returns 1 on failure
+#   - retries ONLY the transient class (network 000 / HTTP 5xx); real 4xx
+#     (e.g. 409 duplicate, 403 authz) are surfaced immediately
+#
+# The username/password/email are derived from RUN_ID + $$ so they are
+# unique per suite invocation and cannot collide across parallel suites.
+#
+# Usage:
+#   ADMIN2_USER="e2e-dedadmin-${RUN_ID}-$$"
+#   ADMIN2_PASS="DedAdmin_${RUN_ID:0:8}_Aa1!"
+#   ADMIN2_ID=$(create_dedicated_admin "$ADMIN2_USER" "$ADMIN2_PASS") || fail ...
+#   add_exit_handler "cleanup_dedicated_admin $ADMIN2_ID"
+#
+# Or let it generate the credentials for you and read them back via the
+# convenience globals it exports (DEDICATED_ADMIN_USER / _PASS / _ID):
+#   create_dedicated_admin >/dev/null || fail "could not create dedicated admin"
+#   add_exit_handler "cleanup_dedicated_admin ${DEDICATED_ADMIN_ID}"
+create_dedicated_admin() {
+  # Generate unique, policy-compliant credentials when not supplied. The
+  # backend password policy wants >=12 chars + mixed case + digit + symbol;
+  # the suffix guarantees all four classes regardless of RUN_ID contents.
+  local label="${3:-dedadmin}"
+  local username="${1:-e2e-${label}-${RUN_ID}-$$}"
+  local password="${2:-Ded_${RUN_ID:0:8}_$$_Aa1!}"
+  local email="${username}@e2e.local"
+
+  # Export the resolved identity so callers that did not pass explicit args
+  # can still recover the credentials (and so the cleanup handler can be
+  # registered without recomputing them).
+  DEDICATED_ADMIN_USER="$username"
+  DEDICATED_ADMIN_PASS="$password"
+  export DEDICATED_ADMIN_USER DEDICATED_ADMIN_PASS
+
+  local body
+  body="{\"username\":\"${username}\",\"password\":\"${password}\",\"email\":\"${email}\",\"display_name\":\"E2E Dedicated Admin\",\"is_admin\":true}"
+
+  local _max="${CREATE_USER_MAX_ATTEMPTS:-4}"
+  local _delay="${CREATE_USER_RETRY_DELAY:-1}"
+  local _attempt _status _tmp _resp uid=""
+  for _attempt in $(seq 1 "$_max"); do
+    _tmp=$(mktemp)
+    # Uses the GLOBAL admin token via auth_header(); creating a user does not
+    # mutate the global admin, so its JWT stays valid for concurrent suites.
+    _status=$(curl -s $CURL_TIMEOUT -o "$_tmp" -w '%{http_code}' \
+      -X POST -H "$(auth_header)" -H 'Content-Type: application/json' \
+      -d "$body" "${BASE_URL}/api/v1/users" 2>/dev/null) || _status="000"
+    _resp=$(cat "$_tmp" 2>/dev/null || true)
+    rm -f "$_tmp"
+
+    if [ "$_status" -ge 200 ] 2>/dev/null && [ "$_status" -lt 300 ] 2>/dev/null; then
+      uid=$(echo "$_resp" | jq -r '.user.id // .id // .user_id // empty' 2>/dev/null) || uid=""
+      if [ -n "$uid" ] && [ "$uid" != "null" ]; then
+        DEDICATED_ADMIN_ID="$uid"
+        export DEDICATED_ADMIN_ID
+        echo "$uid"
+        return 0
+      fi
+      echo "create_dedicated_admin: ${username} got HTTP ${_status} but no id: ${_resp:0:200}" >&2
+      echo ""
+      return 1
+    fi
+
+    # Retry ONLY transient class: network 000 or any 5xx.
+    if [ "$_status" != "000" ] && { [ "$_status" -lt 500 ] 2>/dev/null || [ "$_status" -ge 600 ] 2>/dev/null; }; then
+      echo "create_dedicated_admin: ${username} non-transient HTTP ${_status}: ${_resp:0:200}" >&2
+      echo ""
+      return 1
+    fi
+
+    if [ "$_attempt" -lt "$_max" ]; then
+      echo "  create-dedicated-admin ${username} attempt ${_attempt}/${_max} transient HTTP ${_status}, retrying in ${_delay}s..." >&2
+      sleep "$_delay"
+      _delay=$(( _delay * 2 ))
+    fi
+  done
+  echo "create_dedicated_admin: ${username} failed after ${_max} attempts (last HTTP ${_status})" >&2
+  echo ""
+  return 1
+}
+
+# Delete a throwaway admin created by create_dedicated_admin. Best-effort:
+# re-authenticates as the global admin first (in case the suite rotated its
+# own ADMIN_TOKEN while testing), then DELETEs the user. Safe to call with an
+# empty/invalid id (no-op). Intended for use with add_exit_handler so an
+# interrupted run leaves no dangling admin users.
+#
+# Usage:
+#   add_exit_handler "cleanup_dedicated_admin $ADMIN2_ID"
+cleanup_dedicated_admin() {
+  local uid="${1:-${DEDICATED_ADMIN_ID:-}}"
+  if [ -z "$uid" ] || [ "$uid" = "null" ]; then
+    return 0
+  fi
+  auth_admin > /dev/null 2>&1 || true
+  api_delete "/api/v1/users/${uid}" > /dev/null 2>&1 || true
+}
+
 # Log in as the named user and echo the access_token on stdout.
 # On failure, echoes empty string and the response body to stderr.
 #

--- a/tests/platform/test-admin-password-recovery.sh
+++ b/tests/platform/test-admin-password-recovery.sh
@@ -7,8 +7,22 @@
 # recover. The fix added pg_advisory_xact_lock and write-before-DB ordering.
 #
 # Since E2E tests cannot directly verify filesystem operations, this suite
-# validates the observable behavior: admin auth works, password can be
-# changed and restored, and the system stays stable under rapid auth load.
+# validates the observable behavior: an admin user's auth works, the password
+# can be changed and restored, the old password is rejected, and the system
+# stays stable under rapid auth load.
+#
+# RELEASE-GATE SAFETY (shared-admin credential poisoning fix):
+#   This suite used to mutate the SHARED global admin (ADMIN_USER) -- resolve
+#   its user id, change its password, then reset it. Under the gate's ~25-way
+#   concurrency that poisons every other suite: changing the shared admin's
+#   password trips the backend credential-invalidation map and invalidates the
+#   global admin JWT process-wide, so all concurrent suites' ADMIN_TOKEN start
+#   returning 401. The "intent" of this regression test is the password
+#   change -> rapid-login -> reset cycle on an *admin* identity, not on the
+#   *shared* one. So we now mint a DEDICATED throwaway admin
+#   (create_dedicated_admin) and run the entire cycle against it. The global
+#   admin token is used only to create/delete the throwaway user and is never
+#   mutated, so concurrent suites are unaffected.
 #
 # Requires: curl, jq
 source "$(dirname "$0")/../lib/common.sh"
@@ -16,36 +30,46 @@ source "$(dirname "$0")/../lib/common.sh"
 begin_suite "admin-password-recovery"
 auth_admin
 
-ORIGINAL_PASS="$ADMIN_PASS"
-TEST_PASS="N3wP@ssw0rd!Zxq"
+# -------------------------------------------------------------------------
+# Mint a dedicated throwaway admin. ALL password mutations below target THIS
+# user, never the shared ADMIN_USER. Credentials are unique per run.
+# -------------------------------------------------------------------------
+
+DED_USER="e2e-pwrec-${RUN_ID}-$$"
+ORIGINAL_PASS="DedPwRec_${RUN_ID:0:8}_Aa1!"
+TEST_PASS="DedPwRec_${RUN_ID:0:8}_Bb2!"
+ADMIN_ID=""
 PASSWORD_MUTATED=false
 
-# Best-effort restore of the admin password if the suite is interrupted or
-# any test fails between the password change and the explicit reset step.
-# Without this, a partial run leaves the admin user locked to TEST_PASS,
-# which breaks every subsequent suite's auth_admin call in the namespace.
-restore_admin_password() {
+# Cleanup: delete the throwaway admin. add_exit_handler re-auths as the global
+# admin first, so cleanup works even though we rotate the dedicated admin's
+# password mid-suite. The global admin token is never touched here.
+add_exit_handler "cleanup_dedicated_admin \"\${ADMIN_ID:-}\""
+
+# Best-effort restore of the DEDICATED admin's password if the suite is
+# interrupted between the password change and the explicit reset step. This is
+# now purely cosmetic (the user is deleted on exit anyway), but it keeps the
+# dedicated admin loginable with ORIGINAL_PASS for any in-suite
+# assertions. It NEVER touches the shared admin.
+restore_dedicated_password() {
   if [ "$PASSWORD_MUTATED" != "true" ]; then
     return 0
   fi
   if [ -z "${ADMIN_ID:-}" ] || [ "$ADMIN_ID" = "null" ]; then
     return 0
   fi
-  # Re-login with whatever password is currently active (TEST_PASS first).
   local _tok=""
   for _candidate in "$TEST_PASS" "$ORIGINAL_PASS"; do
     local _login
     _login=$(curl -sf --max-time 10 -X POST "${BASE_URL}/api/v1/auth/login" \
       -H "Content-Type: application/json" \
-      -d "{\"username\":\"${ADMIN_USER}\",\"password\":\"${_candidate}\"}" 2>/dev/null) || true
+      -d "{\"username\":\"${DED_USER}\",\"password\":\"${_candidate}\"}" 2>/dev/null) || true
     if [ -n "$_login" ]; then
       _tok=$(echo "$_login" | jq -r '.token // .access_token // empty' 2>/dev/null) || true
       if [ -n "$_tok" ] && [ "$_tok" != "null" ]; then
-        # If we got in with the original, nothing to restore.
         if [ "$_candidate" = "$ORIGINAL_PASS" ]; then
           return 0
         fi
-        # Got in with TEST_PASS, push original back.
         curl -sf --max-time 10 -X POST \
           -H "Authorization: Bearer ${_tok}" \
           -H "Content-Type: application/json" \
@@ -56,60 +80,43 @@ restore_admin_password() {
     fi
   done
 }
-trap restore_admin_password EXIT
+add_exit_handler restore_dedicated_password
 
 # -------------------------------------------------------------------------
-# Resolve admin user ID (needed for password change endpoint)
+# Create the dedicated admin (needed for the password-change endpoint, which
+# is keyed on user id).
 # -------------------------------------------------------------------------
 
-ADMIN_ID=""
-resolve_admin_id() {
-  local resp
-  resp=$(api_get "/api/v1/users?username=${ADMIN_USER}" 2>/dev/null) || true
-  if [ -n "$resp" ]; then
-    ADMIN_ID=$(echo "$resp" | jq -r '
-      if type == "array" then .[0].id
-      elif .items then .items[0].id
-      elif .users then .users[0].id
-      elif .id then .id
-      else empty
-      end // empty
-    ')
-  fi
-  # Fallback: list all users and find admin by username
-  if [ -z "$ADMIN_ID" ] || [ "$ADMIN_ID" = "null" ]; then
-    resp=$(api_get "/api/v1/users" 2>/dev/null) || true
-    if [ -n "$resp" ]; then
-      ADMIN_ID=$(echo "$resp" | jq -r --arg u "$ADMIN_USER" '
-        if type == "array" then (.[] | select(.username == $u) | .id)
-        elif .items then (.items[] | select(.username == $u) | .id)
-        elif .users then (.users[] | select(.username == $u) | .id)
-        else empty
-        end // empty
-      ')
-    fi
-  fi
-}
-
-resolve_admin_id
-
-# -------------------------------------------------------------------------
-# 1. Admin login works (basic health check for auth)
-# -------------------------------------------------------------------------
-
-begin_test "Admin login works"
-login_resp=$(curl -sf $CURL_TIMEOUT -X POST "${BASE_URL}/api/v1/auth/login" \
-  -H "Content-Type: application/json" \
-  -d "{\"username\":\"${ADMIN_USER}\",\"password\":\"${ORIGINAL_PASS}\"}" 2>/dev/null) || true
-if [ -n "$login_resp" ]; then
-  token=$(echo "$login_resp" | jq -r '.token // .access_token // empty')
-  if [ -n "$token" ] && [ "$token" != "null" ]; then
-    pass
-  else
-    fail "login response did not contain a token"
-  fi
+begin_test "Create dedicated admin user"
+ADMIN_ID=$(create_dedicated_admin "$DED_USER" "$ORIGINAL_PASS") || ADMIN_ID=""
+if [ -n "$ADMIN_ID" ] && [ "$ADMIN_ID" != "null" ]; then
+  pass
 else
-  fail "login request returned empty response"
+  fail "could not create dedicated admin user"
+fi
+
+# -------------------------------------------------------------------------
+# 1. Dedicated admin login works (basic health check for auth)
+# -------------------------------------------------------------------------
+
+begin_test "Dedicated admin login works"
+if [ -z "$ADMIN_ID" ] || [ "$ADMIN_ID" = "null" ]; then
+  skip "dedicated admin not created"
+else
+  login_resp=$(curl -sf $CURL_TIMEOUT -X POST "${BASE_URL}/api/v1/auth/login" \
+    -H "Content-Type: application/json" \
+    -d "{\"username\":\"${DED_USER}\",\"password\":\"${ORIGINAL_PASS}\"}" 2>/dev/null) || true
+  if [ -n "$login_resp" ]; then
+    token=$(echo "$login_resp" | jq -r '.token // .access_token // empty')
+    if [ -n "$token" ] && [ "$token" != "null" ]; then
+      DED_TOKEN="$token"
+      pass
+    else
+      fail "login response did not contain a token"
+    fi
+  else
+    fail "login request returned empty response"
+  fi
 fi
 
 # -------------------------------------------------------------------------
@@ -131,19 +138,20 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# 3. Admin can change password
+# 3. Dedicated admin can change its own password
 # -------------------------------------------------------------------------
 
-begin_test "Admin can change password"
-if [ -z "$ADMIN_ID" ] || [ "$ADMIN_ID" = "null" ]; then
-  skip "could not resolve admin user ID"
+begin_test "Dedicated admin can change password"
+if [ -z "$ADMIN_ID" ] || [ "$ADMIN_ID" = "null" ] || [ -z "${DED_TOKEN:-}" ]; then
+  skip "dedicated admin not available"
 else
   # Send exactly one request. The change_password handler invalidates the
   # caller's existing JWT after a successful change (backend
   # auth_service::invalidate_user_tokens), so a second call with the same
-  # ADMIN_TOKEN would get 401 and look like a backend failure.
+  # DED_TOKEN would get 401 and look like a backend failure. Crucially this
+  # is the DEDICATED admin's token -- the GLOBAL admin token is untouched.
   change_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X POST \
-    -H "$(auth_header)" \
+    -H "Authorization: Bearer ${DED_TOKEN}" \
     -H "Content-Type: application/json" \
     -d "{\"current_password\":\"${ORIGINAL_PASS}\",\"new_password\":\"${TEST_PASS}\"}" \
     "${BASE_URL}/api/v1/users/${ADMIN_ID}/password") || true
@@ -161,18 +169,16 @@ fi
 # -------------------------------------------------------------------------
 
 begin_test "Login with new password works"
-if [ -z "$ADMIN_ID" ] || [ "$ADMIN_ID" = "null" ]; then
-  skip "admin ID not resolved, password was not changed"
+if [ "$PASSWORD_MUTATED" != "true" ]; then
+  skip "password was not changed"
 else
   new_login_resp=$(curl -sf $CURL_TIMEOUT -X POST "${BASE_URL}/api/v1/auth/login" \
     -H "Content-Type: application/json" \
-    -d "{\"username\":\"${ADMIN_USER}\",\"password\":\"${TEST_PASS}\"}" 2>/dev/null) || true
+    -d "{\"username\":\"${DED_USER}\",\"password\":\"${TEST_PASS}\"}" 2>/dev/null) || true
   if [ -n "$new_login_resp" ]; then
     new_token=$(echo "$new_login_resp" | jq -r '.token // .access_token // empty')
     if [ -n "$new_token" ] && [ "$new_token" != "null" ]; then
-      # Update the token for subsequent API calls
-      ADMIN_TOKEN="$new_token"
-      export ADMIN_TOKEN
+      DED_TOKEN="$new_token"
       pass
     else
       fail "login with new password did not return a token"
@@ -187,13 +193,13 @@ fi
 # -------------------------------------------------------------------------
 
 begin_test "Login with old password fails"
-if [ -z "$ADMIN_ID" ] || [ "$ADMIN_ID" = "null" ]; then
-  skip "admin ID not resolved, password was not changed"
+if [ "$PASSWORD_MUTATED" != "true" ]; then
+  skip "password was not changed"
 else
   old_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X POST \
     "${BASE_URL}/api/v1/auth/login" \
     -H "Content-Type: application/json" \
-    -d "{\"username\":\"${ADMIN_USER}\",\"password\":\"${ORIGINAL_PASS}\"}" 2>/dev/null) || true
+    -d "{\"username\":\"${DED_USER}\",\"password\":\"${ORIGINAL_PASS}\"}" 2>/dev/null) || true
   if [ "$old_status" = "401" ]; then
     pass
   else
@@ -206,11 +212,11 @@ fi
 # -------------------------------------------------------------------------
 
 begin_test "Reset back to original password"
-if [ -z "$ADMIN_ID" ] || [ "$ADMIN_ID" = "null" ]; then
-  skip "admin ID not resolved, nothing to reset"
+if [ "$PASSWORD_MUTATED" != "true" ] || [ -z "${DED_TOKEN:-}" ]; then
+  skip "nothing to reset"
 else
   reset_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X POST \
-    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    -H "Authorization: Bearer ${DED_TOKEN}" \
     -H "Content-Type: application/json" \
     -d "{\"current_password\":\"${TEST_PASS}\",\"new_password\":\"${ORIGINAL_PASS}\"}" \
     "${BASE_URL}/api/v1/users/${ADMIN_ID}/password") || true
@@ -219,12 +225,11 @@ else
     # Verify we can log in with the original password again
     verify_resp=$(curl -sf $CURL_TIMEOUT -X POST "${BASE_URL}/api/v1/auth/login" \
       -H "Content-Type: application/json" \
-      -d "{\"username\":\"${ADMIN_USER}\",\"password\":\"${ORIGINAL_PASS}\"}" 2>/dev/null) || true
+      -d "{\"username\":\"${DED_USER}\",\"password\":\"${ORIGINAL_PASS}\"}" 2>/dev/null) || true
     if [ -n "$verify_resp" ]; then
       restored_token=$(echo "$verify_resp" | jq -r '.token // .access_token // empty')
       if [ -n "$restored_token" ] && [ "$restored_token" != "null" ]; then
-        ADMIN_TOKEN="$restored_token"
-        export ADMIN_TOKEN
+        DED_TOKEN="$restored_token"
         PASSWORD_MUTATED=false
         pass
       else
@@ -261,33 +266,37 @@ else
 fi
 
 # -------------------------------------------------------------------------
-# 8. Multiple rapid login attempts do not cause errors
+# 8. Multiple rapid login attempts (for the dedicated admin) do not error
 # -------------------------------------------------------------------------
 
 begin_test "Rapid sequential login attempts stay stable"
-success_count=0
-error_count=0
-for i in $(seq 1 10); do
-  rapid_resp=$(curl -sf $CURL_TIMEOUT -X POST "${BASE_URL}/api/v1/auth/login" \
-    -H "Content-Type: application/json" \
-    -d "{\"username\":\"${ADMIN_USER}\",\"password\":\"${ORIGINAL_PASS}\"}" 2>/dev/null) || true
-  if [ -n "$rapid_resp" ]; then
-    rapid_token=$(echo "$rapid_resp" | jq -r '.token // .access_token // empty')
-    if [ -n "$rapid_token" ] && [ "$rapid_token" != "null" ]; then
-      success_count=$(( success_count + 1 ))
+if [ -z "$ADMIN_ID" ] || [ "$ADMIN_ID" = "null" ]; then
+  skip "dedicated admin not available"
+else
+  success_count=0
+  error_count=0
+  for i in $(seq 1 10); do
+    rapid_resp=$(curl -sf $CURL_TIMEOUT -X POST "${BASE_URL}/api/v1/auth/login" \
+      -H "Content-Type: application/json" \
+      -d "{\"username\":\"${DED_USER}\",\"password\":\"${ORIGINAL_PASS}\"}" 2>/dev/null) || true
+    if [ -n "$rapid_resp" ]; then
+      rapid_token=$(echo "$rapid_resp" | jq -r '.token // .access_token // empty')
+      if [ -n "$rapid_token" ] && [ "$rapid_token" != "null" ]; then
+        success_count=$(( success_count + 1 ))
+      else
+        error_count=$(( error_count + 1 ))
+      fi
     else
       error_count=$(( error_count + 1 ))
     fi
+  done
+  echo "  ${success_count}/10 logins succeeded, ${error_count}/10 failed"
+  # Allow up to 2 failures (rate limiting may kick in) but most should succeed
+  if [ "$success_count" -ge 8 ]; then
+    pass
   else
-    error_count=$(( error_count + 1 ))
+    fail "only ${success_count}/10 rapid login attempts succeeded"
   fi
-done
-echo "  ${success_count}/10 logins succeeded, ${error_count}/10 failed"
-# Allow up to 2 failures (rate limiting may kick in) but most should succeed
-if [ "$success_count" -ge 8 ]; then
-  pass
-else
-  fail "only ${success_count}/10 rapid login attempts succeeded"
 fi
 
 end_suite


### PR DESCRIPTION
**The systemic release-gate flake fix.** The gate runs ~25 suites concurrently, all as the SHARED global admin. `test-admin-password-recovery` mutated the SHARED admin's password, which (correctly, post credential-invalidation hardening) invalidated every other concurrent suite's admin JWT → non-deterministic 401 cascades (e.g. security-tests user-create getting 401). 

Audited all of tests/: this was the ONLY perpetrator (every other password/role/deactivate test uses dedicated e2e-*-RUN_ID users). Added `create_dedicated_admin`/`cleanup_dedicated_admin` helpers and rewrote the test to run change→rapid-login→reset against a throwaway admin. Verified locally: 9/0 AND the global admin token survives before/after (proof of no cross-suite poisoning).