### PR TITLE
test(release-gate): add v1.3.0 feature gates (metrics/streaming/cache/OCI-GC)

### DIFF
--- a/.github/workflows/format-tests.yml
+++ b/.github/workflows/format-tests.yml
@@ -38,9 +38,9 @@ jobs:
           - name: system-packages
             scripts: "test-debian.sh test-rpm.sh test-alpine.sh test-opkg.sh"
           - name: containers
-            scripts: "test-oci.sh test-docker-native-client.sh test-helm.sh test-incus.sh"
+            scripts: "test-oci.sh test-docker-native-client.sh test-helm.sh test-incus.sh test-streaming-blob-fallback.sh"
           - name: misc-native
-            scripts: "test-terraform.sh test-composer.sh test-hex.sh test-rubygems.sh test-nuget.sh test-cocoapods.sh test-cran.sh"
+            scripts: "test-terraform.sh test-composer.sh test-composer-dist-cache.sh test-hex.sh test-rubygems.sh test-nuget.sh test-cocoapods.sh test-cran.sh"
           - name: generic-protocol
             scripts: "test-generic.sh test-generic-native-client.sh test-gitlfs.sh test-protobuf.sh test-bazel.sh test-conan.sh test-conan-auth.sh test-conan-recipes.sh test-conan-packages.sh test-conan-search.sh test-conan-revisions.sh test-conan-remote.sh test-conan-errors.sh test-conan-stress.sh test-ansible.sh test-p2.sh test-jetbrains.sh test-vagrant.sh test-wasm.sh test-puppet.sh test-chef.sh"
     env:

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -937,9 +937,9 @@ jobs:
           - name: system-packages
             scripts: "test-debian.sh test-rpm.sh test-alpine.sh test-opkg.sh"
           - name: containers
-            scripts: "test-oci.sh test-oci-remote.sh test-docker-native-client.sh test-helm.sh test-incus.sh"
+            scripts: "test-oci.sh test-oci-remote.sh test-docker-native-client.sh test-helm.sh test-incus.sh test-streaming-blob-fallback.sh"
           - name: misc-native
-            scripts: "test-terraform.sh test-composer.sh test-hex.sh test-rubygems.sh test-nuget.sh test-cocoapods.sh test-cran.sh"
+            scripts: "test-terraform.sh test-composer.sh test-composer-dist-cache.sh test-hex.sh test-rubygems.sh test-nuget.sh test-cocoapods.sh test-cran.sh"
           - name: generic-protocol
             scripts: "test-generic.sh test-generic-native-client.sh test-gitlfs.sh test-protobuf.sh test-bazel.sh test-conan.sh test-conan-auth.sh test-conan-recipes.sh test-conan-packages.sh test-conan-search.sh test-conan-revisions.sh test-conan-remote.sh test-conan-errors.sh test-conan-stress.sh test-ansible.sh test-p2.sh test-jetbrains.sh test-vagrant.sh test-wasm.sh test-puppet.sh test-chef.sh"
     env:

--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -88,6 +88,14 @@ backend:
     # actually does so. (Release-gate run 26616763325: webhook-delivery 4
     # failures, all rooted at the producer never starting.)
     WEBHOOKS_V2_PRODUCER_ENABLED: "true"
+    # Blob GC is opt-in (BLOB_GC_ENABLED defaults false → the admin
+    # storage-gc endpoint dry-runs and never reclaims). Enable it so the
+    # v1.3.0 OCI GC reclaim gate (test-oci-gc-mark-sweep.sh, #1660) can prove
+    # an unreferenced blob is actually deleted. The admin-triggered orchestrator
+    # runs mark+sweep at grace 0 (immediate), so a short sweep grace only
+    # affects the scheduler path; keep it short for determinism.
+    BLOB_GC_ENABLED: "true"
+    BLOB_GC_SWEEP_GRACE_SECS: "5"
     # NOTE: TRIVY_URL and SCAN_WORKSPACE_PATH were previously set here, but
     # the chart's backend-deployment.yaml auto-injects them when
     # trivy.enabled=true. Setting them here too produces duplicate env keys

--- a/tests/formats/test-composer-dist-cache.sh
+++ b/tests/formats/test-composer-dist-cache.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# test-composer-dist-cache.sh - A warm composer dist fetch is served from the
+# pull-through cache without re-dialing upstream.
+#
+# Release gate for:
+#   artifact-keeper#2204 - composer dist cache (warm-hit after cold-miss)
+#
+# Strategy: AK-to-AK upstream (see tests/pullthrough/test-cache-hit-no-refetch.sh
+# for the full rationale -- the Python mock binds an RFC1918 addr that the
+# backend's validate_outbound_url rejects, so we point a remote composer repo
+# at a local composer repo's own AK URL and the backend dials itself).
+#
+#   U = local composer repo, published with one package archive.
+#   R = remote composer repo whose upstream_url is U's AK URL.
+#
+# Assertions:
+#   1. Cold dist fetch through R is 2xx (cache miss, proxied from U, cached).
+#   2. N warm refetches are byte-identical (cache serves a stable source, no
+#      partial-cache-write race / per-request re-fetch).
+#   3. After U is removed, the warm dist fetch through R STILL returns the
+#      cached archive (byte-identical). If R re-dialed upstream on the warm
+#      request it would now fail -- so a 2xx here proves the hit came from
+#      cache, not a re-fetch.
+#
+# Feature-gated on `composer_dist_cache` so it auto-skips on a 1.2.x backend.
+#
+# NOTE (formats matrix): lives in tests/formats/, so it must be listed in a
+# format-tests batch. Appended to the `misc-native` batch in
+# .github/workflows/release-gate.yml and .github/workflows/format-tests.yml.
+#
+# Requires: curl, jq, zip
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "composer-dist-cache"
+auth_admin
+setup_workdir
+
+begin_test "Backend supports composer_dist_cache (v1.3.0)"
+if require_feature "composer_dist_cache"; then
+  pass
+else
+  end_suite
+  exit 0
+fi
+
+require_cmd zip
+
+UPSTREAM_KEY="cdc-up-${RUN_ID}"
+REMOTE_KEY="cdc-rem-${RUN_ID}"
+VENDOR="e2e${RUN_ID//-/}"
+PACKAGE="distpkg"
+VERSION="1.0.0"
+# Long TTL so the warm window never slips on a loaded runner.
+TTL_SECS=300
+
+DIST_PATH="dist/${VENDOR}/${PACKAGE}/${VERSION}.zip"
+
+cleanup_repos() {
+  api_delete "/api/v1/repositories/${REMOTE_KEY}" >/dev/null 2>&1 || true
+  api_delete "/api/v1/repositories/${UPSTREAM_KEY}" >/dev/null 2>&1 || true
+}
+add_exit_handler "cleanup_repos"
+
+fetch_dist() {
+  local out="$1"
+  curl -s -o "$out" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(format_auth_header)" \
+    "${BASE_URL}/composer/${REMOTE_KEY}/${DIST_PATH}" 2>/dev/null || echo "000"
+}
+
+# ---------------------------------------------------------------------------
+# Setup: local upstream U with one package archive
+# ---------------------------------------------------------------------------
+
+begin_test "Create local composer upstream U"
+if create_local_repo "$UPSTREAM_KEY" "composer"; then
+  pass
+else
+  fail "could not create composer upstream"
+fi
+
+begin_test "Publish package to U"
+PKG_DIR="${WORK_DIR}/pkg"
+mkdir -p "$PKG_DIR"
+cat > "${PKG_DIR}/composer.json" <<EOJSON
+{"name": "${VENDOR}/${PACKAGE}", "version": "${VERSION}", "type": "library"}
+EOJSON
+echo "payload-${RUN_ID}" > "${PKG_DIR}/payload.txt"
+PKG_ARCHIVE="${WORK_DIR}/${VENDOR}-${PACKAGE}-${VERSION}.zip"
+( cd "$PKG_DIR" && zip -qr "$PKG_ARCHIVE" . )
+pub_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X PUT \
+  -H "$(format_auth_header)" -H "Content-Type: application/zip" \
+  --data-binary "@${PKG_ARCHIVE}" \
+  "${BASE_URL}/composer/${UPSTREAM_KEY}/api/packages" 2>/dev/null) || pub_status="000"
+if [ "$pub_status" = "200" ] || [ "$pub_status" = "201" ]; then
+  pass
+else
+  skip "composer publish endpoint unavailable (status ${pub_status}); cannot run dist-cache assertion"
+  cleanup_repos
+  end_suite
+  exit 0
+fi
+
+begin_test "Create remote R pointing at U (TTL=${TTL_SECS}s)"
+if create_remote_repo "$REMOTE_KEY" "composer" "${BASE_URL}/composer/${UPSTREAM_KEY}"; then
+  pass
+else
+  fail "could not create remote R"
+fi
+api_put "/api/v1/repositories/${REMOTE_KEY}/cache-ttl" \
+  "{\"cache_ttl_seconds\": ${TTL_SECS}}" >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
+# 1. Cold dist fetch (cache miss -> proxied -> cached)
+# ---------------------------------------------------------------------------
+
+begin_test "Cold dist fetch through R is 2xx (cache miss, proxied + cached)"
+cold_status=$(fetch_dist "${WORK_DIR}/cold.zip")
+if assert_http_2xx "$cold_status" "cold composer dist fetch should be 2xx"; then
+  COLD_SHA=$(shasum -a 256 "${WORK_DIR}/cold.zip" | awk '{print $1}')
+  pass
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Warm refetches are byte-identical (stable cache source)
+# ---------------------------------------------------------------------------
+
+begin_test "5 warm dist refetches are byte-identical (cache hit)"
+mismatch=0
+for i in $(seq 1 5); do
+  st=$(fetch_dist "${WORK_DIR}/warm-${i}.zip")
+  if [ "$st" != "200" ]; then
+    mismatch=1; echo "  warm fetch ${i}: status ${st}"; break
+  fi
+  sha=$(shasum -a 256 "${WORK_DIR}/warm-${i}.zip" | awk '{print $1}')
+  if [ "${COLD_SHA:-}" != "" ] && [ "$sha" != "$COLD_SHA" ]; then
+    mismatch=1; echo "  warm fetch ${i}: bytes differ from cold prime"; break
+  fi
+done
+if [ "$mismatch" -eq 0 ]; then
+  pass
+else
+  fail "warm composer dist refetches diverged; cache is not a stable byte source"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. After U is removed, the warm fetch STILL serves the cached archive.
+#    A re-fetch would now fail (upstream gone), so 2xx here == served from cache.
+# ---------------------------------------------------------------------------
+
+begin_test "Warm dist fetch still 2xx after upstream U removed (served from cache, not re-fetched)"
+api_delete "/api/v1/repositories/${UPSTREAM_KEY}" >/dev/null 2>&1 || true
+sleep 1
+after_status=$(fetch_dist "${WORK_DIR}/after.zip")
+if [ "$after_status" = "200" ]; then
+  after_sha=$(shasum -a 256 "${WORK_DIR}/after.zip" | awk '{print $1}')
+  if [ "${COLD_SHA:-}" = "" ] || [ "$after_sha" = "$COLD_SHA" ]; then
+    pass
+  else
+    fail "post-removal dist bytes differ from cached copy (unexpected re-fetch/rewrite)"
+  fi
+else
+  fail "post-removal warm dist fetch returned ${after_status}; cache did not serve the warm hit (re-dialed the now-absent upstream)"
+fi
+
+end_suite

