### PR TITLE
test(release-gate): per-scanner image-scan efficacy canary (#237)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -834,6 +834,88 @@ jobs:
           if-no-files-found: ignore
 
   # -------------------------------------------------------------------
+  # Pinned-CVE IMAGE efficacy gate, PER SCANNER (#237, v1.2.4).
+  #
+  # Closes the blind spot that let artifact-keeper#2088 ship: container-
+  # image Trivy scans silently returned 0 findings (false-clean) after the
+  # trivy CLI was removed in #2059, while Grype still found CVEs in the same
+  # image. The existing pinned-cve-gate uploads an npm tarball (filesystem
+  # scanner) and asserts findings in AGGREGATE, so a dead image scanner
+  # hiding behind a healthy peer was invisible.
+  #
+  # This gate pushes a digest-pinned, known-vulnerable container image
+  # (alpine:3.4) into an AK OCI repo via the /v2/ distribution API (curl,
+  # no docker daemon on the runner) and asserts PER SCANNER that each wired
+  # image scanner (Trivy `image` + Grype) reached `completed` AND surfaced
+  # findings_count >= FINDINGS_FLOOR. A scanner that completes with ~0
+  # findings on the canary is a HARD FAIL.
+  #
+  # BLOCKING (not in the flaky tier): it must be reliable, so it gates the
+  # rollout at exactly the point #2088 should have been stopped. Wired into
+  # the collect-results rollup with the STRICTER `result != 'success'`
+  # predicate alongside the other silent-success gates.
+  # -------------------------------------------------------------------
+  pinned-cve-image-gate:
+    needs: deploy
+    runs-on: ak-e2e-runners
+    timeout-minutes: 10
+    env:
+      BASE_URL: ${{ needs.deploy.outputs.backend_url }}
+      RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
+      JUNIT_OUTPUT_DIR: /tmp/test-results
+      # RELEASE_GATE=1 turns common.sh's skip_suite() into a hard fail.
+      # ALLOW_SCANNER_SKIP=0 is enforced inside the gate too -- a scanner-
+      # down skip in release-gate context is the #888/#2088 silent-success
+      # / false-clean class this gate exists to catch.
+      RELEASE_GATE: '1'
+      ALLOW_SCANNER_SKIP: '0'
+      # Per-scanner floor. alpine:3.4 yields >100 findings via a healthy
+      # scanner, so 10 is a generous, drift-proof lower bound. Override via
+      # the repo variable if a future canary is swapped.
+      FINDINGS_FLOOR: ${{ vars.IMAGE_SCAN_FINDINGS_FLOOR || '10' }}
+      # The wired image scanners that MUST independently find the floor.
+      # scan_type values on the scan rows: `image` = Trivy image scan
+      # (the #2088 target), `grype` = Grype.
+      REQUIRED_IMAGE_SCANNERS: 'image grype'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: artifact-keeper/artifact-keeper-test
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
+
+      - name: Run pinned-CVE image efficacy gate (per scanner)
+        run: |
+          mkdir -p "$JUNIT_OUTPUT_DIR"
+          chmod +x tests/release-gate/test-pinned-cve-image.sh
+          ./tests/release-gate/test-pinned-cve-image.sh
+
+      - name: Capture scanner pod logs on failure
+        if: failure()
+        run: |
+          NS="test-${{ needs.deploy.outputs.run_id }}"
+          mkdir -p /tmp/test-logs
+          # #1379: Trivy pods are labelled app.kubernetes.io/component=trivy.
+          kubectl -n "$NS" logs -l app.kubernetes.io/component=trivy \
+            --tail=2000 > /tmp/test-logs/pinned-cve-image-trivy.log 2>&1 || true
+          kubectl -n "$NS" logs -l app.kubernetes.io/component=scanner \
+            --tail=2000 > /tmp/test-logs/pinned-cve-image-scanner.log 2>&1 || true
+          kubectl -n "$NS" logs -l app=artifact-keeper-backend \
+            --tail=1000 > /tmp/test-logs/pinned-cve-image-backend.log 2>&1 || true
+
+      - name: Upload pinned-CVE image gate results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: junit-pinned-cve-image
+          path: |
+            /tmp/test-results/
+            /tmp/test-logs/
+          if-no-files-found: ignore
+
+  # -------------------------------------------------------------------
   # Format tests (8 parallel batches)
   # -------------------------------------------------------------------
   format-tests:
@@ -1871,7 +1953,7 @@ jobs:
   # Collect results and publish summary
   # -------------------------------------------------------------------
   collect-results:
-    needs: [version-set-integrity, clean-install-smoke, clean-install-smoke-with-deps, chart-upgrade-smoke, deploy, real-flow-smoke, scan-completion-gate, sbom-correctness-gate, pinned-cve-gate, format-tests, security-tests, compatibility-tests, repo-tests, promotion-tests, rbac-tests, lifecycle-tests, webhook-tests, search-tests, platform-tests, auth-tests, admin-tests, stress-tests, resilience-tests, mesh-tests]
+    needs: [version-set-integrity, clean-install-smoke, clean-install-smoke-with-deps, chart-upgrade-smoke, deploy, real-flow-smoke, scan-completion-gate, sbom-correctness-gate, pinned-cve-gate, pinned-cve-image-gate, format-tests, security-tests, compatibility-tests, repo-tests, promotion-tests, rbac-tests, lifecycle-tests, webhook-tests, search-tests, platform-tests, auth-tests, admin-tests, stress-tests, resilience-tests, mesh-tests]
     if: always()
     runs-on: ak-e2e-runners
     steps:
@@ -1890,7 +1972,7 @@ jobs:
           echo "| Suite | Status |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-------|--------|" >> "$GITHUB_STEP_SUMMARY"
 
-          for job in version-set-integrity clean-install-smoke clean-install-smoke-with-deps chart-upgrade-smoke real-flow-smoke scan-completion-gate sbom-correctness-gate pinned-cve-gate format-tests repo-tests promotion-tests rbac-tests lifecycle-tests webhook-tests search-tests platform-tests auth-tests admin-tests security-tests compatibility-tests stress-tests resilience-tests mesh-tests; do
+          for job in version-set-integrity clean-install-smoke clean-install-smoke-with-deps chart-upgrade-smoke real-flow-smoke scan-completion-gate sbom-correctness-gate pinned-cve-gate pinned-cve-image-gate format-tests repo-tests promotion-tests rbac-tests lifecycle-tests webhook-tests search-tests platform-tests auth-tests admin-tests security-tests compatibility-tests stress-tests resilience-tests mesh-tests; do
             status="skipped"
             case "$job" in
               version-set-integrity) status="${{ needs.version-set-integrity.result }}" ;;
@@ -1901,6 +1983,7 @@ jobs:
               scan-completion-gate) status="${{ needs.scan-completion-gate.result }}" ;;
               sbom-correctness-gate) status="${{ needs.sbom-correctness-gate.result }}" ;;
               pinned-cve-gate) status="${{ needs.pinned-cve-gate.result }}" ;;
+              pinned-cve-image-gate) status="${{ needs.pinned-cve-image-gate.result }}" ;;
               format-tests) status="${{ needs.format-tests.result }}" ;;
               repo-tests) status="${{ needs.repo-tests.result }}" ;;
               promotion-tests) status="${{ needs.promotion-tests.result }}" ;;
@@ -1978,6 +2061,7 @@ jobs:
           needs.scan-completion-gate.result != 'success' ||
           needs.sbom-correctness-gate.result != 'success' ||
           needs.pinned-cve-gate.result != 'success' ||
+          needs.pinned-cve-image-gate.result != 'success' ||
           needs.deploy.result == 'failure' || needs.deploy.result == 'cancelled' ||
           needs.format-tests.result == 'failure' || needs.format-tests.result == 'cancelled' ||
           needs.compatibility-tests.result == 'failure' || needs.compatibility-tests.result == 'cancelled' ||

--- a/.github/workflows/scan-completes-self-test.yml
+++ b/.github/workflows/scan-completes-self-test.yml
@@ -1,44 +1,60 @@
 name: Scan-Completes Self-Test
 
-# Meta-test for the scan-completion gate per the #883 contract.
+# Meta-test for the per-scanner IMAGE-scan efficacy gate per the #883 contract.
 #
-# Covers artifact-keeper-test#61.
+# Covers artifact-keeper-test#61 and #237.
 #
 # Why this exists
 # ---------------
