### PR TITLE
feat: object-storage backend E2E suites with self-hosted emulators

### DIFF
--- a/helm/storage-emulators.yaml
+++ b/helm/storage-emulators.yaml
@@ -1,0 +1,194 @@
+# storage-emulators.yaml - Self-hosted object-storage emulators for the
+# full-stack test deploy.
+#
+# Applied by create-test-namespace.sh --full-stack BEFORE the Helm install:
+# the backend registers its named storage backends (s3, azure) at boot from
+# env vars (main.rs storage registry), so the emulators must be reachable
+# when the backend pod starts. values-test-full.yaml carries the matching
+# S3_* / AZURE_STORAGE_* env.
+#
+# Emulators:
+#   minio    - S3 API        (bucket ak-e2e created by the minio-init Job)
+#   azurite  - Azure Blob    (container ak-e2e created by the azurite-init
+#                             Job; well-known devstoreaccount1 account).
+#                             Deployed but not yet wired to the backend:
+#                             Shared Key signing breaks on path-style
+#                             endpoints (artifact-keeper#2649); the AZURE_*
+#                             env in values-test-full.yaml is commented out
+#                             until that fix ships.
+#
+# GCS (fake-gcs-server) is intentionally absent until the backend supports
+# an endpoint override (artifact-keeper#2646); tests/platform/
+# test-storage-backend-gcs.sh skips until then.
+#
+# Credentials below are throwaway test-namespace values, torn down with the
+# namespace. The Azurite key is the PUBLIC well-known emulator key that
+# ships in Azure SDK docs, not a secret.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: storage-minio
+  labels:
+    app: storage-minio
+    app.kubernetes.io/part-of: storage-emulators
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: storage-minio
+  template:
+    metadata:
+      labels:
+        app: storage-minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+          args: ["server", "/data"]
+          env:
+            - name: MINIO_ROOT_USER
+              value: ak-test-access
+            - name: MINIO_ROOT_PASSWORD
+              value: ak-test-secret-2026
+          ports:
+            - containerPort: 9000
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+            initialDelaySeconds: 2
+            periodSeconds: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: storage-minio
+  labels:
+    app: storage-minio
+    app.kubernetes.io/part-of: storage-emulators
+spec:
+  selector:
+    app: storage-minio
+  ports:
+    - port: 9000
+      targetPort: 9000
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: storage-minio-init
+  labels:
+    app.kubernetes.io/part-of: storage-emulators
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        app: storage-minio-init
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              until mc alias set local http://storage-minio:9000 ak-test-access ak-test-secret-2026; do
+                echo "waiting for minio..."; sleep 2
+              done
+              mc mb --ignore-existing local/ak-e2e
+              echo "bucket ak-e2e ready"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: storage-azurite
+  labels:
+    app: storage-azurite
+    app.kubernetes.io/part-of: storage-emulators
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: storage-azurite
+  template:
+    metadata:
+      labels:
+        app: storage-azurite
+    spec:
+      containers:
+        - name: azurite
+          image: mcr.microsoft.com/azure-storage/azurite:3.34.0
+          args: ["azurite-blob", "--blobHost", "0.0.0.0", "--blobPort", "10000"]
+          ports:
+            - containerPort: 10000
+          readinessProbe:
+            tcpSocket:
+              port: 10000
+            initialDelaySeconds: 2
+            periodSeconds: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: storage-azurite
+  labels:
+    app: storage-azurite
+    app.kubernetes.io/part-of: storage-emulators
+spec:
+  selector:
+    app: storage-azurite
+  ports:
+    - port: 10000
+      targetPort: 10000
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: storage-azurite-init
+  labels:
+    app.kubernetes.io/part-of: storage-emulators
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        app: storage-azurite-init
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: az
+          image: mcr.microsoft.com/azure-cli:2.72.0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              # Well-known Azurite dev account (public emulator credentials).
+              CONN="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://storage-azurite:10000/devstoreaccount1;"
+              for i in $(seq 1 30); do
+                if az storage container create --name ak-e2e --connection-string "$CONN" > /dev/null 2>&1; then
+                  echo "container ak-e2e ready"
+                  exit 0
+                fi
+                echo "waiting for azurite..."; sleep 2
+              done
+              echo "azurite never became ready" >&2
+              exit 1