--- a/tests/formats/test-streaming-blob-fallback.sh
+++ b/tests/formats/test-streaming-blob-fallback.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# test-streaming-blob-fallback.sh - >16 MiB blobs stream through every
+# format-native blob-fallback route (2xx, never 502).
+#
+# Release gate for:
+#   artifact-keeper#1608 - streaming invariant (>16 MiB not buffered / 502'd),
+#   exercised across the format-native routes (not just the generic API).
+#
+# The generic-API copy of this invariant lives in
+# tests/platform/test-streaming-large-artifact.sh. This suite pushes a
+# >16 MiB blob through each blob-fallback format's own route (helm, npm,
+# swift, oci, pypi) and pulls it back, asserting the write and read paths
+# both STREAM: status is 2xx and NEVER 502 (buffered/OOM). Where the format
+# stores and serves the blob byte-for-byte (oci, swift, npm) it also checks
+# the SHA256 round-trips.
+#
+# Each format section is independent and SKIPs (does not fail) if its repo
+# or push setup does not return 2xx, so a route-shape surprise on the target
+# degrades to a skip rather than a red gate.
+#
+# NOTE (formats matrix): because this lives in tests/formats/, it only runs
+# if it is listed in a format-tests batch. It is appended to the `containers`
+# batch in .github/workflows/release-gate.yml and .github/workflows/format-tests.yml.
+#
+# Feature-gated on `streaming_large_artifact` so it auto-skips on a 1.2.x backend.
+#
+# Requires: curl, dd, tar, shasum, base64, jq
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "streaming-blob-fallback"
+auth_admin
+setup_workdir
+
+begin_test "Backend supports streaming_large_artifact (v1.3.0)"
+if require_feature "streaming_large_artifact"; then
+  pass
+else
+  end_suite
+  exit 0
+fi
+
+# 18 MiB: strictly greater than the 16 MiB in-memory buffer cap, small
+# enough that base64/multipart overhead stays manageable in the matrix.
+BLOB_MB=18
+BLOB="${WORK_DIR}/blob.bin"
+dd if=/dev/urandom bs=1048576 count="$BLOB_MB" of="$BLOB" 2>/dev/null
+BLOB_SHA=$(shasum -a 256 "$BLOB" | awk '{print $1}')
+
+# Assert a captured HTTP status is 2xx and, loudly, is not 502. Returns 0
+# on a clean 2xx. On 502 it fails with the buffered/OOM message; on any
+# other non-2xx it fails generically.
+assert_streamed_2xx() {
+  local status="$1" what="$2"
+  if [ "$status" = "502" ]; then
+    fail "${what} returned 502: >16 MiB body buffered/OOM instead of streamed"
+    return 1
+  fi
+  assert_http_2xx "$status" "${what} should be 2xx (streamed)"
+}
+
+# =========================================================================
+# OCI: raw layer blob by digest (byte-exact)
+# =========================================================================
+OCI_REPO="e2e-sbf-oci-${RUN_ID}"
+begin_test "oci: create docker repo"
+oci_ok=false
+if create_local_repo "$OCI_REPO" "docker"; then oci_ok=true; pass; else skip "could not create oci repo"; fi
+
+if $oci_ok; then
+  OCI_DIGEST="sha256:${BLOB_SHA}"
+  OCI_TOKEN=$(curl -sf -u "${ADMIN_USER}:${ADMIN_PASS}" "${BASE_URL}/v2/token" 2>/dev/null | jq -r '.token // empty') || true
+
+  begin_test "oci: push ${BLOB_MB} MiB layer blob is 2xx (streamed, not 502)"
+  curl -s -D "${WORK_DIR}/oci-upl.hdr" -o /dev/null -X POST \
+    -H "Authorization: Bearer ${OCI_TOKEN}" \
+    "${BASE_URL}/v2/${OCI_REPO}/blob-fallback/blobs/uploads/" >/dev/null 2>&1 || true
+  loc=$(grep -i '^location:' "${WORK_DIR}/oci-upl.hdr" 2>/dev/null | tr -d '\r' | awk '{print $2}') || true
+  if [ -z "$loc" ]; then
+    skip "oci: blob upload initiation returned no Location header"
+  else
+    if [[ "$loc" == http* ]]; then base="$loc"; else base="${BASE_URL}${loc}"; fi
+    if [[ "$loc" == *"?"* ]]; then put_url="${base}&digest=${OCI_DIGEST}"; else put_url="${base}?digest=${OCI_DIGEST}"; fi
+    oci_put=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X PUT \
+      -H "Authorization: Bearer ${OCI_TOKEN}" \
+      -H "Content-Type: application/octet-stream" \
+      --data-binary "@${BLOB}" "$put_url" 2>/dev/null) || oci_put="000"
+    echo "  oci blob PUT status: ${oci_put}"
+    if [ "$oci_put" = "502" ]; then
+      fail "oci blob PUT returned 502: >16 MiB layer buffered instead of streamed"
+    elif [ "$oci_put" = "201" ] || { [ "$oci_put" -ge 200 ] 2>/dev/null && [ "$oci_put" -lt 300 ] 2>/dev/null; }; then
+      pass
+    else
+      skip "oci: blob PUT returned ${oci_put} (setup issue, not a streaming failure)"
+    fi
+  fi
+
+  begin_test "oci: pull ${BLOB_MB} MiB layer blob is 2xx + SHA256 round-trips"
+  oci_get=$(curl -s -o "${WORK_DIR}/oci-dl.bin" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "Authorization: Bearer ${OCI_TOKEN}" \
+    "${BASE_URL}/v2/${OCI_REPO}/blob-fallback/blobs/${OCI_DIGEST}" 2>/dev/null) || oci_get="000"
+  if assert_streamed_2xx "$oci_get" "oci blob GET"; then
+    dl=$(shasum -a 256 "${WORK_DIR}/oci-dl.bin" | awk '{print $1}')
+    if assert_eq "$dl" "$BLOB_SHA" "oci blob SHA256 mismatch on ${BLOB_MB} MiB round-trip"; then pass; fi
+  fi
+  api_delete "/api/v1/repositories/${OCI_REPO}" >/dev/null 2>&1 || true
+fi
+
+# =========================================================================
+# Swift: raw archive by path (byte-exact)
+# =========================================================================
+SWIFT_REPO="e2e-sbf-swift-${RUN_ID}"
+SWIFT_SCOPE="e2escope"
+SWIFT_PKG="blobpkg"
+SWIFT_VER="1.0.0"
+begin_test "swift: create swift repo"
+swift_ok=false
+if create_local_repo "$SWIFT_REPO" "swift"; then swift_ok=true; pass; else skip "could not create swift repo"; fi
+
+if $swift_ok; then
+  begin_test "swift: push ${BLOB_MB} MiB release is 2xx (streamed, not 502)"
+  swift_put=$(format_put_with_retry \
+    "${BASE_URL}/swift/${SWIFT_REPO}/${SWIFT_SCOPE}/${SWIFT_PKG}/${SWIFT_VER}" "$BLOB") || true
+  echo "  swift PUT status: ${swift_put}"
+  if [ "$swift_put" = "502" ]; then
+    fail "swift release PUT returned 502: >16 MiB buffered instead of streamed"
+  elif [ "$swift_put" -ge 200 ] 2>/dev/null && [ "$swift_put" -lt 300 ] 2>/dev/null; then
+    pass
+  else
+    skip "swift: release PUT returned ${swift_put} (setup issue, not a streaming failure)"
+  fi
+
+  begin_test "swift: pull ${BLOB_MB} MiB release is 2xx + SHA256 round-trips"
+  swift_get=$(format_get_with_retry \
+    "${BASE_URL}/swift/${SWIFT_REPO}/${SWIFT_SCOPE}/${SWIFT_PKG}/${SWIFT_VER}.zip" \
+    "${WORK_DIR}/swift-dl.bin") || true
+  if assert_streamed_2xx "$swift_get" "swift release GET"; then
+    dl=$(shasum -a 256 "${WORK_DIR}/swift-dl.bin" | awk '{print $1}')
+    if assert_eq "$dl" "$BLOB_SHA" "swift release SHA256 mismatch on ${BLOB_MB} MiB round-trip"; then pass; fi
+  fi
+  api_delete "/api/v1/repositories/${SWIFT_REPO}" >/dev/null 2>&1 || true
+fi
+
+# =========================================================================
+# NPM: tarball attachment (byte-exact tgz)
+# =========================================================================
+NPM_REPO="e2e-sbf-npm-${RUN_ID}"
+NPM_PKG="sbfpkg${RUN_ID//-/}"
+NPM_VER="1.0.0"
+begin_test "npm: create npm repo"
+npm_ok=false
+if create_local_repo "$NPM_REPO" "npm"; then npm_ok=true; pass; else skip "could not create npm repo"; fi
+
+if $npm_ok; then
+  # Pack the >16 MiB blob into a tgz so it is a real npm tarball.
+  mkdir -p "${WORK_DIR}/npmpkg"
+  cp "$BLOB" "${WORK_DIR}/npmpkg/payload.bin"
+  printf '{"name":"%s","version":"%s"}\n' "$NPM_PKG" "$NPM_VER" > "${WORK_DIR}/npmpkg/package.json"
+  NPM_TGZ="${WORK_DIR}/${NPM_PKG}-${NPM_VER}.tgz"
+  tar czf "$NPM_TGZ" -C "${WORK_DIR}/npmpkg" .
+  NPM_TGZ_SHA=$(shasum -a 256 "$NPM_TGZ" | awk '{print $1}')
+  NPM_TGZ_SIZE=$(wc -c < "$NPM_TGZ" | tr -d ' ')
+  base64 < "$NPM_TGZ" | tr -d '\n' > "${WORK_DIR}/npm-b64.txt"
+  jq -n \
+    --arg name "$NPM_PKG" --arg version "$NPM_VER" \
+    --arg tarball "${BASE_URL}/npm/${NPM_REPO}/${NPM_PKG}/-/${NPM_PKG}-${NPM_VER}.tgz" \
+    --rawfile data "${WORK_DIR}/npm-b64.txt" \
+    --argjson length "$NPM_TGZ_SIZE" \
+    '{name: $name, versions: {($version): {name: $name, version: $version, dist: {tarball: $tarball}}},
+      "_attachments": {("\($name)-\($version).tgz"): {content_type: "application/octet-stream", data: $data, length: $length}}}' \
+    > "${WORK_DIR}/npm-publish.json"
+
+  begin_test "npm: publish ${BLOB_MB} MiB tarball is 2xx (streamed, not 502)"
+  npm_put=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X PUT \
+    -H "$(format_auth_header)" -H "Content-Type: application/json" \
+    --data-binary "@${WORK_DIR}/npm-publish.json" \
+    "${BASE_URL}/npm/${NPM_REPO}/${NPM_PKG}" 2>/dev/null) || npm_put="000"
+  echo "  npm publish status: ${npm_put}"
+  if [ "$npm_put" = "502" ]; then
+    fail "npm publish returned 502: >16 MiB tarball buffered instead of streamed"
+  elif [ "$npm_put" -ge 200 ] 2>/dev/null && [ "$npm_put" -lt 300 ] 2>/dev/null; then
+    pass
+  else
+    skip "npm: publish returned ${npm_put} (setup issue, not a streaming failure)"
+  fi
+
+  begin_test "npm: pull ${BLOB_MB} MiB tarball is 2xx + SHA256 round-trips"
+  npm_get=$(curl -s -o "${WORK_DIR}/npm-dl.tgz" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(format_auth_header)" \
+    "${BASE_URL}/npm/${NPM_REPO}/${NPM_PKG}/-/${NPM_PKG}-${NPM_VER}.tgz" 2>/dev/null) || npm_get="000"
+  if assert_streamed_2xx "$npm_get" "npm tarball GET"; then
+    dl=$(shasum -a 256 "${WORK_DIR}/npm-dl.tgz" | awk '{print $1}')
+    if assert_eq "$dl" "$NPM_TGZ_SHA" "npm tarball SHA256 mismatch on ${BLOB_MB} MiB round-trip"; then pass; fi
+  fi
+  api_delete "/api/v1/repositories/${NPM_REPO}" >/dev/null 2>&1 || true
+fi
+
+# =========================================================================
+# Helm: chart tgz (streaming invariant; server may re-index, so size not SHA)
+# =========================================================================
+HELM_REPO="e2e-sbf-helm-${RUN_ID}"
+HELM_CHART="sbfchart${RUN_ID//-/}"
+HELM_VER="1.0.0"
+begin_test "helm: create helm repo"
+helm_ok=false
+if create_local_repo "$HELM_REPO" "helm"; then helm_ok=true; pass; else skip "could not create helm repo"; fi
+
+if $helm_ok; then
+  mkdir -p "${WORK_DIR}/${HELM_CHART}"
+  printf 'apiVersion: v2\nname: %s\nversion: %s\n' "$HELM_CHART" "$HELM_VER" > "${WORK_DIR}/${HELM_CHART}/Chart.yaml"
+  cp "$BLOB" "${WORK_DIR}/${HELM_CHART}/bigfile.bin"
+  HELM_TGZ="${WORK_DIR}/${HELM_CHART}-${HELM_VER}.tgz"
+  tar czf "$HELM_TGZ" -C "${WORK_DIR}" "${HELM_CHART}"
+
+  begin_test "helm: push ${BLOB_MB} MiB chart is 2xx (streamed, not 502)"
+  helm_put=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X POST \
+    -H "$(format_auth_header)" -F "chart=@${HELM_TGZ}" \
+    "${BASE_URL}/helm/${HELM_REPO}/api/charts" 2>/dev/null) || helm_put="000"
+  echo "  helm push status: ${helm_put}"
+  if [ "$helm_put" = "502" ]; then
+    fail "helm chart push returned 502: >16 MiB chart buffered instead of streamed"
+  elif [ "$helm_put" -ge 200 ] 2>/dev/null && [ "$helm_put" -lt 300 ] 2>/dev/null; then
+    pass
+  else
+    skip "helm: chart push returned ${helm_put} (setup issue, not a streaming failure)"
+  fi
+
+  begin_test "helm: pull ${BLOB_MB} MiB chart is 2xx (streamed, not 502)"
+  helm_get=$(curl -s -o "${WORK_DIR}/helm-dl.tgz" -w '%{http_code}' $CURL_TIMEOUT \
+    -H "$(format_auth_header)" \
+    "${BASE_URL}/helm/${HELM_REPO}/charts/${HELM_CHART}-${HELM_VER}.tgz" 2>/dev/null) || helm_get="000"
+  if assert_streamed_2xx "$helm_get" "helm chart GET"; then
+    dl_size=$(wc -c < "${WORK_DIR}/helm-dl.tgz" | tr -d ' ')
+    if [ "$dl_size" -gt $((16 * 1024 * 1024)) ] 2>/dev/null; then
+      pass
+    else
+      fail "helm chart download is ${dl_size} bytes, expected > 16 MiB (truncated read)"
+    fi
+  fi
+  api_delete "/api/v1/repositories/${HELM_REPO}" >/dev/null 2>&1 || true
+fi
+
+# =========================================================================
+# PyPI: sdist via multipart file_upload (streaming invariant on write path)
+# =========================================================================
+PYPI_REPO="e2e-sbf-pypi-${RUN_ID}"
+PYPI_PKG="sbfpypi${RUN_ID//-/}"
+PYPI_VER="1.0.0"
+begin_test "pypi: create pypi repo"
+pypi_ok=false
+if create_local_repo "$PYPI_REPO" "pypi"; then pypi_ok=true; pass; else skip "could not create pypi repo"; fi
+
+if $pypi_ok; then
+  mkdir -p "${WORK_DIR}/${PYPI_PKG}-${PYPI_VER}"
+  printf 'Metadata-Version: 1.0\nName: %s\nVersion: %s\n' "$PYPI_PKG" "$PYPI_VER" \
+    > "${WORK_DIR}/${PYPI_PKG}-${PYPI_VER}/PKG-INFO"
+  cp "$BLOB" "${WORK_DIR}/${PYPI_PKG}-${PYPI_VER}/payload.bin"
+  PYPI_SDIST="${WORK_DIR}/${PYPI_PKG}-${PYPI_VER}.tar.gz"
+  tar czf "$PYPI_SDIST" -C "${WORK_DIR}" "${PYPI_PKG}-${PYPI_VER}"
+
+  begin_test "pypi: upload ${BLOB_MB} MiB sdist is 2xx (streamed, not 502)"
+  pypi_put=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X POST \
+    -H "$(format_auth_header)" \
+    -F ":action=file_upload" -F "name=${PYPI_PKG}" -F "version=${PYPI_VER}" \
+    -F "filetype=sdist" -F "content=@${PYPI_SDIST}" \
+    "${BASE_URL}/pypi/${PYPI_REPO}/" 2>/dev/null) || pypi_put="000"
+  echo "  pypi upload status: ${pypi_put}"
+  if [ "$pypi_put" = "502" ]; then
+    fail "pypi sdist upload returned 502: >16 MiB buffered instead of streamed"
+  elif [ "$pypi_put" -ge 200 ] 2>/dev/null && [ "$pypi_put" -lt 300 ] 2>/dev/null; then
+    pass
+  else
+    skip "pypi: sdist upload returned ${pypi_put} (setup issue, not a streaming failure)"
+  fi
+
+  begin_test "pypi: sdist appears in simple index (streamed write persisted)"
+  norm_name=$(echo "$PYPI_PKG" | tr '[:upper:]_' '[:lower:]-')
+  idx=$(curl -sf $CURL_TIMEOUT -H "$(format_auth_header)" \
+    "${BASE_URL}/pypi/${PYPI_REPO}/simple/${norm_name}/" 2>/dev/null) || idx=""
+  if [ -n "$idx" ] && echo "$idx" | grep -q ".tar.gz"; then
+    pass
+  else
+    skip "pypi: sdist not listed in simple index (write path did not persist)"
+  fi
+  api_delete "/api/v1/repositories/${PYPI_REPO}" >/dev/null 2>&1 || true
+fi
+
+end_suite