-# The lite scan-completion gate at tests/security/test-scan-completes.sh
-# (and the release-gate wrapper at tests/release-gate/scan-completion-gate.sh)
-# is the load-bearing assertion against the #871 (stuck queued) and #888
-# (silent completed-but-not-scanned) regression classes.
+# The load-bearing release gate for the scanner-efficacy silent-success class
+# is tests/release-gate/test-pinned-cve-image.sh -- the PER-SCANNER container-
+# image efficacy canary (#237). It closes the blind spot that let
+# artifact-keeper#2088 ship: after the trivy CLI was removed from the backend
+# image (#2059), container-image Trivy scans silently returned 0 findings and
+# were recorded as `completed` (a false-clean), while Grype still found real
+# CVEs in the same image. Any AGGREGATE ("total findings > 0") check PASSED --
+# Grype covered for the dead Trivy.
 #
-# Without a paired pass/fail meta-test, a future PR can silently weaken
-# the gate -- drop the findings_count >= 1 check, raise the timeout
-# until SCAN_TIMEOUT is useless, swallow the assertion in a tolerant
-# ALLOW_SCANNER_SKIP path -- and the gate goes green forever on a
-# broken backend. That is the same silent-success failure class the
-# gate exists to prevent. The #883 contract requires explicit paired
-# evidence.
+# Without a paired pass/fail meta-test, a future PR can silently weaken the
+# gate -- drop the per-scanner floor, stop requiring a scanner to be PRESENT,
+# swallow the assertion in a tolerant ALLOW_SCANNER_SKIP path -- and the gate
+# goes green forever on a broken backend. That is the same silent-success
+# failure class the gate exists to prevent. The #883 contract requires explicit
+# paired evidence.
 #
-# We pin TWO distinct failure shapes because each exercises a different
-# code path in the gate:
+# We pin TWO distinct failure shapes because each exercises a different arm of
+# the gate's required-scanner invariant:
 #
 #   A. Trivy scaled to zero (scanner pod unreachable).
-#      The lite gate's scanner_unavailable() helper MUST fail loud
-#      (RELEASE_GATE=1 + ALLOW_SCANNER_SKIP=0). If a refactor accidentally
-#      makes scanner-down silently exit 0, this fixture catches it.
+#      With no Trivy pod, the backend produces NO scan_type=image row at all
+#      (adapter down -> fail-closed / absent) -- only Grype's row exists, and
+#      Grype finds CVEs. A findings-on-present-scanners check would PASS. The
+#      gate's REQUIRED-SCANNER PRESENCE assertion MUST fail: a required scanner
+#      that produced no completed row is a hard fail. This is the exact #2088
+#      sibling (Trivy entirely absent, vs. Trivy-returns-0).
 #
-#   B. Findings forgery (backend stub completes scans with findings_count=0).
-#      The lite gate's findings_count >= 1 assertion is the only
-#      thing standing between "scan ran" and "scan ran AND inspected
-#      the bytes". If a refactor removes that check (or replaces it
-#      with `>= 0`), this fixture catches it.
+#   B. A required scanner completes BELOW the CVE floor.
+#      Trivy's `dependency` (language-dependency) scan legitimately finds zero
+#      on an OS-only base image, while Grype clears the ground-truth floor on
+#      the same image. Requiring `grype dependency` therefore leaves `grype`
+#      passing (ground truth intact) and `dependency` completing below the
+#      floor. The gate's per-scanner floor assertion -- the analog of the old
+#      lite gate's `findings_count >= 1` -- MUST bite. If a refactor drops it
+#      (or replaces it with `>= 0`), this fixture catches it. This arm is
+#      independent of the #2088 backend state (dependency stays 0 whether or
+#      not the Trivy image adapter is fixed), so it does not go stale when
+#      artifact-keeper#2088 lands.
+#
+# Both fixtures run the gate with EXPECT_FAILURE=1: common.sh's end_suite
+# inverts the exit code, so the gate correctly REJECTING the broken state
+# becomes a green self-test, and the gate going soft (every assertion passing)
+# becomes a red self-test.
 #
 # Triggers
 # --------
-# Run on every PR that touches the gate primitive, the wrapper, the
-# common library, the release-gate workflow, or this self-test.
-# Without this, a PR could weaken the gate and the self-test would
-# not run, defeating the meta-test entirely.
+# Run on every PR that touches the gate primitive, the common library, the
+# release-gate workflow, or this self-test. Without this, a PR could weaken the
+# gate and the self-test would not run, defeating the meta-test entirely.
 
 on:
   # Path filter is intentionally broad. The self-test must re-run on any
@@ -73,20 +89,22 @@ concurrency:
 
 jobs:
   # -------------------------------------------------------------------
-  # Fixture A: Trivy scaled to zero.
+  # Fixture A: Trivy scaled to zero -> the required image scanner is ABSENT.
   #
-  # Deploy a test stack with `trivy.replicaCount=0` (or the chart's
-  # equivalent). With no scanner pod reachable, every scan trigger
-  # surfaces as 503 from the backend's scanner-service stub, OR the
-  # scan transitions to `failed` with error_message set. Either way
-  # the gate primitive MUST fail (RELEASE_GATE=1 + ALLOW_SCANNER_SKIP=0).
-  # EXPECT_FAILURE=1 inverts the exit code so this job reports green
-  # when the gate correctly rejects the broken backend.
+  # Deploy the full stack (Trivy + Grype) but override trivy.replicaCount=0 so
+  # the Trivy pod is unschedulable. A scan of the vulnerable canary then fans
+  # out to Grype only: the scan_type=image (Trivy) row is never produced.
+  #
+  # The gate's REQUIRED-SCANNER PRESENCE assertion (default REQUIRED_IMAGE_
+  # SCANNERS="image grype") MUST fail because `image` produced no completed
+  # row -- even though Grype found dozens of CVEs. EXPECT_FAILURE=1 inverts the
+  # exit code so this job reports green when the gate correctly rejects the
+  # broken backend, and red if the gate went soft on an absent scanner.
   # -------------------------------------------------------------------
   pin-gate-fails-on-trivy-zero:
     name: Gate must reject Trivy scaled to zero (fixture A)
     runs-on: ak-e2e-runners
-    timeout-minutes: 12
+    timeout-minutes: 15
     env:
       ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
@@ -96,6 +114,9 @@ jobs:
       # (the gate working correctly on a broken backend) becomes exit 0;
       # a pass (the gate weakened to a no-op) becomes exit 1.
       EXPECT_FAILURE: '1'
+      # Default required set. `image` (Trivy) is absent with Trivy scaled to
+      # zero, so the presence assertion fires on it while grype passes.
+      REQUIRED_IMAGE_SCANNERS: 'image grype'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -114,7 +135,7 @@ jobs:
           # --full-stack normally enables Trivy. Override the replica
           # count to zero via a fixture-only values file so the chart
           # still installs but the scanner pod is unschedulable. The
-          # backend's scan-trigger path then surfaces scanner-unavailable.
+          # backend's scan then never produces a scan_type=image row.
           #
           # The values file path is relative-to-repo-root because
           # create-test-namespace.sh prepends REPO_ROOT to --values.
@@ -143,19 +164,19 @@ jobs:
           chmod +x tests/lib/wait-for-ready.sh
           ./tests/lib/wait-for-ready.sh "${{ steps.deploy.outputs.backend_url }}" 300
 
-      - name: Run gate against Trivy-zero fixture; expect failure
+      - name: Run image efficacy gate against Trivy-zero fixture; expect failure
         env:
           BASE_URL: ${{ steps.deploy.outputs.backend_url }}
           RUN_ID: ${{ steps.deploy.outputs.run_id }}
         run: |
           mkdir -p "$JUNIT_OUTPUT_DIR"
-          chmod +x tests/release-gate/scan-completion-gate.sh
-          # EXPECT_FAILURE=1 in env. end_suite() reads it and inverts
-          # the exit code. If the gate's findings_count assertion or
-          # the scanner_unavailable hard-fail is intact, this script
-          # exits 0 (because the gate exited 1 -- expected). If the
-          # gate has been weakened, the script exits 1 here.
-          ./tests/release-gate/scan-completion-gate.sh
+          chmod +x tests/release-gate/test-pinned-cve-image.sh
+          # EXPECT_FAILURE=1 in env. end_suite() reads it and inverts the
+          # exit code. With Trivy scaled to zero the scan_type=image row is
+          # absent, so the gate's required-scanner PRESENCE assertion fails
+          # and this script exits 0 (gate rejected the broken backend, as
+          # expected). If the gate went soft on an absent scanner, it exits 1.
+          ./tests/release-gate/test-pinned-cve-image.sh
 
       - name: Capture scanner diagnostics
         if: always()
