### PR TITLE
release-gate: version-set-integrity also verifies the CHANGELOG documents the release

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -100,6 +100,13 @@ jobs:
   # exists at that tag." Failing here is a release-blocker that should
   # NEVER be soft-failed: a missing tag is a publish-pipeline regression,
   # not a flake.
+  #
+  # Also enforces the release-documentation policy: when backend_tag is
+  # a final release version (X.Y.Z), artifact-keeper's CHANGELOG.md must
+  # contain a non-empty `## [X.Y.Z]` section for that version (promote
+  # [Unreleased] before tagging; see artifact-keeper RELEASING.md).
+  # Non-release tags (dev, sha-*, prereleases) skip that sub-check, so
+  # routine gate runs against non-release builds are unaffected.
   # -------------------------------------------------------------------
   version-set-integrity:
     runs-on: ak-e2e-runners
@@ -125,7 +132,7 @@ jobs:
             https://github.com/artifact-keeper/artifact-keeper-iac.git \
             "${RUNNER_TEMP}/iac"
 
-      - name: Verify backend / web / openscap image tags exist on ghcr.io
+      - name: Verify image tags exist on ghcr.io and CHANGELOG documents the release
         env:
           BACKEND_TAG: ${{ inputs.backend_tag }}
           WEB_TAG: ${{ inputs.web_tag }}

--- a/tests/release-gate/verify-image-set.sh
+++ b/tests/release-gate/verify-image-set.sh
@@ -6,10 +6,24 @@
 #       --backend-tag <tag> \
 #       --web-tag <tag> \
 #       --openscap-tag <tag> \
-#       [--chart-dir <path>]
+#       [--chart-dir <path>] \
+#       [--changelog-file <path>]
 #
 # Probes the GHCR registry's manifest endpoint for each image at the
 # specified tag. A missing tag fails fast with a clear error.
+#
+# When the backend tag is a final release version (X.Y.Z), the script
+# ALSO verifies that artifact-keeper's CHANGELOG.md documents that
+# version: a `## [X.Y.Z]` heading (a trailing ` - DATE` is fine) with
+# at least one non-empty content line under it. A release with no
+# CHANGELOG entry for its version FAILS the gate. Non-release tags
+# (dev, sha-*, rc/beta prereleases) skip this check, so normal test
+# runs are unaffected. The CHANGELOG is fetched from the
+# artifact-keeper repo at tag vX.Y.Z, falling back to main (the gate
+# runs before tagging, so the promoted entry normally lives on main).
+# Use --changelog-file to point at a local file instead (testing), or
+# CHANGELOG_REPO to override the GitHub repo (default
+# artifact-keeper/artifact-keeper).
 #
 # When --chart-dir is provided AND `helm` is on PATH, the script also
 # renders the chart with no overrides and asserts that the default
@@ -36,9 +50,11 @@
 #   * Tolerates schema 1 and schema 2 manifests (we just need a 200).
 #
 # Exit codes:
-#   0 - All images exist at their tags
+#   0 - All images exist at their tags (and, for final release
+#       versions, CHANGELOG.md documents the version)
 #   1 - Usage error
-#   2 - At least one image is missing
+#   2 - At least one image is missing, or the CHANGELOG entry for the
+#       release version is missing/empty
 #
 # Required env: none. Optional: GHCR_REGISTRY (default ghcr.io),
 #               GHCR_NAMESPACE (default artifact-keeper).
@@ -49,16 +65,18 @@ BACKEND_TAG=""
 WEB_TAG=""
 OPENSCAP_TAG=""
 CHART_DIR=""
+CHANGELOG_FILE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --backend-tag)  BACKEND_TAG="${2:-}"; shift 2 ;;
-    --web-tag)      WEB_TAG="${2:-}"; shift 2 ;;
-    --openscap-tag) OPENSCAP_TAG="${2:-}"; shift 2 ;;
-    --chart-dir)    CHART_DIR="${2:-}"; shift 2 ;;
+    --backend-tag)     BACKEND_TAG="${2:-}"; shift 2 ;;
+    --web-tag)         WEB_TAG="${2:-}"; shift 2 ;;
+    --openscap-tag)    OPENSCAP_TAG="${2:-}"; shift 2 ;;
+    --chart-dir)       CHART_DIR="${2:-}"; shift 2 ;;
+    --changelog-file)  CHANGELOG_FILE="${2:-}"; shift 2 ;;
     *)
       echo "Unknown argument: $1" >&2
-      echo "Usage: verify-image-set.sh --backend-tag <tag> --web-tag <tag> --openscap-tag <tag> [--chart-dir <path>]" >&2
+      echo "Usage: verify-image-set.sh --backend-tag <tag> --web-tag <tag> --openscap-tag <tag> [--chart-dir <path>] [--changelog-file <path>]" >&2
       exit 1
       ;;
   esac
@@ -263,9 +281,99 @@ if [ -n "$CHART_DIR" ]; then
   fi
 fi
 