--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -200,6 +200,31 @@ _feature_min_version() {
   case "$1" in
     "conan_remote_search_forward")    echo "1.3.0" ;;
     "conan_virtual_search_aggregate") echo "1.3.0" ;;
+    # v1.3.0 release-gate additions (see rig FixSpec v130-test-gates-plan.md).
+    # metrics_unmatched_path: the metrics middleware collapses requests that
+    # match no route to a single path="unmatched" series instead of echoing
+    # the raw request path, closing the per-path label-cardinality DoS
+    # (artifact-keeper#2217). Pre-1.3.0 backends emit one series per junk path.
+    "metrics_unmatched_path")         echo "1.3.0" ;;
+    # streaming_large_artifact: artifacts larger than the 16 MiB in-memory
+    # buffer cap are streamed to/from storage rather than buffered, so a
+    # >16 MiB upload/download returns 2xx instead of 502/OOM (the #1608
+    # streaming-invariant trilogy). Pre-1.3.0 backends buffer and 502/OOM.
+    "streaming_large_artifact")       echo "1.3.0" ;;
+    # composer_dist_cache: a warm composer dist fetch is served from the
+    # pull-through cache without re-dialing upstream (artifact-keeper#2204).
+    # Pre-1.3.0 backends re-fetch upstream on every dist request.
+    "composer_dist_cache")            echo "1.3.0" ;;
+    # npm_packument_swr: npm packument responses are served stale-while-
+    # revalidate from cache within the TTL window (no upstream re-hit) and
+    # refreshed after a new version lands (artifact-keeper#2166).
+    "npm_packument_swr")              echo "1.3.0" ;;
+    # oci_gc_two_phase: the OCI/storage GC sweep reclaims a genuinely
+    # unreferenced blob (manifest deleted, grace elapsed) and leaves no
+    # dangling manifest reference behind (artifact-keeper#1660). Pre-1.3.0
+    # backends do not maintain the manifest->blob reference table the sweep
+    # needs, so the reclaim assertion cannot be driven there.
+    "oci_gc_two_phase")               echo "1.3.0" ;;
     # recipe_latest / recipe_revisions filter by user/channel rather than
     # collapsing variants to _/_/latest. Backported via artifact-keeper#869.
     # v1.1.x backend lacks this scoping; tracked for v1.1.10 backport in #986.