@@ -184,48 +205,48 @@ jobs:
           if-no-files-found: ignore
 
   # -------------------------------------------------------------------
-  # Fixture B: Non-vulnerable fixture must trip the findings_count check.
+  # Fixture B: a required scanner completes BELOW the CVE floor.
   #
-  # The lite gate's load-bearing assertion is `findings_count >= 1` on
-  # a known-vulnerable lodash fixture. If a refactor weakens that check
-  # (drops it, replaces it with `>= 0`, swallows it in a tolerant
-  # branch), the gate goes green forever on a broken backend. Fixture A
-  # covers the scanner_unavailable half; Fixture B covers the
-  # findings-emitted half.
+  # The gate's load-bearing per-scanner assertion is `findings_count >= FLOOR`
+  # for every required scanner on the known-vulnerable canary. If a refactor
+  # weakens that (drops it, replaces it with `>= 0`, swallows it in a tolerant
+  # branch), the gate goes green forever on a false-clean scanner. Fixture A
+  # covers the absent-scanner arm; Fixture B covers the below-floor arm.
   #
   # Approach (no backend debug knob required):
-  #   - Override FIXTURE_LODASH_VERSION=4.17.21 (a non-vulnerable
-  #     release of lodash). Trivy's npm parser still parses the
-  #     lockfile but emits zero findings because the version carries
-  #     no published CVE.
-  #   - findings_count=0 on a non-vulnerable fixture is the CORRECT
-  #     scanner behavior. The gate's `findings_count >= 1` assertion
-  #     must therefore FAIL (the fixture proves the assertion is
-  #     load-bearing). EXPECT_FAILURE=1 inverts the exit code so a
-  #     gate failure becomes a self-test pass.
+  #   - Deploy the full stack with Trivy ENABLED, so every scanner is healthy.
+  #   - Require `grype dependency`. On the alpine OS-base canary, Grype clears
+  #     the ground-truth + per-scanner floor (dozens of OS-package CVEs), while
+  #     Trivy's `dependency` (language-dependency) scan legitimately completes
+  #     with zero findings -- there are no application dependency manifests in a
+  #     bare OS image. `dependency` therefore sits BELOW the floor while ground
+  #     truth stays intact via Grype.
+  #   - A required scanner completing below the floor is the exact false-clean
+  #     the gate must reject. The per-scanner floor assertion fires, end_suite
+  #     exits non-zero, and EXPECT_FAILURE=1 inverts it to a self-test pass.
   #
-  # This fixture pairs with Fixture A to provide the full #883
-  # paired-evidence contract: A proves scanner-unavailable fails loud,
-  # B proves the findings_count >= 1 assertion bites.
+  # This arm is independent of the #2088 backend state (dependency stays 0
+  # whether or not the Trivy image adapter is fixed), so the fixture does not
+  # go stale when artifact-keeper#2088 lands.
   # -------------------------------------------------------------------
-  pin-gate-fails-on-non-vulnerable-fixture:
-    name: Gate must reject non-vulnerable fixture (fixture B)
+  pin-gate-fails-on-below-floor-scanner:
+    name: Gate must reject a required scanner below the CVE floor (fixture B)
     runs-on: ak-e2e-runners
-    timeout-minutes: 12
+    timeout-minutes: 15
     env:
       ADMIN_PASS: TestRunner!2026secure
       JUNIT_OUTPUT_DIR: /tmp/test-results
       RELEASE_GATE: '1'
       ALLOW_SCANNER_SKIP: '0'
       # EXPECT_FAILURE inverts common.sh's end_suite exit code: the gate
-      # must fail on the non-vulnerable fixture (correct scanner
-      # behavior: zero findings on a clean lockfile), and that failure
-      # becomes exit 0 here.
+      # must fail because a required scanner is below the floor, and that
+      # failure becomes exit 0 here.
       EXPECT_FAILURE: '1'
-      # Override the fixture to a clean lodash version. test-scan-completes.sh
-      # reads FIXTURE_LODASH_VERSION and builds the lockfile from it.
-      # 4.17.21 is the latest patch; no CVE rows for it.
-      FIXTURE_LODASH_VERSION: '4.17.21'
+      # Require a scanner that legitimately finds nothing on an OS-only image
+      # (`dependency`) alongside one that finds dozens (`grype`). Grype keeps
+      # the ground-truth check satisfied; `dependency` trips the per-scanner
+      # floor -- proving that assertion is load-bearing.
+      REQUIRED_IMAGE_SCANNERS: 'grype dependency'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -238,7 +259,7 @@ jobs:
       - name: Deploy backend with Trivy enabled (full stack)
         id: deploy
         run: |
-          RUN_ID="self-clean-fixture-${{ github.run_id }}-${{ github.run_attempt }}"
+          RUN_ID="self-below-floor-${{ github.run_id }}-${{ github.run_attempt }}"
           echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
           chmod +x scripts/create-test-namespace.sh
           ./scripts/create-test-namespace.sh \
@@ -253,35 +274,37 @@ jobs:
         run: |
           chmod +x tests/lib/wait-for-ready.sh
           ./tests/lib/wait-for-ready.sh "${{ steps.deploy.outputs.backend_url }}" 300
-          # Confirm Trivy is up; if it is not, fixture A's failure mode
-          # would mask fixture B's signal.
+          # Confirm Trivy is up; a Trivy-down here would collapse fixture B
+          # into fixture A (absent image scanner) and mask the below-floor
+          # signal we are trying to exercise.
           kubectl -n "${{ steps.deploy.outputs.namespace }}" wait \
             --for=condition=Available deployment/artifact-keeper-trivy \
             --timeout=120s
 
-      - name: Run gate against clean-lodash fixture; expect failure
+      - name: Run image efficacy gate against below-floor fixture; expect failure
         env:
           BASE_URL: ${{ steps.deploy.outputs.backend_url }}
           RUN_ID: ${{ steps.deploy.outputs.run_id }}
         run: |
           mkdir -p "$JUNIT_OUTPUT_DIR"
-          chmod +x tests/release-gate/scan-completion-gate.sh
-          # FIXTURE_LODASH_VERSION=4.17.21 (set at job env). The fixture
-          # builds a clean lockfile, Trivy scans it, findings_count=0,
-          # the gate's `findings_count >= 1` assertion fires, end_suite
-          # exits non-zero. EXPECT_FAILURE=1 inverts to exit 0.
-          ./tests/release-gate/scan-completion-gate.sh
+          chmod +x tests/release-gate/test-pinned-cve-image.sh
+          # REQUIRED_IMAGE_SCANNERS='grype dependency' (job env). Grype clears
+          # the ground-truth + per-scanner floor on the vulnerable canary;
+          # Trivy's dependency scan completes below the floor (no lang deps in
+          # an OS image). The gate's per-scanner floor assertion fires,
+          # end_suite exits non-zero, EXPECT_FAILURE=1 inverts to exit 0.
+          ./tests/release-gate/test-pinned-cve-image.sh
 
       - name: Capture scanner diagnostics
         if: always()
         run: |
           NS="${{ steps.deploy.outputs.namespace }}"
           mkdir -p /tmp/test-logs
-          kubectl -n "$NS" get pods > /tmp/test-logs/pods-clean-fixture.txt 2>&1 || true
+          kubectl -n "$NS" get pods > /tmp/test-logs/pods-below-floor.txt 2>&1 || true
           kubectl -n "$NS" logs -l app.kubernetes.io/name=trivy \
-            --tail=2000 > /tmp/test-logs/trivy-clean-fixture.log 2>&1 || true
+            --tail=2000 > /tmp/test-logs/trivy-below-floor.log 2>&1 || true
           kubectl -n "$NS" logs -l app=artifact-keeper-backend \
-            --tail=500 > /tmp/test-logs/backend-clean-fixture.log 2>&1 || true
+            --tail=500 > /tmp/test-logs/backend-below-floor.log 2>&1 || true
 
       - name: Teardown
         if: always()
@@ -293,7 +316,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: scan-self-test-clean-fixture-${{ github.run_attempt }}
+          name: scan-self-test-below-floor-${{ github.run_attempt }}
           path: |
             /tmp/test-results/
             /tmp/test-logs/

