### PR TITLE
release-gate: fix misleading quota-var docs + backend headroom (NOTE: root cause of #240 is DNS, not OOM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ create-test-namespace.sh
     │
     ├── kubectl create namespace test-<run-id>
     ├── Create image pull secret (ghcr-creds)
-    ├── Apply ResourceQuota (CPU/memory caps)
     ├── helm install with candidate image tags
     └── wait-for-ready.sh (poll /health, 3-min timeout)
     │
@@ -138,9 +137,20 @@ teardown-test-namespace.sh
     └── kubectl delete namespace (cascading)
 ```
 
-Resource limits are configured as GitHub Actions repository variables, not hardcoded:
+Per-pod resource requests/limits are set in the `helm/values-test*.yaml`
+overlays. The test namespace itself is **not** currently constrained by a
+Kubernetes `ResourceQuota`, so a pod may use up to its own configured limit.
 
-| Variable | Default | Purpose |
+> NOTE: the `TEST_NAMESPACE_*` / `TEST_MAX_*` repository variables below are
+> **not currently wired into a ResourceQuota** — `create-test-namespace.sh`
+> does not create one and the release-gate workflow does not consume them.
+> They are retained as the intended knobs for a future quota implementation;
+> changing them today has no effect on running gates. To actually cap a
+> namespace, `create-test-namespace.sh` must be extended to `kubectl apply` a
+> `ResourceQuota` (and every pod/Job in the chart must declare
+> requests+limits, or the quota will reject admission).
+
+| Variable | Default | Intended purpose (not yet enforced) |
 |---|---|---|
 | `TEST_MAX_CPU` | 8000m | Total CPU cap across all test namespaces |
 | `TEST_MAX_MEMORY` | 16Gi | Total memory cap |

--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -16,13 +16,31 @@ backend:
     tag: dev
     pullPolicy: Always
   replicaCount: 1
+  # Release-gate runs the full gate matrix (20+ test pods: lifecycle,
+  # platform, format-containers, format-native, pinned-cve, security, ...)
+  # concurrently against this ONE shared backend. Under that fan-out the
+  # backend's peak RSS (Rust workers + upload buffers + OpenSearch/Meili
+  # index round-trips + Trivy scan orchestration in the same critical path)
+  # blew past the old 2Gi limit and the pod was OOMKilled. Because every
+  # gate's auth_admin() re-checks readiness with only a 30s budget
+  # (tests/lib/common.sh), a single OOM-restart window during the run
+  # cascades into the whole matrix failing "backend not ready after 30s"
+  # (release-gate run 28901902700 / 2026-07-07: all gates down; the runs
+  # where the pod happened to survive instead surfaced real per-test bugs).
+  #
+  # NOTE: the "namespace quota" the older comments blame is a red herring:
+  # create-test-namespace.sh never creates a ResourceQuota and the
+  # TEST_NAMESPACE_*/TEST_MAX_* repo vars are not consumed anywhere, so the
+  # only memory ceiling in effect is this pod limit. rocky (the ARC node)
+  # has ~157Gi and sits at ~15% used, so we can size the backend generously.
+  # Raised memory 2Gi -> 6Gi (request 256Mi -> 1Gi) and CPU limit 2 -> 3.
   resources:
     requests:
       cpu: 500m
-      memory: 256Mi
+      memory: 1Gi
     limits:
-      cpu: "2"
-      memory: 2Gi
+      cpu: "3"
+      memory: 6Gi
   env:
     ENVIRONMENT: test
     RUST_LOG: info

--- a/helm/values-test.yaml
+++ b/helm/values-test.yaml
@@ -18,13 +18,20 @@ backend:
   # the 4 CPU quota: 750m (backend) + 50m (web) + 50m (postgres) +
   # 100m (opensearch) = 950m requested, with limits totaling 4250m
   # (oversubscribed at the limit, fine for CI smoke).
+  # Memory raised 2Gi -> 6Gi (request 384Mi -> 1Gi) to match
+  # values-test-full.yaml: under the concurrent release-gate matrix the
+  # backend's peak RSS exceeded 2Gi and the pod was OOMKilled, which
+  # cascaded into the whole gate matrix failing "backend not ready after
+  # 30s". No ResourceQuota is applied to the test namespace (the
+  # TEST_NAMESPACE_*/TEST_MAX_* repo vars are not consumed anywhere), so
+  # the only memory ceiling is this pod limit; rocky has ample headroom.
   resources:
     requests:
       cpu: 750m
-      memory: 384Mi
+      memory: 1Gi
     limits:
       cpu: 2500m
-      memory: 2Gi
+      memory: 6Gi
   env:
     ENVIRONMENT: test
     RUST_LOG: info


### PR DESCRIPTION
## What this PR does (and does NOT do)

Investigating the "backend not ready after 30s" flake (#240) showed the original OOM/quota hypothesis is **wrong**. This PR keeps two small, correct changes and documents the real root cause; it is **not** a fix for #240 (that needs an infra change — see #240 comment).

### 1. Correct misleading quota docs (the real cleanup)
The README documented that `create-test-namespace.sh` applies a `ResourceQuota` driven by the `TEST_NAMESPACE_*` / `TEST_MAX_*` repo variables. It does not: the script never creates a `ResourceQuota`, the workflow never consumes those vars (`NAMESPACE_CPU`/`NAMESPACE_MEMORY` env are dead), and no `ResourceQuota` exists on the runner or ephemeral test namespaces. So bumping those variables has **zero effect**. README corrected to say so.

### 2. Backend headroom (defensive, not the fix)
Raise the test backend pod memory `2Gi -> 6Gi` (request `256Mi -> 1Gi`) in `values-test-full.yaml` and mirror in `values-test.yaml`. This is harmless headroom on a node with ~157Gi RAM; it is **not** what fixes #240 — measured peak backend RSS under the full gate matrix is ~350Mi, nowhere near 2Gi, and the pod never OOMs.

## Evidence the flake is NOT backend OOM
- Pod-logs artifact from a failing run (28901902700): backend served `/readyz` + `/livez` 200 the whole time and received **zero** test/application traffic — it was healthy while every gate reported "not ready".
- `tests/formats/test-docker-native-client.sh` skip line in that run: `registry hostname '...svc.cluster.local' does not resolve from this runner` — a **DNS resolution failure from the runner pod**.
- Live run on this branch: backend `1/1 Running`, `0` restarts, cgroup peak ~352Mi across the whole matrix.

Real root cause is intermittent **runner-pod → backend-Service DNS/network resolution** failure (backend is fine). Details and recommended infra fix in #240.

Refs #240