--- a/tests/lib/feature-flags.sh
+++ b/tests/lib/feature-flags.sh
@@ -100,11 +100,38 @@ AK_BACKEND_BRANCH_1_2_X="\
 "
 
 # main: everything 1.2.x has, plus anything in-flight on main.
+#
+# v1.3.0 release-gate feature tokens (see rig FixSpec
+# v130-test-gates-plan.md). Each guards one new gate suite so the same
+# main-branch test tree auto-skips it on a 1.2.x backend instead of
+# hard-failing on an unshipped feature:
+#   metrics_unmatched_path  -> tests/platform/test-metrics-unmatched-cardinality.sh (G7, #2217)
+#   streaming_large_artifact-> tests/platform/test-streaming-large-artifact.sh    (G1, #1608)
+#                              tests/formats/test-streaming-blob-fallback.sh       (G1, #1608)
+#   composer_dist_cache     -> tests/formats/test-composer-dist-cache.sh           (G1, #2204)
+#   npm_packument_swr       -> tests/pullthrough/test-npm-packument-swr.sh         (G6, #2166)
+#   oci_gc_two_phase        -> tests/lifecycle/test-oci-gc-mark-sweep.sh           (G3, #1660)
+#
+# Deferred v1.3.0 gates (NOT registered until their infra/endpoints land,
+# see v130-test-gates-plan.md Part 2):
+#   G2 access_scope_authz  -- no REST endpoint sets an arbitrary AccessScope
+#      (repository_scopes list / empty / user-level); the AccessScope enum is
+#      covered by backend lib unit tests. Register when a scope-write endpoint ships.
+#   G4 sso_oidc_v13        -- happy-path OIDC/SAML login needs a mock IdP (backend
+#      e2e #2210/#2214); negative/forged-assertion cases already covered by
+#      tests/auth/test-oidc-*.sh + tests/security/test-saml-signature.sh.
+#   G5 cross_replica_cache_invalidation -- needs a new 2-replica shared-DB
+#      helm/values-test-ha.yaml overlay + deploy job (#2169); no such overlay today.
 AK_BACKEND_BRANCH_MAIN="\
   $AK_BACKEND_BRANCH_1_2_X \
   conan_remote_search_forward \
   conan_virtual_search_aggregate \
   conan_error_correctness \
+  metrics_unmatched_path \
+  streaming_large_artifact \
+  composer_dist_cache \
+  npm_packument_swr \
+  oci_gc_two_phase \
 "
 
 # -----------------------------------------------------------------------------