--- a/tests/release-gate/test-pinned-cve-image.sh
+++ b/tests/release-gate/test-pinned-cve-image.sh
@@ -1,0 +1,578 @@
+#!/usr/bin/env bash
+# test-pinned-cve-image.sh -- PER-SCANNER image-scan efficacy canary.
+#
+# Covers artifact-keeper-test#237 (milestone v1.2.4).
+#
+# Why this exists, on top of test-pinned-cve.sh and scan-completion-gate.sh:
+#
+#   test-pinned-cve.sh uploads a lodash npm tarball and asserts a pinned CVE
+#   shows up. That exercises the filesystem/package scanner path only. The
+#   CONTAINER-IMAGE scanner path has no efficacy gate at all -- which is
+#   exactly where artifact-keeper#2088 lived: after the trivy CLI was removed
+#   from the backend image (artifact-keeper#2059), container-image Trivy scans
+#   silently returned 0 findings and were recorded as `completed` (a false-
+#   clean). Grype still found real CVEs in the same image, so any AGGREGATE
+#   check ("total findings > 0") PASSED -- Grype covered for the dead Trivy.
+#
+#   scan-completion-gate.sh only proves scans reach `completed`. A false-clean
+#   IS `completed`. Completion != efficacy.
+#
+#   Net blind spot: nothing asserted "EACH wired scanner, independently, finds
+#   a known CVE in a known-vulnerable image."
+#
+# This gate closes that hole. It pushes a KNOWN-VULNERABLE, DIGEST-PINNED
+# container image into an AK OCI repo, triggers a scan, and asserts -- PER
+# SCANNER, not in aggregate -- that each wired image scanner reached
+# `completed` AND surfaced findings_count >= FLOOR. A scanner that returns 0
+# on the canary (the #2088 signature: scan_type=image -> completed/0 while
+# scan_type=grype -> dozens) is a HARD FAIL.
+#
+# Backend contract (discovered against the v1.2.x backend; see #237):
+#   - Triggering a scan fans out into one scan ROW PER scanner. The per-
+#     scanner identity is the `scan_type` field on each row:
+#       GET /api/v1/security/scans?artifact_id=<id>
+#       -> { items: [ { id, scan_type, status, findings_count,
+#                       scanner_version, error_message, ... } ], total }
+#     Observed scan_type values for a container image: grype, image
+#     (Trivy image scan), dependency (Trivy), filesystem (Trivy, N/A for an
+#     image), incus (N/A for an image). The image scanners that MUST find
+#     OS-package CVEs in a vulnerable base image are `image` (Trivy) and
+#     `grype` (Grype).
+#   - Findings carry a `source` field naming the producing scanner:
+#       GET /api/v1/security/scans/<scan_id>/findings
+#       -> { items: [ { cve_id, severity, source, ... } ], total }
+#     We use `source` to corroborate that a scanner's findings are actually
+#     attributed to it (defends against a denormalized findings_count lying).
+#
+# DESIGN PRINCIPLES (from #237):
+#   - Assert against GROUND TRUTH: the canary is known-vulnerable, so a clean
+#     per-scanner result is definitionally a bug.
+#   - PER SCANNER, not aggregate: one dead scanner must not hide behind
+#     another. The scan_type row IS the per-scanner grouping.
+#   - PIN BY DIGEST + assert a FLOOR (>= N), never an exact count: CVE DBs
+#     grow, so exact counts drift. Plus a DB-freshness / ground-truth sanity
+#     check: if NO scanner finds the floor, that is a stale-DB / canary-rot
+#     test-infra problem, surfaced distinctly rather than blamed on one
+#     scanner.
+#   - FAIL CLOSED: a required image scanner that is missing, `failed`,
+#     `not_applicable`, or `completed`-with-zero on a real vulnerable image is
+#     a hard fail. This gate refuses ALLOW_SCANNER_SKIP=1, mirroring
+#     scan-completion-gate.sh's #888 discipline.
+#
+# Image transfer uses the OCI distribution API over curl (NOT the docker
+# daemon): the e2e runner pods have no docker daemon (test-oci.sh defaults to
+# the curl path, test-docker-native-client.sh skips when docker is absent).
+# We pull the digest-pinned manifest + blobs from the upstream registry and
+# re-push them into AK, so the stored bytes are byte-identical to the pinned
+# image and the CVE floor is stable.
+#
+# Environment:
+#   BASE_URL                  backend URL (default http://localhost:8080)
+#   ADMIN_USER / ADMIN_PASS   admin credentials
+#   RUN_ID                    resource-name suffix
+#   RELEASE_GATE              1 in the gate (skip_suite -> hard fail)
+#   ALLOW_SCANNER_SKIP        forced to 0 here; a skipped scanner is the bug
+#   SCAN_TIMEOUT              poll-until-terminal budget (default 240)
+#   FINDINGS_FLOOR            per-scanner lower bound (default 10)
+#   REQUIRED_IMAGE_SCANNERS   space-separated scan_type values that MUST find
+#                             the floor (default "image grype" = Trivy + Grype)
+#   CANARY_UPSTREAM_REGISTRY  upstream registry host (default registry-1.docker.io)
+#   CANARY_UPSTREAM_REPO      upstream repo path (default library/alpine)
+#   CANARY_DIGEST             digest to pin (default alpine:3.4 manifest-list digest)
+#   CANARY_TAG                tag to store under in AK (default 3.4)
+#   CANARY_PLATFORM_OS/ARCH   platform to select from a manifest list
+#                             (default linux/amd64)
+#   EXPECT_FAILURE            set by the meta self-test to invert the exit code
+
+# shellcheck source=../lib/common.sh disable=SC1091
+source "$(dirname "$0")/../lib/common.sh"
+
+# ---------------------------------------------------------------------------
+# Release-gate semantics. Refuse to honor ALLOW_SCANNER_SKIP=1: a release-gate
+# that gracefully skips when a scanner is unavailable is the exact silent-
+# success / false-clean class this gate exists to catch (#888, #2088).
+# ---------------------------------------------------------------------------
+if [ "${ALLOW_SCANNER_SKIP:-0}" = "1" ]; then
+  echo "ERROR: test-pinned-cve-image.sh refuses ALLOW_SCANNER_SKIP=1 (release-gate must fail loud on scanner unavailability / false-clean; that is the #2088 class)" >&2
+  exit 2
+fi
+export ALLOW_SCANNER_SKIP=0
+
+SCAN_TIMEOUT="${SCAN_TIMEOUT:-240}"
+FINDINGS_FLOOR="${FINDINGS_FLOOR:-10}"
+REQUIRED_IMAGE_SCANNERS="${REQUIRED_IMAGE_SCANNERS:-image grype}"
+
+CANARY_UPSTREAM_REGISTRY="${CANARY_UPSTREAM_REGISTRY:-registry-1.docker.io}"
+CANARY_UPSTREAM_REPO="${CANARY_UPSTREAM_REPO:-library/alpine}"
+# alpine:3.4 is a 7-year-old base image that yields dozens of CVEs across both
+# Trivy and Grype. The pinned digest is the multi-arch manifest-list digest;
+# the linux/amd64 platform manifest is resolved from it at runtime.
+CANARY_DIGEST="${CANARY_DIGEST:-sha256:b733d4a32c4da6a00a84df2ca32791bb03df95400243648d8c539e7b4cce329c}"
+CANARY_TAG="${CANARY_TAG:-3.4}"
+CANARY_PLATFORM_OS="${CANARY_PLATFORM_OS:-linux}"
+CANARY_PLATFORM_ARCH="${CANARY_PLATFORM_ARCH:-amd64}"
+
+# Human-readable label for a scan_type, used only in messages.
+scanner_label() {
+  case "$1" in
+    image)      echo "Trivy (image)" ;;
+    grype)      echo "Grype" ;;
+    dependency) echo "Trivy (dependency)" ;;
+    filesystem) echo "Trivy (filesystem)" ;;
+    incus)      echo "Incus" ;;
+    *)          echo "$1" ;;
+  esac
+}
+
+begin_suite "pinned-cve-image"
+auth_admin
+setup_workdir
+
+REPO_KEY="pinned-cve-image-${RUN_ID}"
+IMAGE_NAME="alpine"
+ARTIFACT_ID=""
+
+MT_LIST="application/vnd.docker.distribution.manifest.list.v2+json"
+MT_OCI_INDEX="application/vnd.oci.image.index.v1+json"
+MT_V2="application/vnd.docker.distribution.manifest.v2+json"
+MT_OCI="application/vnd.oci.image.manifest.v1+json"
+ACCEPT_MANIFEST="${MT_LIST},${MT_OCI_INDEX},${MT_V2},${MT_OCI}"
+
+cleanup_image_pin() {
+  # shellcheck disable=SC2086
+  curl -sf $CURL_TIMEOUT -X DELETE -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/repositories/${REPO_KEY}" >/dev/null 2>&1 || true
+}
+add_exit_handler "cleanup_image_pin"
+
+# ---------------------------------------------------------------------------
+# Upstream registry auth (challenge-based, so it works for docker.io and any
+# token-auth registry). Returns a bearer token on stdout (empty if the
+# registry allows anonymous pulls without one).
+# ---------------------------------------------------------------------------
+UPSTREAM_TOKEN=""
+upstream_acquire_token() {
+  local chal_hdr="${WORK_DIR}/upstream-challenge.hdr"
+  # Probe with an unauthenticated manifest HEAD to read the auth challenge.
+  # shellcheck disable=SC2086
+  curl -s $CURL_TIMEOUT -D "$chal_hdr" -o /dev/null -I \
+    -H "Accept: ${ACCEPT_MANIFEST}" \
+    "https://${CANARY_UPSTREAM_REGISTRY}/v2/${CANARY_UPSTREAM_REPO}/manifests/${CANARY_DIGEST}" \
+    >/dev/null 2>&1 || true
+
+  local www
+  www=$(grep -i '^www-authenticate:' "$chal_hdr" 2>/dev/null | head -n1 | tr -d '\r' || true)
+  if [ -z "$www" ]; then
+    # No challenge -> anonymous pulls allowed.
+    echo ""
+    return 0
+  fi
+
+  # Parse: Www-Authenticate: Bearer realm="...",service="...",scope="..."
+  local realm service scope
+  realm=$(echo "$www" | sed -n 's/.*realm="\([^"]*\)".*/\1/p')
+  service=$(echo "$www" | sed -n 's/.*service="\([^"]*\)".*/\1/p')
+  scope=$(echo "$www" | sed -n 's/.*scope="\([^"]*\)".*/\1/p')
+  if [ -z "$scope" ]; then
+    scope="repository:${CANARY_UPSTREAM_REPO}:pull"
+  fi
+  if [ -z "$realm" ]; then
+    echo ""
+    return 0
+  fi
+
+  local tok
+  # shellcheck disable=SC2086
+  tok=$(curl -s $CURL_TIMEOUT \
+    --data-urlencode "service=${service}" \
+    --data-urlencode "scope=${scope}" \
+    -G "$realm" 2>/dev/null | jq -r '.token // .access_token // empty' 2>/dev/null || true)
+  echo "$tok"
+}
+
+upstream_curl() {
+  # GET an upstream path with the bearer token if we have one. Args after the
+  # path are passed through to curl (e.g. -o, -D, -I, -H Accept).
+  local path="$1"; shift
+  if [ -n "$UPSTREAM_TOKEN" ]; then
+    # shellcheck disable=SC2086
+    curl -sL $CURL_TIMEOUT -H "Authorization: Bearer ${UPSTREAM_TOKEN}" "$@" \
+      "https://${CANARY_UPSTREAM_REGISTRY}/v2/${CANARY_UPSTREAM_REPO}${path}"
+  else
+    # shellcheck disable=SC2086
+    curl -sL $CURL_TIMEOUT "$@" \
+      "https://${CANARY_UPSTREAM_REGISTRY}/v2/${CANARY_UPSTREAM_REPO}${path}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# AK registry bearer (GET /v2/token with admin Basic creds), used for blob /
+# manifest pushes via the OCI distribution API.
+# ---------------------------------------------------------------------------
+AK_REGISTRY_TOKEN=""
+
+ak_push_blob() {
+  # ak_push_blob <blob_file> <digest> -> echoes the PUT http status
+  local blob_file="$1" dg="$2"
+  local hdr="${WORK_DIR}/ak-upload.hdr"
+  # Open a monolithic upload session.
+  # shellcheck disable=SC2086
+  curl -s $CURL_TIMEOUT -D "$hdr" -o /dev/null -X POST \
+    -H "Authorization: Bearer ${AK_REGISTRY_TOKEN}" \
+    "${BASE_URL}/v2/${REPO_KEY}/${IMAGE_NAME}/blobs/uploads/" >/dev/null 2>&1 || true
+  local loc
+  loc=$(grep -i '^location:' "$hdr" 2>/dev/null | head -n1 | tr -d '\r' | sed 's/^[Ll]ocation: *//')
+  if [ -z "$loc" ]; then echo "000"; return 1; fi
+  [[ "$loc" != http* ]] && loc="${BASE_URL}${loc}"
+  if [[ "$loc" == *"?"* ]]; then loc="${loc}&digest=${dg}"; else loc="${loc}?digest=${dg}"; fi
+  local code
+  # shellcheck disable=SC2086
+  code=$(curl -s $CURL_TIMEOUT -o /dev/null -w '%{http_code}' -X PUT \
+    -H "Authorization: Bearer ${AK_REGISTRY_TOKEN}" \
+    -H "Content-Type: application/octet-stream" \
+    --data-binary "@${blob_file}" "$loc" 2>/dev/null) || code="000"
+  echo "$code"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Create the OCI repo.
+# ---------------------------------------------------------------------------
+begin_test "Create docker (OCI) local repository"
+if create_local_repo "$REPO_KEY" "docker"; then
+  pass
+else
+  fail "could not create docker repository ${REPO_KEY}"
+  end_suite
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Acquire registry tokens.
+# ---------------------------------------------------------------------------
+begin_test "Acquire AK registry bearer (/v2/token)"
+# shellcheck disable=SC2086
+AK_REGISTRY_TOKEN=$(curl -s $CURL_TIMEOUT -u "${ADMIN_USER}:${ADMIN_PASS}" \
+  "${BASE_URL}/v2/token" 2>/dev/null | jq -r '.token // .access_token // empty' 2>/dev/null || true)
+if [ -n "$AK_REGISTRY_TOKEN" ]; then
+  pass
+else
+  fail "could not obtain AK /v2/token (registry auth broken; cannot push image)"
+  end_suite
+  exit 1
+fi
+
+begin_test "Acquire upstream registry token for ${CANARY_UPSTREAM_REPO}"
+UPSTREAM_TOKEN=$(upstream_acquire_token)
+# An empty token is legitimate for anonymous registries; we verify access by
+# actually fetching the manifest in the next step, so this step only fails if
+# the challenge parse threw. Treat reaching here as success.
+pass
+
+# ---------------------------------------------------------------------------
+# 3. Pull the digest-pinned manifest from upstream; resolve platform manifest.
+# ---------------------------------------------------------------------------
+begin_test "Fetch pinned upstream manifest ${CANARY_DIGEST}"
+TOP_JSON="${WORK_DIR}/upstream-top.json"
+up_status=$(upstream_curl "/manifests/${CANARY_DIGEST}" \
+  -H "Accept: ${ACCEPT_MANIFEST}" -o "$TOP_JSON" -w '%{http_code}') || up_status="000"
+if [ "$up_status" != "200" ] || ! jq -e . "$TOP_JSON" >/dev/null 2>&1; then
+  body=$(head -c 300 "$TOP_JSON" 2>/dev/null || true)
+  fail "could not fetch pinned manifest from ${CANARY_UPSTREAM_REGISTRY}/${CANARY_UPSTREAM_REPO}@${CANARY_DIGEST} (HTTP ${up_status})" \
+"$body
+note: the e2e runner needs egress to ${CANARY_UPSTREAM_REGISTRY}. Override the
+canary via CANARY_UPSTREAM_REGISTRY / CANARY_UPSTREAM_REPO / CANARY_DIGEST to
+point at an in-cluster mirror if direct egress is unavailable."
+  end_suite
+  exit 1
+fi
+pass
+
+begin_test "Resolve linux/${CANARY_PLATFORM_ARCH} platform manifest"
+MANIFEST_JSON="${WORK_DIR}/upstream-manifest.json"
+top_mt=$(jq -r '.mediaType // empty' "$TOP_JSON")
+has_manifests=$(jq -r 'has("manifests")' "$TOP_JSON" 2>/dev/null || echo false)
+if [ "$top_mt" = "$MT_LIST" ] || [ "$top_mt" = "$MT_OCI_INDEX" ] || [ "$has_manifests" = "true" ]; then
+  plat_digest=$(jq -r --arg os "$CANARY_PLATFORM_OS" --arg arch "$CANARY_PLATFORM_ARCH" \
+    '.manifests[] | select(.platform.os==$os and .platform.architecture==$arch) | .digest' \
+    "$TOP_JSON" 2>/dev/null | head -n1)
+  if [ -z "$plat_digest" ]; then
+    fail "manifest list has no ${CANARY_PLATFORM_OS}/${CANARY_PLATFORM_ARCH} entry" \
+      "$(jq -c '[.manifests[].platform]' "$TOP_JSON" 2>/dev/null | cut -c1-400)"
+    end_suite
+    exit 1
+  fi
+  pm_status=$(upstream_curl "/manifests/${plat_digest}" \
+    -H "Accept: ${ACCEPT_MANIFEST}" -o "$MANIFEST_JSON" -w '%{http_code}') || pm_status="000"
+  if [ "$pm_status" != "200" ] || ! jq -e . "$MANIFEST_JSON" >/dev/null 2>&1; then
+    fail "could not fetch platform manifest ${plat_digest} (HTTP ${pm_status})"
+    end_suite
+    exit 1
+  fi
+  echo "  platform manifest digest=${plat_digest}"
+else
+  # The pinned digest is already a single-platform image manifest.
+  cp "$TOP_JSON" "$MANIFEST_JSON"
+fi
+MANIFEST_MT=$(jq -r '.mediaType // empty' "$MANIFEST_JSON")
+[ -z "$MANIFEST_MT" ] && MANIFEST_MT="$MT_V2"
+if ! jq -e '.config.digest and (.layers | type == "array") and (.layers | length >= 1)' \
+     "$MANIFEST_JSON" >/dev/null 2>&1; then
+  fail "platform manifest missing config/layers" "$(jq -c . "$MANIFEST_JSON" 2>/dev/null | cut -c1-400)"
+  end_suite
+  exit 1
+fi
+pass
+
+# ---------------------------------------------------------------------------
+# 4. Copy config + layer blobs and the manifest into AK via the /v2/ API.
+# ---------------------------------------------------------------------------
+begin_test "Push config + layer blobs into ${REPO_KEY}"
+push_ok=true
+CONFIG_DIGEST=$(jq -r '.config.digest' "$MANIFEST_JSON")
+mapfile -t LAYER_DIGESTS < <(jq -r '.layers[].digest' "$MANIFEST_JSON")
+for dg in "$CONFIG_DIGEST" "${LAYER_DIGESTS[@]}"; do
+  blob_file="${WORK_DIR}/blob.bin"
+  bstatus=$(upstream_curl "/blobs/${dg}" -o "$blob_file" -w '%{http_code}') || bstatus="000"
+  if [ "$bstatus" != "200" ]; then
+    fail "upstream blob fetch ${dg} returned HTTP ${bstatus}"
+    push_ok=false
+    break
+  fi
+  put_code=$(ak_push_blob "$blob_file" "$dg") || put_code="000"
+  if [ "$put_code" != "201" ] && [ "$put_code" != "200" ] && [ "$put_code" != "202" ]; then
+    fail "AK blob PUT ${dg} returned HTTP ${put_code}"
+    push_ok=false
+    break
+  fi
+  echo "  blob ${dg:0:23}.. -> HTTP ${put_code}"
+done
+if $push_ok; then pass; else end_suite; exit 1; fi
+
+begin_test "Push manifest ${IMAGE_NAME}:${CANARY_TAG}"
+# shellcheck disable=SC2086
+man_code=$(curl -s $CURL_TIMEOUT -o /dev/null -w '%{http_code}' -X PUT \
+  -H "Authorization: Bearer ${AK_REGISTRY_TOKEN}" \
+  -H "Content-Type: ${MANIFEST_MT}" \
+  --data-binary "@${MANIFEST_JSON}" \
+  "${BASE_URL}/v2/${REPO_KEY}/${IMAGE_NAME}/manifests/${CANARY_TAG}" 2>/dev/null) || man_code="000"
+if [ "$man_code" = "201" ] || [ "$man_code" = "200" ]; then
+  pass
+else
+  fail "manifest PUT returned HTTP ${man_code}"
+  end_suite
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Resolve the stored manifest artifact_id.
+# ---------------------------------------------------------------------------
+begin_test "Resolve image artifact_id"
+list_json="${WORK_DIR}/artifacts.json"
+# shellcheck disable=SC2086
+list_status=$(curl -s $CURL_TIMEOUT -o "$list_json" -w '%{http_code}' \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts") || list_status="000"
+if [ "$list_status" = "200" ]; then
+  ARTIFACT_ID=$(jq -r --arg tag "${IMAGE_NAME}:${CANARY_TAG}" '
+    .items
+    | map(select((.content_type // "") | test("manifest")))
+    | (map(select(.name == $tag)) | first) // (.[0])
+    | .id // empty' "$list_json" 2>/dev/null || true)
+fi
+if [ -n "$ARTIFACT_ID" ]; then
+  echo "  artifact_id=${ARTIFACT_ID}"
+  pass
+else
+  fail "could not resolve image artifact_id (list HTTP ${list_status})" \
+    "$(head -c 400 "$list_json" 2>/dev/null || true)"
+  end_suite
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Trigger scan; poll until every scan row reaches a terminal state.
+# ---------------------------------------------------------------------------
+begin_test "Trigger image scan"
+trig_resp="${WORK_DIR}/trigger.json"
+trig_body=$(jq -n --arg id "$ARTIFACT_ID" '{artifact_id: $id, force: true}')
+# shellcheck disable=SC2086
+trig_status=$(curl -s $CURL_TIMEOUT -o "$trig_resp" -w '%{http_code}' -X POST \
+  -H "$(auth_header)" -H "Content-Type: application/json" \
+  -d "$trig_body" \
+  "${BASE_URL}/api/v1/security/scan") || trig_status="000"
+case "$trig_status" in
+  2*) pass ;;
+  501|502|503|504)
+    # Scanner subsystem unreachable. In release-gate context this is NOT a
+    # skip -- an unreachable scanner that prevents efficacy verification must
+    # fail the gate loud (fail-closed; #888/#2088 discipline).
+    fail "scan trigger returned HTTP ${trig_status} (scanner subsystem unreachable; release-gate fails closed)" \
+      "$(head -c 300 "$trig_resp" 2>/dev/null || true)"
+    end_suite
+    exit 1
+    ;;
+  *)
+    fail "scan trigger returned HTTP ${trig_status}" "$(head -c 300 "$trig_resp" 2>/dev/null || true)"
+    end_suite
+    exit 1
+    ;;
+esac
+
+begin_test "All scanner rows reach a terminal state within ${SCAN_TIMEOUT}s"
+SCANS_JSON="${WORK_DIR}/scans.json"
+elapsed=0
+all_terminal=false
+while [ "$elapsed" -lt "$SCAN_TIMEOUT" ]; do
+  # shellcheck disable=SC2086
+  poll_status=$(curl -s $CURL_TIMEOUT -o "$SCANS_JSON" -w '%{http_code}' \
+    -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/security/scans?artifact_id=${ARTIFACT_ID}&per_page=50") || poll_status="000"
+  if [ "$poll_status" = "200" ] && jq -e '.items | type == "array"' "$SCANS_JSON" >/dev/null 2>&1; then
+    total_rows=$(jq -r '.items | length' "$SCANS_JSON")
+    pending_rows=$(jq -r '[.items[] | select((.status|ascii_downcase) as $s
+      | ($s=="pending" or $s=="scanning" or $s=="running" or $s=="queued" or $s=="in_progress"))]
+      | length' "$SCANS_JSON")
+    if [ "${total_rows:-0}" -gt 0 ] && [ "${pending_rows:-0}" -eq 0 ]; then
+      all_terminal=true
+      break
+    fi
+  fi
+  sleep 5
+  elapsed=$(( elapsed + 5 ))
+done
+if $all_terminal; then
+  echo "  scan rows:"
+  jq -r '.items[] | "    scan_type=\(.scan_type)  status=\(.status)  findings=\(.findings_count)  ver=\(.scanner_version // "null")"' "$SCANS_JSON"
+  pass
+else
+  fail "not all scanner rows reached terminal within ${SCAN_TIMEOUT}s" \
+    "$(jq -c '[.items[] | {scan_type, status, findings_count}]' "$SCANS_JSON" 2>/dev/null | cut -c1-500)"
+  end_suite
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 7. GROUND-TRUTH / DB-FRESHNESS SANITY.
+#
+# The canary IS vulnerable. If NO scanner cleared the floor, the problem is
+# test-infra (stale/empty CVE DB, canary rot, wrong platform) -- NOT a single
+# scanner regression. Surface that distinctly so the per-scanner failures
+# below are not misread as "scanner X is broken" when the whole DB is dead.
+# ---------------------------------------------------------------------------
+begin_test "Ground truth: canary detected as vulnerable by at least one scanner (min ${FINDINGS_FLOOR})"
+max_findings=$(jq -r '[.items[].findings_count // 0] | max // 0' "$SCANS_JSON")
+best_scanner=$(jq -r --argjson m "${max_findings:-0}" \
+  'first(.items[] | select((.findings_count // 0) == $m) | .scan_type) // "none"' "$SCANS_JSON")
+if [ "${max_findings:-0}" -ge "$FINDINGS_FLOOR" ]; then
+  echo "  best scanner '${best_scanner}' found ${max_findings} findings (floor ${FINDINGS_FLOOR})"
+  pass
+else
+  fail "NO scanner found >= ${FINDINGS_FLOOR} findings on known-vulnerable ${CANARY_UPSTREAM_REPO}@${CANARY_DIGEST} (max=${max_findings})" \
+"This is a test-infra / ground-truth failure, NOT a per-scanner regression:
+the canary is known-vulnerable, so every scanner returning ~0 means the CVE
+database is stale/empty, the canary digest rotted, or the wrong platform was
+scanned. Refresh the scanner DBs or re-pin CANARY_DIGEST before trusting the
+per-scanner assertions below."
+  end_suite
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 8. PER-SCANNER EFFICACY ASSERTIONS (the core #2088 invariant).
+#
+# For EACH wired image scanner (default Trivy `image` + `grype`):
+#   - a scan row with that scan_type must exist (not missing),
+#   - it must be `completed` (not failed / error / not_applicable), AND
+#   - findings_count must be >= FLOOR.
+#
+# An aggregate "total > 0" is explicitly NOT sufficient: that is the exact
+# hole that let #2088 pass (Trivy image scan completed with 0 findings while
+# Grype found dozens). Each scanner is asserted INDEPENDENTLY.
+# ---------------------------------------------------------------------------
+for scan_type in $REQUIRED_IMAGE_SCANNERS; do
+  label=$(scanner_label "$scan_type")
+  begin_test "Per-scanner efficacy: ${label} (scan_type=${scan_type}) found at least ${FINDINGS_FLOOR} CVEs"
+
+  row=$(jq -c --arg st "$scan_type" 'first(.items[] | select(.scan_type == $st)) // empty' "$SCANS_JSON")
+  if [ -z "$row" ]; then
+    present=$(jq -r '[.items[].scan_type] | join(", ")' "$SCANS_JSON" 2>/dev/null || echo "?")
+    fail "${label}: no scan row with scan_type='${scan_type}' (scanner not wired / not dispatched)" \
+"scan_types present: ${present}
+A required image scanner producing no scan row at all is a wiring regression."
+    continue
+  fi
+
+  st_status=$(echo "$row" | jq -r '.status | ascii_downcase')
+  st_findings=$(echo "$row" | jq -r '.findings_count // 0')
+  st_ver=$(echo "$row" | jq -r '.scanner_version // "null"')
+  st_err=$(echo "$row" | jq -r '.error_message // ""')
+
+  if [ "$st_status" != "completed" ]; then
+    fail "${label}: scan row status='${st_status}', expected 'completed' (fail-closed: a vulnerable image must not yield ${st_status})" \
+"scan_type=${scan_type} status=${st_status} findings=${st_findings} scanner_version=${st_ver}
+error_message: ${st_err}
+A required image scanner reporting '${st_status}' on a known-vulnerable image
+means its efficacy cannot be verified -- the release fails closed."
+    continue
+  fi
+
+  if [ "${st_findings:-0}" -lt "$FINDINGS_FLOOR" ]; then
+    # This is the #2088 false-clean signature when it bites Trivy: the row is
+    # completed but findings_count is 0/low while another scanner found many.
+    fail "${label}: completed with ONLY ${st_findings} findings (floor ${FINDINGS_FLOOR}) on a known-vulnerable image -- FALSE-CLEAN (#2088 class)" \
+"scan_type=${scan_type} status=completed findings=${st_findings} scanner_version=${st_ver}
+ground-truth: best scanner '${best_scanner}' found ${max_findings} on the same image.
+A scanner that completes with ~0 findings while a peer finds dozens is silently
+broken (e.g. the trivy CLI removed in #2059, the #2088 image false-clean).
+An aggregate 'total > 0' check would have PASSED here -- that is the hole this
+gate closes. Per-scanner, this is a HARD FAIL."
+    continue
+  fi
+
+  echo "  ${label}: completed, findings=${st_findings} (>= ${FINDINGS_FLOOR}), scanner_version=${st_ver}"
+  pass
+
+  # Corroborate via the findings endpoint: each finding must carry a non-empty
+  # `source`, proving findings are attributed to a real scanner rather than a
+  # denormalized counter that lies. (Defense-in-depth; the floor check above
+  # is the load-bearing assertion.)
+  scan_id=$(echo "$row" | jq -r '.id')
+  begin_test "Per-scanner attribution: ${label} findings carry a source"
+  findings_json="${WORK_DIR}/findings-${scan_type}.json"
+  # shellcheck disable=SC2086
+  f_status=$(curl -s $CURL_TIMEOUT -o "$findings_json" -w '%{http_code}' \
+    -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/security/scans/${scan_id}/findings?per_page=200") || f_status="000"
+  if [ "$f_status" != "200" ] || ! jq -e '.items | type == "array"' "$findings_json" >/dev/null 2>&1; then
+    fail "${label}: findings endpoint HTTP ${f_status} or bad shape for scan ${scan_id}" \
+      "$(head -c 300 "$findings_json" 2>/dev/null || true)"
+    continue
+  fi
+  returned=$(jq -r '.items | length' "$findings_json")
+  attributed=$(jq -r '[.items[] | select((.source // "") != "")] | length' "$findings_json")
+  sources=$(jq -r '[.items[].source // "<null>"] | unique | join(", ")' "$findings_json")
+  if [ "${returned:-0}" -ge 1 ] && [ "${attributed:-0}" -eq "${returned:-0}" ]; then
+    echo "  ${returned} findings, all attributed; source(s): ${sources}"
+    pass
+  else
+    fail "${label}: ${attributed}/${returned} findings carry a non-empty source (expected all)" \
+      "observed source(s): ${sources}"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 9. Fail-closed contract note (covered behaviourally above).
+#
+# The per-scanner block already fails the gate on every fail-closed deviation
+# for a required image scanner: missing row, status != completed (failed /
+# error / not_applicable), or completed-with-zero. Combined with the refusal
+# of ALLOW_SCANNER_SKIP=1 at the top, an unreachable scanner adapter can never
+# masquerade as a pass: it surfaces either as a non-2xx trigger (failed
+# closed), a non-completed row, or a completed/0 false-clean -- all hard fails.
+#
+# Self-test hook: a meta-workflow can scale the scanner to zero and run this
+# gate with EXPECT_FAILURE=1 to prove the unreachable-scanner path yields a
+# `failed`/zero state that this gate catches (never completed/N).
+# ---------------------------------------------------------------------------
+
+end_suite

--- a/tests/release-gate/test-pinned-cve-image.sh
+++ b/tests/release-gate/test-pinned-cve-image.sh
@@ -100,7 +100,18 @@ export ALLOW_SCANNER_SKIP=0
 
 SCAN_TIMEOUT="${SCAN_TIMEOUT:-240}"
 FINDINGS_FLOOR="${FINDINGS_FLOOR:-10}"
+# Required-scanner list. Default "image grype" = Trivy image scan + Grype, the
+# two scanners that MUST independently find OS-package CVEs in a vulnerable base
+# image. Accept either comma- or space-separated input (image,grype == image
+# grype). An EMPTY list is a configuration error, not a silent pass: if this
+# gate asserted nothing it would be a no-op release gate -- the exact silent-
+# success class it exists to catch.
 REQUIRED_IMAGE_SCANNERS="${REQUIRED_IMAGE_SCANNERS:-image grype}"
+REQUIRED_IMAGE_SCANNERS="$(echo "$REQUIRED_IMAGE_SCANNERS" | tr ',' ' ' | tr -s ' ' | sed 's/^ *//;s/ *$//')"
+if [ -z "$REQUIRED_IMAGE_SCANNERS" ]; then
+  echo "ERROR: test-pinned-cve-image.sh: REQUIRED_IMAGE_SCANNERS is empty. A gate that requires no scanner asserts nothing -- refusing to run (that is the silent-success / no-op class this gate exists to catch)." >&2
+  exit 2
+fi
 
 CANARY_UPSTREAM_REGISTRY="${CANARY_UPSTREAM_REGISTRY:-registry-1.docker.io}"
 CANARY_UPSTREAM_REPO="${CANARY_UPSTREAM_REPO:-library/alpine}"
@@ -489,6 +500,43 @@ fi
 # hole that let #2088 pass (Trivy image scan completed with 0 findings while
 # Grype found dozens). Each scanner is asserted INDEPENDENTLY.
 # ---------------------------------------------------------------------------
+#
+# REQUIRED-SCANNER PRESENCE (the load-bearing #237 invariant).
+#
+# Before the detailed per-scanner loop below (which also checks finding
+# attribution), assert the single hard invariant in ONE place so a future
+# refactor of the loop cannot silently drop it: EVERY required scanner must
+# have produced a `completed` scan row with findings_count >= FLOOR on the
+# known-vulnerable canary.
+#
+# This is what #2088's sibling case needs: when the Trivy adapter is down, the
+# backend produces NO scan_type=image row at all (fail-closed / absent) -- only
+# Grype's row exists, and Grype has findings, so a "findings on the scanners
+# that happened to report" check would pass. Requiring PRESENCE (not just
+# findings-on-present-scanners) turns an absent required scanner into a hard
+# fail. An ABSENT row, a non-`completed` row (failed / error / not_applicable),
+# or a below-floor / zero row for ANY required scanner all fail here.
+# ---------------------------------------------------------------------------
+begin_test "Required image scanners present, completed, and >= ${FINDINGS_FLOOR}: [${REQUIRED_IMAGE_SCANNERS}]"
+req_failed=$(jq -r --arg req "$REQUIRED_IMAGE_SCANNERS" --argjson floor "$FINDINGS_FLOOR" '
+  ($req | split(" ") | map(select(length > 0))) as $required
+  | ([ .items[]
+       | select((.status | ascii_downcase) == "completed" and ((.findings_count // 0) >= $floor))
+       | .scan_type ]) as $good
+  | ($required - $good) | join(", ")' "$SCANS_JSON" 2>/dev/null || echo "?")
+if [ -z "$req_failed" ]; then
+  echo "  all required scanners (${REQUIRED_IMAGE_SCANNERS}) reached completed with >= ${FINDINGS_FLOOR} findings"
+  pass
+else
+  fail "required scanner(s) NOT present+completed+>=floor on a known-vulnerable image: ${req_failed}" "REQUIRED_IMAGE_SCANNERS=${REQUIRED_IMAGE_SCANNERS} floor=${FINDINGS_FLOOR}
+scan rows observed:
+$(jq -r '.items[] | "  scan_type=\(.scan_type) status=\(.status) findings=\(.findings_count // 0)"' "$SCANS_JSON" 2>/dev/null)
+A required scanner that is ABSENT (no row -- adapter down / not dispatched, the
+#2088 Trivy-scaled-to-zero sibling), NON-completed (failed / not_applicable), or
+completed BELOW the floor (the #2088 Trivy-returns-0 false-clean) is a HARD FAIL.
+Presence is required, not just findings on whichever scanners reported."
+fi
+
 for scan_type in $REQUIRED_IMAGE_SCANNERS; do
   label=$(scanner_label "$scan_type")
   begin_test "Per-scanner efficacy: ${label} (scan_type=${scan_type}) found at least ${FINDINGS_FLOOR} CVEs"


### PR DESCRIPTION
## What

New `tests/release-gate/test-pinned-cve-image.sh` — a container-image scan **efficacy** canary that asserts **per scanner** (not in aggregate) that each wired image scanner independently finds CVEs in a known-vulnerable, digest-pinned image. Wired into `.github/workflows/release-gate.yml` as a **blocking** gate (`pinned-cve-image-gate`).

Closes #237

## Why

This closes the exact blind spot that let artifact-keeper#2088 ship. After the trivy CLI was removed from the backend image (#2059), container-image Trivy scans silently returned **0 findings** and were recorded as `completed` (a false-clean), while Grype still found real CVEs in the same image. The existing `test-pinned-cve.sh` uploads an npm tarball (filesystem/package scanner path) and asserts findings in **aggregate**, so a dead image scanner hiding behind a healthy peer was invisible. `scan-completion-gate.sh` only proves scans reach `completed` — and a false-clean *is* `completed`.

## How it works

- Pushes `alpine:3.4` (digest-pinned, dozens of CVEs) into an AK OCI repo via the **`/v2/` distribution API over curl** — the e2e runner pods have no docker daemon (`test-oci.sh` defaults to the curl path; `test-docker-native-client.sh` skips when docker is absent). Stored bytes are byte-identical to the pinned image, so the CVE floor is stable. Canary is fully env-overridable.
- Triggers a scan, waits for every scan row to reach a terminal state.
- **Ground-truth / DB-freshness sanity:** at least one scanner must clear the floor, so a stale/empty CVE DB is surfaced as a *test-infra* failure rather than blamed on one scanner.
- **Per-scanner efficacy (the core #237 invariant):** for each wired scanner (`scan_type=image` = Trivy, `scan_type=grype` = Grype) assert the row reached `completed` (not failed/error/not_applicable/missing) **and** `findings_count >= FINDINGS_FLOOR` (default 10), corroborated by per-finding `source` attribution. An aggregate "total > 0" is explicitly **not** sufficient.

Backend contract discovered for this gate: a scan fans out into one row per scanner; the per-scanner identity is `scan_type` on `GET /api/v1/security/scans?artifact_id=...`, and findings carry a `source` field.

**Fail-closed:** a required image scanner that is missing, non-completed, or completed-with-zero on a real vulnerable image is a hard fail; the gate also refuses `ALLOW_SCANNER_SKIP=1`, mirroring `scan-completion-gate.sh`'s #888 discipline.

## Validation (worker pool, current-main backend with `--trivy` = the #2088-broken false-clean state)

Ran against a slot reproducing #2088 (Trivy image scan returns 0 while Grype finds many). The gate **FAILS exactly on the per-scanner Trivy assertion** and **passes its Grype side** — proving it catches #2088 and that the failure is the assertion, not broken plumbing:

```
--- All scanner rows reach a terminal state within 240s ---
    scan_type=grype  status=completed  findings=115  ver=grype-0.114.0
    scan_type=image  status=completed  findings=0    ver=null
    scan_type=dependency  status=completed  findings=0  ver=null
    scan_type=filesystem  status=not_applicable  findings=0
    scan_type=incus       status=not_applicable  findings=0
  PASS

--- Ground truth: canary detected as vulnerable by at least one scanner (min 10) ---
  best scanner 'grype' found 115 findings (floor 10)
  PASS

--- Per-scanner efficacy: Trivy (image) (scan_type=image) found at least 10 CVEs ---
  FAIL: Trivy (image): completed with ONLY 0 findings (floor 10) on a known-vulnerable image -- FALSE-CLEAN (#2088 class)

--- Per-scanner efficacy: Grype (scan_type=grype) found at least 10 CVEs ---
  Grype: completed, findings=115 (>= 10), scanner_version=grype-0.114.0
  PASS

  Results: 13 passed, 1 failed  -> exit 1
```

Corroborating runs:
- `REQUIRED_IMAGE_SCANNERS=grype` → **exit 0**, fully clean (plumbing sound, Grype side passes on its own).
- `EXPECT_FAILURE=1` (self-test) → **exit 0** (the gate inverts: it detected the #2088 failure as expected).

An aggregate "total > 0" check would have **passed** here (total = 115) — that is precisely the hole this gate closes.

## Remaining acceptance step

The "passes on a fully-fixed build (Trivy adapter working)" direction cannot be fully validated until artifact-keeper#2088's adapter fix merges. The assertions are written so they pass once Trivy returns real findings (`completed` + `findings_count >= FINDINGS_FLOOR`). Scope alongside backend v1.2.4 so the trivy fix ships with the gate that proves it.