+# -----------------------------------------------------------------------
+# CHANGELOG entry verification (release policy: the CHANGELOG must
+# document the release version)
+#
+# A green image check tells us the release set was published. It does
+# NOT tell us the release documents itself: v-tags have shipped with
+# CHANGELOG.md still carrying the changes under [Unreleased]. Policy:
+# before tagging vX.Y.Z, the [Unreleased] section is promoted to
+# `## [X.Y.Z] - <date>`. This block enforces that policy at the gate.
+#
+# Scope: only FINAL release versions (X.Y.Z exactly). Prerelease tags
+# (1.2.3-rc1), branch tags (dev), and sha-* tags skip the check, so
+# routine gate runs against non-release builds are unaffected.
+#
+# Source of truth: artifact-keeper/CHANGELOG.md at tag vX.Y.Z if it
+# already exists, else main (the gate normally runs BEFORE tagging,
+# when the promoted entry has just landed on main). --changelog-file
+# short-circuits the fetch for local testing.
+# -----------------------------------------------------------------------
+
+CHANGELOG_FAILURES=()
+RELEASE_SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+if [[ "$BACKEND_TAG_NORM" =~ $RELEASE_SEMVER_RE ]]; then
+  echo ""
+  echo "CHANGELOG entry verification (release version ${BACKEND_TAG_NORM})"
+
+  CHANGELOG_PATH=""
+  if [ -n "$CHANGELOG_FILE" ]; then
+    if [ -f "$CHANGELOG_FILE" ]; then
+      echo "  Using local CHANGELOG file: ${CHANGELOG_FILE}"
+      CHANGELOG_PATH="$CHANGELOG_FILE"
+    else
+      echo "  ERROR: --changelog-file ${CHANGELOG_FILE} does not exist"
+      CHANGELOG_FAILURES+=("changelog-file-missing")
+    fi
+  else
+    CHANGELOG_REPO="${CHANGELOG_REPO:-artifact-keeper/artifact-keeper}"
+    fetched_ref=""
+    changelog_tmp=$(mktemp /tmp/version-set-changelog.XXXXXX)
+    for ref in "v${BACKEND_TAG_NORM}" "main"; do
+      if curl -sf --max-time 15 \
+           "https://raw.githubusercontent.com/${CHANGELOG_REPO}/${ref}/CHANGELOG.md" \
+           -o "$changelog_tmp"; then
+        fetched_ref="$ref"
+        break
+      fi
+    done
+    if [ -n "$fetched_ref" ]; then
+      echo "  Fetched CHANGELOG.md from ${CHANGELOG_REPO}@${fetched_ref}"
+      CHANGELOG_PATH="$changelog_tmp"
+    else
+      echo "  ERROR: could not fetch CHANGELOG.md from ${CHANGELOG_REPO}"
+      echo "         (tried refs: v${BACKEND_TAG_NORM}, main)"
+      CHANGELOG_FAILURES+=("changelog-fetch-failed")
+    fi
+  fi
+
+  if [ -n "$CHANGELOG_PATH" ]; then
+    # Heading match: `## [X.Y.Z]` at line start; a trailing ` - DATE`
+    # (Keep a Changelog style) is tolerated. Dots are escaped so
+    # 1.2.3 cannot match 1.2.30 (the closing bracket anchors the end).
+    ver_esc="${BACKEND_TAG_NORM//./\\.}"
+    if ! grep -qE "^## \[${ver_esc}\]" "$CHANGELOG_PATH"; then
+      echo "  MISSING: no '## [${BACKEND_TAG_NORM}]' section in CHANGELOG.md"
+      CHANGELOG_FAILURES+=("no-changelog-entry-${BACKEND_TAG_NORM}")
+    else
+      # Count non-empty lines between the version heading and the next
+      # `## ` heading (or EOF). Zero content lines = empty stub entry.
+      content_lines=$(awk -v ver="$BACKEND_TAG_NORM" '
+        BEGIN { esc = ver; gsub(/\./, "\\.", esc); pat = "^## \\[" esc "\\]" }
+        $0 ~ pat { insec = 1; next }
+        insec && /^## /  { exit }
+        insec && NF > 0  { n++ }
+        END { print n + 0 }
+      ' "$CHANGELOG_PATH")
+      if [ "$content_lines" -eq 0 ]; then
+        echo "  EMPTY: '## [${BACKEND_TAG_NORM}]' heading exists but has no content under it"
+        CHANGELOG_FAILURES+=("empty-changelog-entry-${BACKEND_TAG_NORM}")
+      else
+        echo "  OK: '## [${BACKEND_TAG_NORM}]' section present (${content_lines} content lines)"
+      fi
+    fi
+  fi
+else
+  echo ""
+  echo "CHANGELOG entry verification skipped: backend tag '${BACKEND_TAG_NORM}'"
+  echo "  is not a final release version (X.Y.Z); check applies at release time only."
+fi
+
 echo ""
 echo "=================================================================="
-if [ "${#FAILED_IMAGES[@]}" -eq 0 ]; then
+if [ "${#FAILED_IMAGES[@]}" -eq 0 ] && [ "${#CHANGELOG_FAILURES[@]}" -eq 0 ]; then
   echo "Version-set integrity check PASSED"
   echo "  All ${REGISTRY}/${NAMESPACE} images exist at their tags."
   if [ "${#CHART_WARNINGS[@]}" -gt 0 ]; then
@@ -280,15 +388,33 @@ if [ "${#FAILED_IMAGES[@]}" -eq 0 ]; then
 fi
 
 echo "Version-set integrity check FAILED"
-echo ""
-echo "Missing images (release set incomplete):"
-for img in "${FAILED_IMAGES[@]}"; do
-  echo "  - ${REGISTRY}/${NAMESPACE}/${img}"
-done
-echo ""
-echo "This is a release blocker. The publish pipeline did not push every"
-echo "required image at the requested tag. Re-run the publish workflow"
-echo "(see artifact-keeper/.github/workflows/release.yml) or pin the"
-echo "release-gate inputs to a tag set that is fully published."
+
+if [ "${#FAILED_IMAGES[@]}" -gt 0 ]; then
+  echo ""
+  echo "Missing images (release set incomplete):"
+  for img in "${FAILED_IMAGES[@]}"; do
+    echo "  - ${REGISTRY}/${NAMESPACE}/${img}"
+  done
+  echo ""
+  echo "This is a release blocker. The publish pipeline did not push every"
+  echo "required image at the requested tag. Re-run the publish workflow"
+  echo "(see artifact-keeper/.github/workflows/release.yml) or pin the"
+  echo "release-gate inputs to a tag set that is fully published."
+fi
+
+if [ "${#CHANGELOG_FAILURES[@]}" -gt 0 ]; then
+  echo ""
+  echo "CHANGELOG.md has no entry for ${BACKEND_TAG_NORM} -- promote the"
+  echo "[Unreleased] section in artifact-keeper's CHANGELOG.md to a"
+  echo "'## [${BACKEND_TAG_NORM}] - <date>' section (with the release's changes"
+  echo "under it, and a fresh empty [Unreleased] above it) before tagging."
+  echo ""
+  echo "This is a release blocker: every release must document its version"
+  echo "in CHANGELOG.md (see artifact-keeper RELEASING.md). Details:"
+  for cf in "${CHANGELOG_FAILURES[@]}"; do
+    echo "  - ${cf}"
+  done
+fi
+
 echo "=================================================================="
 exit 2


### PR DESCRIPTION
## Summary

Extends the `version-set-integrity` gate so a release must document itself: when the gate is dispatched with a final release version (`X.Y.Z`) as `backend_tag`, `verify-image-set.sh` now also fetches artifact-keeper's `CHANGELOG.md` (from tag `vX.Y.Z` if it exists, else `main`, since the gate normally runs before tagging) and asserts it contains a non-empty `## [X.Y.Z]` section (the `## [X.Y.Z] - DATE` form is tolerated; exact-version match so `1.2.50` cannot satisfy `1.2.5`). A missing or empty entry fails the gate (exit 2) with:

> CHANGELOG.md has no entry for X.Y.Z -- promote the [Unreleased] section in artifact-keeper's CHANGELOG.md to a '## [X.Y.Z] - <date>' section ... before tagging.

Motivation: v1.2.5 and v1.3.0 both shipped with their changes still under `## [Unreleased]`; nothing enforced the promotion. `version-set-integrity` is already the required first job of the release gate, so this makes the policy blocking.

Scope guard: non-release tags (`dev`, `sha-*`, `-rc.*` prereleases) skip the check with a notice, so routine gate runs against non-release builds are unaffected. A `--changelog-file` flag short-circuits the fetch for local testing, and `CHANGELOG_REPO` overrides the source repo. Existing image-existence and chart-default checks are unchanged.

Also updates the `version-set-integrity` job comment and step name in `release-gate.yml` to document the new sub-check. Note the tag-triggered `release.yml` path calls this gate with `backend_tag: dev`; artifact-keeper/artifact-keeper#2377 adds the same assertion there so the automated cut path is covered too.

Part of artifact-keeper/artifact-keeper#2376.

## Verification

- `shellcheck` clean on the modified script; workflow YAML parses.
- Simulated locally against fixtures with real published tags (`1.2.5`):
  - entry present -> PASS (exit 0)
  - entry missing -> FAIL (exit 2) with the promote-[Unreleased] message
  - heading present but empty -> FAIL (exit 2)
  - decoy `## [1.2.50]` does not satisfy `1.2.5` -> FAIL
  - `backend_tag=dev` -> check skipped, gate passes on images alone
  - real fetch path (no `--changelog-file`) fetches `artifact-keeper@v1.2.5` and correctly FAILS, since that tag genuinely lacks a `## [1.2.5]` section