--- a/tests/lifecycle/test-oci-gc-mark-sweep.sh
+++ b/tests/lifecycle/test-oci-gc-mark-sweep.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# test-oci-gc-mark-sweep.sh - OCI GC reclaims an unreferenced blob and leaves
+# no dangling manifest reference.
+#
+# Release gate for:
+#   artifact-keeper#1660 - OCI GC two-phase mark-sweep
+#
+# The registry tracks manifest -> blob references (manifest_blob_refs). When a
+# manifest is deleted its layer blobs become unreferenced; the GC sweep must
+# reclaim a genuinely unreferenced blob after the grace window, WITHOUT
+# sweeping any blob still referenced by a live manifest (which would create a
+# dangling reference / 500 on pull).
+#
+# This gate:
+#   1. Pushes image A (layer blob B1) and image B (layer blob B2), each tagged.
+#   2. Deletes image A's manifest so B1 is genuinely unreferenced.
+#   3. Triggers GC (POST /api/v1/admin/storage-gc {"dry_run":false}), polling a
+#      few times to absorb a short grace window.
+#   4. Asserts RECLAIM: B1 GET -> 404 (swept).
+#   5. Asserts NO DANGLING: image B's manifest still resolves (200) and its
+#      referenced blob B2 still resolves (200) -- GC did not sweep a live blob.
+#
+# Resurrection sub-case (a blob re-adopted between mark and sweep must survive)
+# is intentionally SKIPPED: it requires the GC endpoint to expose mark and
+# sweep as separately triggerable phases (or a pinned, timeable grace). The
+# current endpoint is a single atomic run_gc call, so the race cannot be driven
+# deterministically at the gate layer. See v130-test-gates-plan.md G3.
+#
+# Target-capability note: the deploy overlay must set BLOB_GC_ENABLED=true and a
+# short BLOB_GC_SWEEP_GRACE_SECS (the backend default grace is 3600s and blob GC
+# is opt-in) for the reclaim assertion to complete inside the gate timeout.
+#
+# Feature-gated on `oci_gc_two_phase` so it auto-skips on a 1.2.x backend
+# (which does not run the manifest-dereference blob sweep) instead of hard-failing.
+#
+# Requires: curl, jq, shasum
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "oci-gc-mark-sweep"
+auth_admin
+setup_workdir
+
+begin_test "Backend supports oci_gc_two_phase (v1.3.0)"
+if require_feature "oci_gc_two_phase"; then
+  pass
+else
+  end_suite
+  exit 0
+fi
+
+REPO_KEY="e2e-ocigc-${RUN_ID}"
+IMG_A="gc-image-a"
+IMG_B="gc-image-b"
+TAG="v1"
+
+cleanup() {
+  api_delete "/api/v1/repositories/${REPO_KEY}" >/dev/null 2>&1 || true
+}
+add_exit_handler "cleanup"
+
+TOKEN=""
+# Push a monolithic blob; echoes the pushed HTTP status. Digest is computed by
+# the caller (content-addressed).
+push_blob() {
+  local image="$1" content_file="$2" digest="$3"
+  curl -s -D "${WORK_DIR}/upl.hdr" -o /dev/null -X POST \
+    -H "Authorization: Bearer ${TOKEN}" \
+    "${BASE_URL}/v2/${REPO_KEY}/${image}/blobs/uploads/" >/dev/null 2>&1 || true
+  local loc base put_url
+  loc=$(grep -i '^location:' "${WORK_DIR}/upl.hdr" 2>/dev/null | tr -d '\r' | awk '{print $2}') || true
+  [ -z "$loc" ] && { echo "000"; return 1; }
+  if [[ "$loc" == http* ]]; then base="$loc"; else base="${BASE_URL}${loc}"; fi
+  if [[ "$loc" == *"?"* ]]; then put_url="${base}&digest=${digest}"; else put_url="${base}?digest=${digest}"; fi
+  curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X PUT \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/octet-stream" \
+    --data-binary "@${content_file}" "$put_url" 2>/dev/null || echo "000"
+}
+
+blob_status() {
+  local image="$1" digest="$2"
+  curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+    -H "Authorization: Bearer ${TOKEN}" \
+    "${BASE_URL}/v2/${REPO_KEY}/${image}/blobs/${digest}" 2>/dev/null || echo "000"
+}
+
+# Push a config blob + a layer blob, then a manifest referencing them. Echoes
+# the manifest PUT status. Globals set: LAYER_DIGEST (of the given layer file).
+push_image() {
+  local image="$1" layer_file="$2" tag="$3"
+  local cfg='{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":[]},"config":{}}'
+  local cfg_file="${WORK_DIR}/${image}-config.json"
+  printf '%s' "$cfg" > "$cfg_file"
+  local cfg_digest cfg_size layer_digest layer_size
+  cfg_digest="sha256:$(shasum -a 256 "$cfg_file" | awk '{print $1}')"
+  cfg_size=$(wc -c < "$cfg_file" | tr -d ' ')
+  layer_digest="sha256:$(shasum -a 256 "$layer_file" | awk '{print $1}')"
+  layer_size=$(wc -c < "$layer_file" | tr -d ' ')
+  LAYER_DIGEST="$layer_digest"
+
+  push_blob "$image" "$cfg_file" "$cfg_digest" >/dev/null
+  push_blob "$image" "$layer_file" "$layer_digest" >/dev/null
+
+  local manifest="${WORK_DIR}/${image}-manifest.json"
+  cat > "$manifest" <<EOM
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {"mediaType": "application/vnd.oci.image.config.v1+json", "digest": "${cfg_digest}", "size": ${cfg_size}},
+  "layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar", "digest": "${layer_digest}", "size": ${layer_size}}]
+}
+EOM
+  curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X PUT \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/vnd.oci.image.manifest.v1+json" \
+    --data-binary "@${manifest}" \
+    "${BASE_URL}/v2/${REPO_KEY}/${image}/manifests/${tag}" 2>/dev/null || echo "000"
+}
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+begin_test "Create docker repository"
+if create_local_repo "$REPO_KEY" "docker"; then
+  pass
+else
+  fail "could not create docker repo"
+fi
+
+begin_test "Obtain registry token"
+TOKEN=$(curl -sf -u "${ADMIN_USER}:${ADMIN_PASS}" "${BASE_URL}/v2/token" 2>/dev/null | jq -r '.token // empty') || true
+if [ -n "$TOKEN" ]; then
+  pass
+else
+  skip "could not obtain /v2/token; OCI GC gate cannot proceed"
+  cleanup
+  end_suite
+  exit 0
+fi
+
+# Unique layer contents so B1 and B2 are distinct, content-addressed blobs.
+printf 'gc-layer-b1-%s\n' "$RUN_ID" > "${WORK_DIR}/layer-b1.bin"
+printf 'gc-layer-b2-%s\n' "$RUN_ID" > "${WORK_DIR}/layer-b2.bin"
+
+begin_test "Push image A (layer B1)"
+st=$(push_image "$IMG_A" "${WORK_DIR}/layer-b1.bin" "$TAG")
+B1_DIGEST="$LAYER_DIGEST"
+if [ "$st" = "201" ] || [ "$st" = "200" ]; then
+  pass
+else
+  skip "image A manifest PUT returned ${st}; OCI push not available"
+  cleanup
+  end_suite
+  exit 0
+fi
+
+begin_test "Push image B (layer B2, stays referenced)"
+st=$(push_image "$IMG_B" "${WORK_DIR}/layer-b2.bin" "$TAG")
+B2_DIGEST="$LAYER_DIGEST"
+if [ "$st" = "201" ] || [ "$st" = "200" ]; then
+  pass
+else
+  fail "image B manifest PUT returned ${st}, expected 201/200"
+fi
+
+begin_test "Blob B1 is present before GC"
+st=$(blob_status "$IMG_A" "$B1_DIGEST")
+if [ "$st" = "200" ]; then
+  pass
+else
+  fail "blob B1 GET returned ${st} before GC, expected 200"
+fi
+
+# ---------------------------------------------------------------------------
+# Delete image A's manifest -> B1 becomes unreferenced
+# ---------------------------------------------------------------------------
+
+begin_test "Delete image A manifest (B1 becomes unreferenced)"
+del_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X DELETE \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "${BASE_URL}/v2/${REPO_KEY}/${IMG_A}/manifests/${TAG}" 2>/dev/null) || del_status="000"
+if [ "$del_status" = "202" ] || [ "$del_status" = "200" ]; then
+  pass
+elif [ "$del_status" = "404" ]; then
+  skip "manifest DELETE returned 404 (delete-by-tag unsupported); cannot unreference B1"
+  cleanup
+  end_suite
+  exit 0
+else
+  fail "manifest DELETE returned ${del_status}, expected 202/200"
+fi
+
+# ---------------------------------------------------------------------------
+# Trigger GC (poll to absorb a short grace window)
+# ---------------------------------------------------------------------------
+
+begin_test "GC reclaims unreferenced blob B1 (GET -> 404)"
+reclaimed=false
+for _attempt in $(seq 1 6); do
+  api_post "/api/v1/admin/storage-gc" '{"dry_run":false}' >/dev/null 2>&1 || true
+  st=$(blob_status "$IMG_A" "$B1_DIGEST")
+  if [ "$st" = "404" ]; then
+    reclaimed=true
+    break
+  fi
+  sleep 5
+done
+if $reclaimed; then
+  pass
+else
+  fail "blob B1 still present after GC (last status ${st}); check BLOB_GC_ENABLED=true and a short BLOB_GC_SWEEP_GRACE_SECS in the deploy overlay"
+fi
+
+# ---------------------------------------------------------------------------
+# No dangling reference: image B's manifest + referenced blob survive
+# ---------------------------------------------------------------------------
+
+begin_test "No dangling ref: image B manifest still resolves (200) after GC"
+mb_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+  "${BASE_URL}/v2/${REPO_KEY}/${IMG_B}/manifests/${TAG}" 2>/dev/null) || mb_status="000"
+if [ "$mb_status" = "200" ]; then
+  pass
+else
+  fail "image B manifest GET returned ${mb_status} after GC, expected 200 (GC broke a live manifest)"
+fi
+
+begin_test "No dangling ref: referenced blob B2 survives GC (GET -> 200)"
+st=$(blob_status "$IMG_B" "$B2_DIGEST")
+if [ "$st" = "200" ]; then
+  pass
+else
+  fail "referenced blob B2 GET returned ${st} after GC, expected 200 (GC swept a referenced blob -> dangling ref)"
+fi
+
+# ---------------------------------------------------------------------------
+# Resurrection sub-case: not drivable at the gate layer (single atomic GC)
+# ---------------------------------------------------------------------------
+
+begin_test "Resurrection (re-adopt during mark->sweep window) survives"
+skip "GC endpoint exposes no separately-triggerable mark/sweep phases (single atomic run_gc); resurrection race cannot be driven at the gate layer -- tracked for a backend phase-control hook (v130 plan G3)"
+
+end_suite