--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -118,6 +118,32 @@ backend:
     # the chart's backend-deployment.yaml auto-injects them when
     # trivy.enabled=true. Setting them here too produces duplicate env keys
     # and helm rejects the manifest. Kept the chart-side values authoritative.
+    #
+    # Object-storage emulators (helm/storage-emulators.yaml, deployed by
+    # create-test-namespace.sh --full-stack before this install). With these
+    # set, main.rs registers additional named "s3" and "azure" backends at
+    # boot, which tests/platform/test-storage-backend-{s3,azure}.sh exercise.
+    # The filesystem backend stays the default (STORAGE_BACKEND unset); repos
+    # opt in per-repo via storage_backend. Credentials are throwaway
+    # test-namespace values; the Azurite key is the PUBLIC well-known
+    # emulator key from Azure SDK docs, not a secret.
+    S3_BUCKET: "ak-e2e"
+    S3_REGION: "us-east-1"
+    S3_ENDPOINT: "http://storage-minio:9000"
+    S3_ACCESS_KEY_ID: "ak-test-access"
+    S3_SECRET_ACCESS_KEY: "ak-test-secret-2026"
+    # AZURE deliberately absent: Shared Key signing is wrong for path-style
+    # (Azurite) endpoints, so registration succeeds but every upload 403s
+    # (artifact-keeper#2649). The Azurite deployment and init Job already
+    # ride along in storage-emulators.yaml; when #2649 ships, uncomment and
+    # test-storage-backend-azure.sh starts running with no other changes.
+    # The Azurite key below is the PUBLIC well-known emulator key.
+    # AZURE_STORAGE_ACCOUNT: "devstoreaccount1"
+    # AZURE_STORAGE_CONTAINER: "ak-e2e"
+    # AZURE_STORAGE_ACCESS_KEY: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+    # AZURE_STORAGE_ENDPOINT: "http://storage-azurite:10000/devstoreaccount1"
+    # GCS deliberately absent: the backend has no endpoint override yet
+    # (artifact-keeper#2646). test-storage-backend-gcs.sh skips until then.
   persistence:
     size: 2Gi
   scanWorkspace:

--- a/scripts/create-test-namespace.sh
+++ b/scripts/create-test-namespace.sh
@@ -93,6 +93,25 @@ if [ ! -f "${CHART_DIR}/Chart.yaml" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Storage emulators (full-stack only)
+#
+# The backend registers its named object-storage backends (s3, azure) at
+# boot from env vars, so MinIO and Azurite must be up and their bucket/
+# container provisioned BEFORE the Helm install starts the backend pod.
+# values-test-full.yaml carries the matching S3_* / AZURE_STORAGE_* env.
+# ---------------------------------------------------------------------------
+
+if [ "$FULL_STACK" = true ]; then
+  echo "Deploying storage emulators (MinIO, Azurite)"
+  kubectl apply --namespace "$NAMESPACE" -f "${REPO_ROOT}/helm/storage-emulators.yaml"
+  kubectl rollout status --namespace "$NAMESPACE" deployment/storage-minio --timeout=120s
+  kubectl rollout status --namespace "$NAMESPACE" deployment/storage-azurite --timeout=120s
+  kubectl wait --namespace "$NAMESPACE" --for=condition=complete \
+    job/storage-minio-init job/storage-azurite-init --timeout=180s
+  echo "Storage emulators ready (bucket/container provisioned)"
+fi
+
+# ---------------------------------------------------------------------------
 # Helm install
 # ---------------------------------------------------------------------------
 
@@ -101,7 +120,7 @@ echo "Installing Helm release: ${RELEASE_NAME}"
 # Select base values file: --full-stack enables Trivy + scan workspace
 if [ "$FULL_STACK" = true ]; then
   VALUES_FILE="${REPO_ROOT}/helm/values-test-full.yaml"
-  echo "  Mode: full-stack (Trivy + scan workspace enabled)"
+  echo "  Mode: full-stack (Trivy + scan workspace + storage emulators enabled)"
 else
   VALUES_FILE="${REPO_ROOT}/helm/values-test.yaml"
 fi

--- a/tests/lib/storage-backend-suite.sh
+++ b/tests/lib/storage-backend-suite.sh
@@ -1,0 +1,182 @@
+# storage-backend-suite.sh - Shared object-storage backend E2E suite
+#
+# Runs the same artifact round-trip contract against a named storage backend
+# (s3, azure, gcs). Sourced by the thin per-backend wrappers in
+# tests/platform/test-storage-backend-*.sh.
+#
+# The suite probes GET /api/v1/admin/storage-backends first and skips every
+# test when the backend is not registered, so the gate stays green on
+# deployments without the storage emulators (values-test.yaml) and on
+# backends that cannot run against an emulator yet (gcs until
+# artifact-keeper#2646 ships an endpoint override, azure until
+# artifact-keeper#2649 fixes path-style Shared Key signing).
+#
+# Contract exercised per backend:
+#   1. Repository creation with an explicit storage_backend override
+#   2. Small artifact round-trip with checksum verification
+#   3. Multi-MiB artifact round-trip (exercises multipart/resumable upload
+#      paths and streaming downloads through the real HTTP client)
+#   4. Nested path upload
+#   5. Artifact delete reaches the object store (GET returns 404 after)
+#
+# Requires: curl, jq, shasum or sha256sum
+
+# Portable sha256 (mirrors test-maven-s3.sh).
+_sb_sha256() {
+  if command -v sha256sum > /dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# run_storage_backend_suite <backend-name>
+run_storage_backend_suite() {
+  local backend="$1"
+
+  begin_suite "storage-backend-${backend}"
+  auth_admin
+  setup_workdir
+
+  local repo_key="test-storage-${backend}-${RUN_ID}"
+
+  # -------------------------------------------------------------------------
+  # Backend availability probe
+  # -------------------------------------------------------------------------
+
+  begin_test "Backend '${backend}' is registered"
+  local registered=false
+  local resp
+  if resp=$(api_get "/api/v1/admin/storage-backends" 2>/dev/null); then
+    if echo "$resp" | jq -e --arg b "$backend" '
+        (if type == "array" then . elif (.backends | type == "array") then .backends
+         elif (.items | type == "array") then .items else [] end)
+        | map(if type == "string" then . else (.name // .key // .backend_type // "") end)
+        | index($b) != null' > /dev/null 2>&1; then
+      registered=true
+      pass
+    else
+      skip "storage backend '${backend}' not registered on this deployment"
+    fi
+  else
+    skip "admin storage-backends endpoint unavailable; cannot probe '${backend}'"
+  fi
+
+  if [ "$registered" != "true" ]; then
+    # Emit the remaining sections as explicit skips so the JUnit shape is
+    # stable across deployments (missing tests read as silent gaps).
+    for t in \
+        "Create generic repository on ${backend}" \
+        "Small artifact round-trip on ${backend}" \
+        "Multi-MiB artifact round-trip on ${backend}" \
+        "Nested path upload on ${backend}" \
+        "Artifact delete on ${backend}"; do
+      begin_test "$t"
+      skip "backend '${backend}' not registered"
+    done
+    end_suite
+    return 0
+  fi
+
+  # -------------------------------------------------------------------------
+  # 1. Repository with explicit storage_backend
+  # -------------------------------------------------------------------------
+
+  begin_test "Create generic repository on ${backend}"
+  local payload="{\"key\":\"${repo_key}\",\"name\":\"${repo_key}\",\"format\":\"generic\",\"repo_type\":\"local\",\"is_public\":true,\"storage_backend\":\"${backend}\"}"
+  local http_code
+  http_code=$(curl -s -o "${WORK_DIR}/create-repo.json" -w "%{http_code}" $CURL_TIMEOUT -X POST \
+    -H "$(auth_header)" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "${BASE_URL}/api/v1/repositories")
+  if [ "$http_code" = "201" ] || [ "$http_code" = "200" ]; then
+    pass
+  else
+    fail "repo create with storage_backend=${backend} returned ${http_code}: $(head -c 200 "${WORK_DIR}/create-repo.json")"
+    end_suite
+    return 1
+  fi
+
+  # -------------------------------------------------------------------------
+  # 2. Small artifact round-trip
+  # -------------------------------------------------------------------------
+
+  begin_test "Small artifact round-trip on ${backend}"
+  echo "storage backend ${backend} round-trip ${RUN_ID}" > "${WORK_DIR}/small.txt"
+  local small_sha
+  small_sha=$(_sb_sha256 "${WORK_DIR}/small.txt")
+  if api_upload "/api/v1/repositories/${repo_key}/artifacts/roundtrip/small.txt" \
+      "${WORK_DIR}/small.txt" "text/plain" > /dev/null \
+     && curl -sf $CURL_TIMEOUT -H "$(auth_header)" \
+          -o "${WORK_DIR}/small.down" \
+          "${BASE_URL}/api/v1/repositories/${repo_key}/download/roundtrip/small.txt" \
+     && [ "$(_sb_sha256 "${WORK_DIR}/small.down")" = "$small_sha" ]; then
+    pass
+  else
+    fail "small artifact upload/download/checksum failed on ${backend}"
+  fi
+
+  # -------------------------------------------------------------------------
+  # 3. Multi-MiB artifact round-trip (multipart / resumable upload paths)
+  # -------------------------------------------------------------------------
+
+  begin_test "Multi-MiB artifact round-trip on ${backend}"
+  # 16 MiB of random (incompressible) data: large enough to cross chunked
+  # upload thresholds, small enough for the per-test timeout budget.
+  head -c $((16 * 1024 * 1024)) /dev/urandom > "${WORK_DIR}/large.bin"
+  local large_sha
+  large_sha=$(_sb_sha256 "${WORK_DIR}/large.bin")
+  if api_upload "/api/v1/repositories/${repo_key}/artifacts/roundtrip/large.bin" \
+      "${WORK_DIR}/large.bin" "application/octet-stream" > /dev/null \
+     && curl -sf $CURL_TIMEOUT -H "$(auth_header)" \
+          -o "${WORK_DIR}/large.down" \
+          "${BASE_URL}/api/v1/repositories/${repo_key}/download/roundtrip/large.bin" \
+     && [ "$(_sb_sha256 "${WORK_DIR}/large.down")" = "$large_sha" ]; then
+    pass
+  else
+    fail "16MiB artifact upload/download/checksum failed on ${backend}"
+  fi
+
+  # -------------------------------------------------------------------------
+  # 4. Nested path upload
+  # -------------------------------------------------------------------------
+
+  begin_test "Nested path upload on ${backend}"
+  echo "nested ${backend} ${RUN_ID}" > "${WORK_DIR}/nested.txt"
+  if api_upload "/api/v1/repositories/${repo_key}/artifacts/a/b/c/d/nested.txt" \
+      "${WORK_DIR}/nested.txt" "text/plain" > /dev/null \
+     && curl -sf $CURL_TIMEOUT -H "$(auth_header)" -o /dev/null \
+          "${BASE_URL}/api/v1/repositories/${repo_key}/download/a/b/c/d/nested.txt"; then
+    pass
+  else
+    fail "nested path upload/download failed on ${backend}"
+  fi
+
+  # -------------------------------------------------------------------------
+  # 5. Delete reaches the object store
+  # -------------------------------------------------------------------------
+
+  begin_test "Artifact delete on ${backend}"
+  local del_code get_code
+  del_code=$(curl -s -o /dev/null -w "%{http_code}" $CURL_TIMEOUT -X DELETE \
+    -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/repositories/${repo_key}/artifacts/roundtrip/small.txt")
+  get_code=$(curl -s -o /dev/null -w "%{http_code}" $CURL_TIMEOUT \
+    -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/repositories/${repo_key}/download/roundtrip/small.txt")
+  if [ "$del_code" = "200" ] || [ "$del_code" = "204" ]; then
+    if [ "$get_code" = "404" ] || [ "$get_code" = "410" ]; then
+      pass
+    else
+      fail "deleted artifact still downloadable (GET ${get_code}) on ${backend}"
+    fi
+  else
+    fail "artifact delete returned ${del_code} on ${backend}"
+  fi
+
+  # Cleanup (best effort)
+  api_delete "/api/v1/repositories/${repo_key}" > /dev/null 2>&1 || true
+
+  end_suite
+}

--- a/tests/platform/test-storage-backend-azure.sh
+++ b/tests/platform/test-storage-backend-azure.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# test-storage-backend-azure.sh - Azure Blob backend E2E (Azurite emulator)
+#
+# Runs the shared storage-backend round-trip contract against the "azure"
+# backend registered from AZURE_STORAGE_* env vars. In the full-stack test
+# deploy the backend points at the in-namespace Azurite (well-known
+# devstoreaccount1 account) from helm/storage-emulators.yaml. Skips cleanly
+# when no azure backend is registered.
+#
+# Currently skipping in the gate: Shared Key signing is wrong for path-style
+# (Azurite) endpoints (artifact-keeper#2649), so the AZURE_* env in
+# values-test-full.yaml stays commented out until that fix ships. Verified
+# locally: with the env set, registration succeeds and uploads 403.
+#
+# Real-cloud auth (RBAC, SAS signatures) stays covered by the
+# credential-gated live tests in the main repo (azure_*_live_test.rs).
+#
+# Requires: curl, jq, shasum (or sha256sum)
+source "$(dirname "$0")/../lib/common.sh"
+source "$(dirname "$0")/../lib/storage-backend-suite.sh"
+
+run_storage_backend_suite "azure"

--- a/tests/platform/test-storage-backend-gcs.sh
+++ b/tests/platform/test-storage-backend-gcs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# test-storage-backend-gcs.sh - GCS backend E2E (fake-gcs-server emulator)
+#
+# Runs the shared storage-backend round-trip contract against the "gcs"
+# backend. Currently the backend cannot register a gcs backend against an
+# emulator (no endpoint override; artifact-keeper#2646), so this suite
+# reports every section as skipped. Once #2646 ships and
+# helm/storage-emulators.yaml grows a fake-gcs-server deployment plus GCS_*
+# env in values-test-full.yaml, this suite starts running with no further
+# changes here.
+#
+# Requires: curl, jq, shasum (or sha256sum)
+source "$(dirname "$0")/../lib/common.sh"
+source "$(dirname "$0")/../lib/storage-backend-suite.sh"
+
+run_storage_backend_suite "gcs"

--- a/tests/platform/test-storage-backend-s3.sh
+++ b/tests/platform/test-storage-backend-s3.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# test-storage-backend-s3.sh - S3 object-storage backend E2E (MinIO emulator)
+#
+# Runs the shared storage-backend round-trip contract against the "s3"
+# backend registered from S3_* env vars. In the full-stack test deploy the
+# backend points at the in-namespace MinIO from helm/storage-emulators.yaml.
+# Skips cleanly when no s3 backend is registered.
+#
+# Requires: curl, jq, shasum (or sha256sum)
+source "$(dirname "$0")/../lib/common.sh"
+source "$(dirname "$0")/../lib/storage-backend-suite.sh"
+
+run_storage_backend_suite "s3"


### PR DESCRIPTION
## Summary

Bridges the object-storage E2E gap: the release gate previously had no unconditionally-running cloud-backend coverage (the existing s3 scripts skip because nothing provisions MinIO). This adds self-hosted emulators to the full-stack deploy and a shared round-trip suite run against each named backend.

- `tests/lib/storage-backend-suite.sh`: shared contract — repo creation with `storage_backend` override, small and 16MiB checksum-verified round-trips (multipart/streaming paths), nested paths, delete-reaches-object-store. Probes `GET /api/v1/admin/storage-backends` and emits stable skips when a backend is not registered.
- `tests/platform/test-storage-backend-{s3,azure,gcs}.sh`: thin wrappers, discovered by the existing platform suite glob.
- `helm/storage-emulators.yaml`: MinIO + Azurite deployments/services with bucket/container init Jobs (pinned images; the azure-cli 2.72.0 / azurite 3.34.0 pair is signature-compatible, latest cli is not).
- `scripts/create-test-namespace.sh`: `--full-stack` applies emulators and waits for readiness before the Helm install (backend registers named backends at boot).
- `helm/values-test-full.yaml`: S3_* env pointing at MinIO. AZURE_* is present but commented out pending artifact-keeper#2649; GCS pending artifact-keeper#2646.

## Status per backend

| Backend | Emulator | Gate status |
|---|---|---|
| s3 | MinIO | runs live, 6/6 sections |
| azure | Azurite (deployed, unwired) | skips until artifact-keeper#2649 (path-style Shared Key signing) |
| gcs | none yet | skips until artifact-keeper#2646 (endpoint override) |

Writing the suites immediately caught the azure signing bug: with AZURE_* set, registration succeeds and every upload fails 403 AuthorizationFailure against Azurite. That finding is exactly the class of gap this coverage is for; issue filed with root cause (azure.rs canonicalized resource assumes hostname-style endpoints).

## Verification

Ran locally against backend:latest with podman-run MinIO/Azurite matching the manifests:

- s3: 6 passed, 0 failed, 0 skipped
- azure (env unwired, matching this PR): 6 skipped
- gcs: 6 skipped
- azure (env wired, pre-#2649): registration OK, uploads 403 — confirming the skip-gating is correct

bash -n on all scripts; emulator manifests validated as YAML.