--- a/tests/platform/test-metrics-unmatched-cardinality.sh
+++ b/tests/platform/test-metrics-unmatched-cardinality.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# test-metrics-unmatched-cardinality.sh - Unmatched request paths must collapse
+# to a single path="unmatched" metrics series.
+#
+# Release gate for:
+#   artifact-keeper#2217 - metrics path-label cardinality DoS
+#
+# The HTTP metrics middleware labels ak_http_requests_total with the matched
+# route pattern (e.g. /api/v1/repositories/:key). Before #2217, a request that
+# matched NO route fell back to the raw (normalized) request path, so an
+# attacker spraying distinct junk paths (/.env, /.git/config, /wp-admin, ...)
+# minted one new time-series per path -- an unbounded-cardinality DoS on the
+# metrics registry / scrape pipeline. The v1.3.0 fix collapses every unmatched
+# request to a single path="unmatched" series while matched routes keep their
+# real (low-cardinality) route pattern.
+#
+# This gate probes several distinct junk paths and asserts:
+#   1. No metrics series carries any of the literal junk path labels.
+#   2. A single path="unmatched" series exists with a count >= the number of
+#      junk probes we issued.
+#   3. A genuinely matched route (/health) still keeps its real path label
+#      (the fix must not collapse legitimate routes).
+#
+# Feature-gated on `metrics_unmatched_path` so it auto-skips on a 1.2.x
+# backend (which emits per-path series) instead of hard-failing.
+#
+# Requires: curl, grep, awk
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "metrics-unmatched-cardinality"
+auth_admin
+setup_workdir
+
+# Feature gate: skip on backends without the unmatched-path collapse.
+# Must come before any probing so a gated skip exits fast.
+begin_test "Backend supports metrics_unmatched_path (v1.3.0)"
+if require_feature "metrics_unmatched_path"; then
+  pass
+else
+  end_suite
+  exit 0
+fi
+
+# Junk paths that match no route. Two classes:
+#   - real-world scanner probes (#2217's motivating vectors)
+#   - RUN_ID-unique paths that could ONLY appear as a metrics label if the
+#     per-path cardinality bug were present (nothing else probes them).
+JUNK_PATHS=(
+  "/.env"
+  "/.git/config"
+  "/wp-admin"
+  "/nonexistent-${RUN_ID}-alpha"
+  "/nonexistent-${RUN_ID}-beta"
+  "/nonexistent-${RUN_ID}-gamma"
+)
+NUM_PROBES=${#JUNK_PATHS[@]}
+
+# Fetch /metrics text (public endpoint; no auth needed).
+fetch_metrics() {
+  curl -sf --max-time 15 "${BASE_URL}/metrics" 2>/dev/null
+}
+
+# Sum ak_http_requests_total across every series whose label set contains
+# path="unmatched". There may be several (one per method/status combo), so we
+# sum the trailing value column. Prints an integer (0 if none).
+sum_unmatched_total() {
+  local metrics="$1"
+  echo "$metrics" \
+    | grep '^ak_http_requests_total{' \
+    | grep 'path="unmatched"' \
+    | awk '{sum += $NF} END {printf "%.0f\n", sum+0}'
+}
+
+# =========================================================================
+# Section 1: metrics endpoint reachable
+# =========================================================================
+
+begin_test "Metrics endpoint is available"
+if fetch_metrics > /dev/null 2>&1; then
+  pass
+else
+  fail "GET /metrics returned error"
+fi
+
+# =========================================================================
+# Section 2: probe junk paths + one matched route, then scrape
+# =========================================================================
+
+begin_test "Probe unmatched junk paths and a matched route"
+for p in "${JUNK_PATHS[@]}"; do
+  curl -s -o /dev/null --max-time 10 "${BASE_URL}${p}" > /dev/null 2>&1 || true
+done
+# Hit a genuinely matched route a few times so its real-path series is present.
+for _i in $(seq 1 3); do
+  curl -s -o /dev/null --max-time 10 "${BASE_URL}/health" > /dev/null 2>&1 || true
+done
+# Give the registry a moment to record the completed requests.
+sleep 2
+METRICS="$(fetch_metrics || true)"
+if [ -n "$METRICS" ]; then
+  pass
+else
+  fail "GET /metrics returned an empty body after probing"
+fi
+
+# =========================================================================
+# Section 3: no per-junk-path series exist (cardinality is collapsed)
+# =========================================================================
+
+begin_test "No metrics series carries a literal junk path label"
+leaked=""
+for p in "${JUNK_PATHS[@]}"; do
+  # Only consider the request metrics with an explicit path="<junk>" label.
+  if echo "$METRICS" | grep -q "path=\"${p}\""; then
+    leaked="${leaked} ${p}"
+  fi
+done
+if [ -z "$leaked" ]; then
+  pass
+else
+  fail "metrics leaked per-path series for unmatched paths:${leaked}" \
+    "$(echo "$METRICS" | grep '^ak_http_requests_total{' | grep 'nonexistent\|\.env\|\.git\|wp-admin' | head -20)"
+fi
+
+# =========================================================================
+# Section 4: a single unmatched series exists with count >= probes
+# =========================================================================
+
+begin_test "A path=\"unmatched\" series exists with count >= ${NUM_PROBES}"
+if ! echo "$METRICS" | grep '^ak_http_requests_total{' | grep -q 'path="unmatched"'; then
+  fail "no ak_http_requests_total series with path=\"unmatched\" found" \
+    "$(echo "$METRICS" | grep '^ak_http_requests_total{' | head -20)"
+else
+  UNMATCHED_TOTAL=$(sum_unmatched_total "$METRICS")
+  if [ "$UNMATCHED_TOTAL" -ge "$NUM_PROBES" ] 2>/dev/null; then
+    pass
+  else
+    fail "unmatched total ${UNMATCHED_TOTAL} < probes ${NUM_PROBES} (probes not attributed to the unmatched series)"
+  fi
+fi
+
+# =========================================================================
+# Section 5: matched routes keep their real path label
+# =========================================================================
+
+begin_test "Matched route /health keeps its real path label"
+if echo "$METRICS" | grep '^ak_http_requests_total{' | grep -q 'path="/health"'; then
+  pass
+else
+  fail "matched route /health has no path=\"/health\" series (fix over-collapsed a real route)" \
+    "$(echo "$METRICS" | grep '^ak_http_requests_total{' | head -20)"
+fi
+
+end_suite

--- a/tests/platform/test-streaming-large-artifact.sh
+++ b/tests/platform/test-streaming-large-artifact.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# test-streaming-large-artifact.sh - A >16 MiB artifact must stream, not buffer.
+#
+# Release gate for:
+#   artifact-keeper#1608 - streaming invariant (>16 MiB not buffered / 502'd)
+#
+# The backend buffers request/response bodies up to a 16 MiB in-memory cap.
+# Artifacts larger than that MUST be streamed to/from storage; if the cap is
+# applied to the artifact path the upload/download of a >16 MiB blob returns
+# 502 (or the pod OOM-crashes) instead of 2xx. This gate PUTs a 24 MiB blob
+# (comfortably over the 16 MiB cap) to a generic repo and GETs it back,
+# asserting:
+#   - upload is 2xx and is NEVER 502 (buffered/OOM) or 413 (over MAX_UPLOAD_SIZE;
+#     the test overlay's default cap is 10 GiB, so 413 here means the streaming
+#     path was not taken)
+#   - download is 2xx
+#   - the SHA256 and byte size round-trip exactly (no truncation from a partial
+#     buffered read)
+#
+# Unlike tests/resilience/data/test-large-artifact.sh (100 MB, gated behind
+# `require_cmd kubectl`), this copy needs no kubectl so it runs in the normal
+# platform matrix. 24 MiB keeps it fast while still crossing the 16 MiB cap.
+#
+# Feature-gated on `streaming_large_artifact` so it auto-skips on a 1.2.x
+# backend instead of hard-failing.
+#
+# Requires: curl, dd, shasum
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "streaming-large-artifact"
+auth_admin
+setup_workdir
+
+# Feature gate: skip on backends without the streaming invariant.
+begin_test "Backend supports streaming_large_artifact (v1.3.0)"
+if require_feature "streaming_large_artifact"; then
+  pass
+else
+  end_suite
+  exit 0
+fi
+
+REPO_KEY="e2e-streaming-${RUN_ID}"
+# 24 MiB: strictly greater than the 16 MiB in-memory buffer cap.
+LARGE_SIZE_MB=24
+ART_PATH="files/v1/large-${RUN_ID}.bin"
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+begin_test "Create generic repository"
+if create_local_repo "$REPO_KEY" "generic"; then
+  pass
+else
+  fail "could not create generic repo"
+fi
+
+begin_test "Generate ${LARGE_SIZE_MB} MiB test file (> 16 MiB buffer cap)"
+dd if=/dev/urandom bs=1048576 count="$LARGE_SIZE_MB" \
+  of="${WORK_DIR}/large.bin" 2>/dev/null
+ORIG_SHA=$(shasum -a 256 "${WORK_DIR}/large.bin" | awk '{print $1}')
+ORIG_SIZE=$(wc -c < "${WORK_DIR}/large.bin" | tr -d ' ')
+echo "  File size: ${ORIG_SIZE} bytes, SHA256: ${ORIG_SHA}"
+if [ "$ORIG_SIZE" -gt $((16 * 1024 * 1024)) ] 2>/dev/null; then
+  pass
+else
+  fail "generated file is ${ORIG_SIZE} bytes, expected > 16 MiB"
+fi
+
+# ---------------------------------------------------------------------------
+# Upload: must stream (2xx), never 502 (buffered/OOM) or 413 (cap)
+# ---------------------------------------------------------------------------
+
+begin_test "Upload ${LARGE_SIZE_MB} MiB artifact is 2xx (streamed, not 502/413)"
+upload_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X PUT \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary "@${WORK_DIR}/large.bin" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/artifacts/${ART_PATH}" 2>/dev/null) || upload_status="000"
+echo "  Upload status: ${upload_status}"
+if [ "$upload_status" = "502" ]; then
+  fail "upload returned 502: >16 MiB body was buffered/OOM instead of streamed"
+elif [ "$upload_status" = "413" ]; then
+  fail "upload returned 413: streaming path not taken (overlay MAX_UPLOAD_SIZE default is 10 GiB)"
+elif assert_http_2xx "$upload_status" "large artifact upload should be 2xx"; then
+  pass
+fi
+
+# ---------------------------------------------------------------------------
+# Download: must stream (2xx) and round-trip byte-exact
+# ---------------------------------------------------------------------------
+
+begin_test "Download ${LARGE_SIZE_MB} MiB artifact is 2xx (streamed, not 502)"
+dl_status=$(curl -s -o "${WORK_DIR}/large-dl.bin" -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/repositories/${REPO_KEY}/download/${ART_PATH}" 2>/dev/null) || dl_status="000"
+echo "  Download status: ${dl_status}"
+if [ "$dl_status" = "502" ]; then
+  fail "download returned 502: >16 MiB body was buffered/OOM instead of streamed"
+elif assert_http_2xx "$dl_status" "large artifact download should be 2xx"; then
+  pass
+fi
+
+begin_test "Downloaded artifact SHA256 matches (no truncation)"
+if [ -f "${WORK_DIR}/large-dl.bin" ]; then
+  DL_SHA=$(shasum -a 256 "${WORK_DIR}/large-dl.bin" | awk '{print $1}')
+  if assert_eq "$DL_SHA" "$ORIG_SHA" "SHA256 mismatch on ${LARGE_SIZE_MB} MiB round-trip"; then
+    pass
+  fi
+else
+  fail "downloaded file does not exist"
+fi
+
+begin_test "Downloaded artifact byte size matches"
+if [ -f "${WORK_DIR}/large-dl.bin" ]; then
+  DL_SIZE=$(wc -c < "${WORK_DIR}/large-dl.bin" | tr -d ' ')
+  if assert_eq "$DL_SIZE" "$ORIG_SIZE" "size mismatch: expected ${ORIG_SIZE}, got ${DL_SIZE}"; then
+    pass
+  fi
+else
+  fail "downloaded file does not exist"
+fi
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+api_delete "/api/v1/repositories/${REPO_KEY}" > /dev/null 2>&1 || true
+
+end_suite

--- a/tests/pullthrough/test-npm-packument-swr.sh
+++ b/tests/pullthrough/test-npm-packument-swr.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# test-npm-packument-swr.sh - npm packument is served from cache (no upstream
+# re-fetch) within the TTL window.
+#
+# Release gate for:
+#   artifact-keeper#2166 - npm packument stale-while-revalidate cache
+#
+# Strategy: AK-to-AK upstream (identical rationale to
+# tests/pullthrough/test-cache-hit-no-refetch.sh -- the Python mock binds an
+# RFC1918 address the backend's validate_outbound_url rejects, so a remote npm
+# repo points at a local npm repo's own AK URL and the backend dials itself).
+#
+#   U = local npm repo we publish to.
+#   R = remote npm repo whose upstream_url is U's AK URL.
+#
+# Assertions (count-axis, same technique as the pypi cache-hit test):
+#   1. Cold packument fetch through R primes the cache (v1 present).
+#   2. N warm refetches are byte-identical -- a stable cache source, not a
+#      per-request upstream re-fetch or a partial-cache-write race.
+#   3. After a NEW version lands on U, the packument on R still serves the
+#      cached (v1-only) document within the long TTL window. If the proxy
+#      re-fetched upstream on every call we would already see v2 here; a
+#      packument that still lacks v2 within TTL proves the warm hit was
+#      served from cache (the SWR "serve stale" property).
+#
+# Feature-gated on `npm_packument_swr` so it auto-skips on a 1.2.x backend.
+#
+# Requires: curl, jq, tar
+
+source "$(dirname "$0")/../lib/common.sh"
+
+begin_suite "npm-packument-swr"
+auth_admin
+setup_workdir
+
+begin_test "Backend supports npm_packument_swr (v1.3.0)"
+if require_feature "npm_packument_swr"; then
+  pass
+else
+  end_suite
+  exit 0
+fi
+
+UPSTREAM_KEY="nps-up-${RUN_ID}"
+REMOTE_KEY="nps-rem-${RUN_ID}"
+PKG_NAME="npspkg${RUN_ID//-/}"
+PKG_V1="1.0.0"
+PKG_V2="2.0.0"
+# Long TTL so no test step can slip past it on a loaded runner.
+TTL_SECS=60
+HIT_FETCHES=5
+
+cleanup_repos() {
+  api_delete "/api/v1/repositories/${REMOTE_KEY}" >/dev/null 2>&1 || true
+  api_delete "/api/v1/repositories/${UPSTREAM_KEY}" >/dev/null 2>&1 || true
+}
+add_exit_handler "cleanup_repos"
+
+# Publish PKG_NAME@<version> to the local upstream U via the npm _attachments
+# PUT payload shape (same as tests/formats/test-npm.sh curl fallback).
+publish_to_upstream() {
+  local version="$1"
+  local pkgdir="${WORK_DIR}/pub-${version}"
+  mkdir -p "$pkgdir"
+  printf '{"name":"%s","version":"%s"}\n' "$PKG_NAME" "$version" > "${pkgdir}/package.json"
+  printf 'module.exports = "%s";\n' "$version" > "${pkgdir}/index.js"
+  local tgz="${WORK_DIR}/${PKG_NAME}-${version}.tgz"
+  tar czf "$tgz" -C "$pkgdir" .
+  base64 < "$tgz" | tr -d '\n' > "${WORK_DIR}/b64-${version}.txt"
+  local size
+  size=$(wc -c < "$tgz" | tr -d ' ')
+  jq -n \
+    --arg name "$PKG_NAME" --arg version "$version" \
+    --arg tarball "${BASE_URL}/npm/${UPSTREAM_KEY}/${PKG_NAME}/-/${PKG_NAME}-${version}.tgz" \
+    --rawfile data "${WORK_DIR}/b64-${version}.txt" \
+    --argjson length "$size" \
+    '{name: $name, versions: {($version): {name: $name, version: $version, dist: {tarball: $tarball}}},
+      "_attachments": {("\($name)-\($version).tgz"): {content_type: "application/octet-stream", data: $data, length: $length}}}' \
+    > "${WORK_DIR}/publish-${version}.json"
+  local status
+  status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X PUT \
+    -H "$(format_auth_header)" -H "Content-Type: application/json" \
+    --data-binary "@${WORK_DIR}/publish-${version}.json" \
+    "${BASE_URL}/npm/${UPSTREAM_KEY}/${PKG_NAME}" 2>/dev/null) || status="000"
+  echo "$status"
+}
+
+fetch_packument() {
+  curl -sf $CURL_TIMEOUT -H "$(format_auth_header)" \
+    "${BASE_URL}/npm/${REMOTE_KEY}/${PKG_NAME}" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+begin_test "Create local npm upstream U"
+if create_local_repo "$UPSTREAM_KEY" "npm"; then
+  pass
+else
+  fail "could not create npm upstream"
+fi
+
+begin_test "Publish ${PKG_NAME}@${PKG_V1} to U"
+st=$(publish_to_upstream "$PKG_V1")
+if [ "$st" = "200" ] || [ "$st" = "201" ]; then
+  pass
+else
+  skip "npm publish endpoint unavailable (status ${st}); cannot run packument SWR assertion"
+  cleanup_repos
+  end_suite
+  exit 0
+fi
+
+# Wait for U to surface v1 in its own packument.
+deadline=$(( $(date +%s) + 10 ))
+until curl -sf $CURL_TIMEOUT -H "$(format_auth_header)" \
+        "${BASE_URL}/npm/${UPSTREAM_KEY}/${PKG_NAME}" 2>/dev/null \
+      | grep -q "\"${PKG_V1}\"" || [ "$(date +%s)" -ge "$deadline" ]; do
+  sleep 0.2
+done
+
+begin_test "Create remote R pointing at U (TTL=${TTL_SECS}s)"
+if create_remote_repo "$REMOTE_KEY" "npm" "${BASE_URL}/npm/${UPSTREAM_KEY}"; then
+  pass
+else
+  fail "could not create remote R"
+fi
+api_put "/api/v1/repositories/${REMOTE_KEY}/cache-ttl" \
+  "{\"cache_ttl_seconds\": ${TTL_SECS}}" >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
+# 1. Prime the packument cache
+# ---------------------------------------------------------------------------
+
+begin_test "Prime cache: first packument fetch through R contains v${PKG_V1}"
+PRIMED=$(fetch_packument) || PRIMED=""
+if [ -n "$PRIMED" ] && echo "$PRIMED" | grep -q "\"${PKG_V1}\""; then
+  pass
+else
+  fail "primed packument missing v${PKG_V1}; SWR test cannot proceed (got: ${PRIMED:0:200})"
+fi
+PRIME_TS=$(date +%s)
+
+# ---------------------------------------------------------------------------
+# 2. N tight-loop refetches must return byte-identical bodies (cache hit)
+# ---------------------------------------------------------------------------
+
+begin_test "${HIT_FETCHES} consecutive packument refetches are byte-identical (cache hit)"
+mismatch=0
+last="$PRIMED"
+for i in $(seq 1 $HIT_FETCHES); do
+  body=$(fetch_packument) || body=""
+  if [ -z "$body" ]; then
+    mismatch=1; echo "  fetch ${i}: empty body"; break
+  fi
+  if [ "$body" != "$last" ]; then
+    mismatch=1; echo "  fetch ${i}: body differs from previous (cache miss or partial write)"; break
+  fi
+  last="$body"
+done
+if [ "$mismatch" -eq 0 ]; then
+  pass
+else
+  fail "consecutive packument refetches diverged; cache is not serving hits as a stable byte source"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Publish v2 to U; within the TTL window R still serves the cached
+#    v1-only packument (SWR serve-stale, no per-call upstream re-fetch).
+# ---------------------------------------------------------------------------
+
+begin_test "Publish ${PKG_NAME}@${PKG_V2} to upstream U (cache still primed)"
+st=$(publish_to_upstream "$PKG_V2")
+if [ "$st" = "200" ] || [ "$st" = "201" ]; then
+  pass
+else
+  fail "could not publish v${PKG_V2} to U (status ${st})"
+fi
+
+# Confirm U itself now sees v2 (sanity).
+deadline=$(( $(date +%s) + 10 ))
+until curl -sf $CURL_TIMEOUT -H "$(format_auth_header)" \
+        "${BASE_URL}/npm/${UPSTREAM_KEY}/${PKG_NAME}" 2>/dev/null \
+      | grep -q "\"${PKG_V2}\"" || [ "$(date +%s)" -ge "$deadline" ]; do
+  sleep 0.2
+done
+
+begin_test "Within-TTL packument refetch still serves cached v${PKG_V1}-only (no upstream re-fetch)"
+NOW=$(date +%s)
+ELAPSED=$(( NOW - PRIME_TS ))
+if [ "$ELAPSED" -ge "$TTL_SECS" ]; then
+  skip "scheduling slipped past TTL window (elapsed=${ELAPSED}s, ttl=${TTL_SECS}s)"
+else
+  BODY=$(fetch_packument) || BODY=""
+  if [ -z "$BODY" ]; then
+    fail "within-TTL packument refetch returned empty"
+  elif echo "$BODY" | grep -q "\"${PKG_V2}\""; then
+    fail "CACHE BYPASSED: within-TTL packument already shows v${PKG_V2}; proxy re-fetched upstream every call (SWR serve-stale violated)"
+  elif echo "$BODY" | grep -q "\"${PKG_V1}\""; then
+    pass
+  else
+    fail "within-TTL packument refetch returned unexpected body: ${BODY:0:200}"
+  fi
+fi
+
+end_suite


### PR DESCRIPTION
## Summary

Adds the cheap, auto-registering v1.3.0 release-gate suites from the v1.3.0
test-gate design plan. Each new suite is pure bash + curl + jq, sources
`tests/lib/common.sh`, uses the `begin_suite`/`begin_test`/`pass`/`fail`/`skip`
harness with exact HTTP codes, puts `RUN_ID` in every resource name, and is
guarded by a `require_feature` flag so the same `main` test tree auto-skips on a
1.2.x backend instead of hard-failing on an unshipped feature.

## Gates added

| Gate | File | Feature (#issue) |
|---|---|---|
| G7 | `tests/platform/test-metrics-unmatched-cardinality.sh` | metrics unmatched-path cardinality (#2217) |
| G1 | `tests/platform/test-streaming-large-artifact.sh` | >16 MiB streaming invariant, generic API (#1608) |
| G1 | `tests/formats/test-streaming-blob-fallback.sh` | >16 MiB streaming across oci/swift/npm/helm/pypi (#1608) |
| G1 | `tests/formats/test-composer-dist-cache.sh` | composer dist warm-cache hit (#2204) |
| G6 | `tests/pullthrough/test-npm-packument-swr.sh` | npm packument SWR cache (#2166) |
| G3 | `tests/lifecycle/test-oci-gc-mark-sweep.sh` | OCI GC reclaim + no-dangling (#1660) |

## Registration

- Feature flags registered in both sources of truth: `_feature_min_version()`
  in `tests/lib/common.sh` (`= 1.3.0`) and the `AK_BACKEND_BRANCH_MAIN` bundle in
  `tests/lib/feature-flags.sh`: `metrics_unmatched_path`, `streaming_large_artifact`,
  `composer_dist_cache`, `npm_packument_swr`, `oci_gc_two_phase`.
- Domain suites (platform, pullthrough, lifecycle) auto-register by directory.
- The two `formats/` suites are added to the `containers` and `misc-native`
  batch `scripts:` lists in both `release-gate.yml` and `format-tests.yml`
  (formats does not auto-discover).

## Scoped out / skipped (with reasons)

- **G3 resurrection sub-case** — skipped in-suite: the GC endpoint is a single
  atomic `run_gc` call with no separately-triggerable mark/sweep phases, so the
  re-adopt-during-sweep race cannot be driven at the gate layer.
- **G2 AccessScope authz** — deferred: no REST endpoint sets an arbitrary
  `AccessScope` (repository_scopes list / empty / user-level); the enum's
  semantics are covered by backend lib unit tests. Noted in `feature-flags.sh`.
- **G4 SSO happy-path** — deferred (needs a mock IdP; covered by backend e2e
  #2210/#2214). Negative/forged-assertion cases are already covered by
  `tests/auth/test-oidc-*.sh` and `tests/security/test-saml-signature.sh`, so no
  duplicate negative suite was added.
- **G5 cross-replica cache-invalidation** — deferred (needs a new 2-replica
  shared-DB `values-test-ha.yaml` overlay + deploy job; #2169). Noted in
  `feature-flags.sh`.

## Validation

- `shellcheck -x --severity=warning` clean on all new files (remaining info-level
  SC1091 source-path / SC2086 `$CURL_TIMEOUT` match the existing test baseline).
- `bash -n` parse-clean on all new files and both `tests/lib` edits.
- Suite discovery confirmed via the `run-suite.sh` find glob per domain; both
  formats suites confirmed present in their batch lists.
- Feature-flag resolution confirmed: all five tokens resolve on `main` and are
  absent on `release/1.2.x` (auto-skip), and `_feature_min_version` returns
  `1.3.0` for each.

End-to-end pass against a live current-`main` target is validated separately
during the regression campaign; this PR delivers convention-correct,
shellcheck-clean, auto-registered gates.

## Test plan

- [ ] Run the release gate against a v1.3.0 (`main`) backend: new suites execute.
- [ ] Run against a 1.2.x backend: new suites auto-skip via `require_feature`.
