### PR TITLE
ci(release-gate): optional backend_digest to pin deploys to the candidate manifest digest

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: 'latest'
+      backend_digest:
+        description: 'Manifest-list digest (sha256:...) to pin the backend deploy to. Empty = tag only.'
+        required: false
+        type: string
+        default: ''
       test_suite:
         description: Test suite to run
         required: false
@@ -62,6 +67,11 @@ on:
         required: false
         type: string
         default: 'latest'
+      backend_digest:
+        description: 'Manifest-list digest (sha256:...) to pin the backend deploy to. Empty = tag only.'
+        required: false
+        type: string
+        default: ''
       test_suite:
         required: false
         type: string
@@ -188,6 +198,7 @@ jobs:
       - name: Run clean-install smoke test
         env:
           BACKEND_TAG: ${{ inputs.backend_tag }}
+          BACKEND_DIGEST: ${{ inputs.backend_digest }}
           WEB_TAG: ${{ inputs.web_tag }}
           # Pin iac chart ref so the gate validates against the chart
           # version that ships with the release. Defaults to `main` when
@@ -204,9 +215,12 @@ jobs:
           # attempt (re-runs increment run_attempt). Avoids RUN_ID
           # collisions when a job is retried.
           RUN_ID="${{ github.run_id }}-${{ github.run_attempt }}"
+          # Compose the digest-pinned image ref. Empty BACKEND_DIGEST =>
+          # plain tag (byte-identical to the pre-digest behaviour).
+          BACKEND_TAG_PINNED="${BACKEND_TAG}${BACKEND_DIGEST:+@${BACKEND_DIGEST}}"
           ./scripts/clean-install-smoke.sh \
             --run-id "${RUN_ID}" \
-            --backend-tag "${BACKEND_TAG}" \
+            --backend-tag "${BACKEND_TAG_PINNED}" \
             --web-tag "${WEB_TAG}" \
             --iac-ref "${IAC_REF}" \
             --timeout 300
@@ -274,15 +288,19 @@ jobs:
       - name: Run clean-install-smoke with all deps enabled
         env:
           BACKEND_TAG: ${{ inputs.backend_tag }}
+          BACKEND_DIGEST: ${{ inputs.backend_digest }}
           WEB_TAG: ${{ inputs.web_tag }}
           IAC_REF: ${{ inputs.iac_ref || 'main' }}
           GHCR_DOCKER_CONFIG: ${{ secrets.GHCR_DOCKER_CONFIG }}
         run: |
           chmod +x tests/release-gate/clean-install-smoke-with-deps.sh
           RUN_ID="${{ github.run_id }}-${{ github.run_attempt }}-deps"
+          # Compose the digest-pinned image ref. Empty BACKEND_DIGEST =>
+          # plain tag (byte-identical to the pre-digest behaviour).
+          BACKEND_TAG_PINNED="${BACKEND_TAG}${BACKEND_DIGEST:+@${BACKEND_DIGEST}}"
           ./tests/release-gate/clean-install-smoke-with-deps.sh \
             --run-id "${RUN_ID}" \
-            --backend-tag "${BACKEND_TAG}" \
+            --backend-tag "${BACKEND_TAG_PINNED}" \
             --web-tag "${WEB_TAG}" \
             --iac-ref "${IAC_REF}" \
             --timeout 600
@@ -334,6 +352,7 @@ jobs:
       - name: Run chart-upgrade-smoke
         env:
           BACKEND_TAG: ${{ inputs.backend_tag }}
+          BACKEND_DIGEST: ${{ inputs.backend_digest }}
           WEB_TAG: ${{ inputs.web_tag }}
           IAC_REF: ${{ inputs.iac_ref || 'main' }}
           GHCR_DOCKER_CONFIG: ${{ secrets.GHCR_DOCKER_CONFIG }}
@@ -360,10 +379,15 @@ jobs:
           # the script; pinned here so the chart-template upgrade path
           # exercises the actual prev->current chart diff (issue #54).
           PREVIOUS_IAC_REF="artifact-keeper-${PREVIOUS_TAG}"
+          # Compose the digest-pinned image ref for the TARGET side only.
+          # --previous-tag stays a plain tag (it pins the previously
+          # released image, not the candidate). Empty BACKEND_DIGEST =>
+          # plain tag (byte-identical to the pre-digest behaviour).
+          BACKEND_TAG_PINNED="${BACKEND_TAG}${BACKEND_DIGEST:+@${BACKEND_DIGEST}}"
           ./tests/release-gate/chart-upgrade-smoke.sh \
             --run-id "${RUN_ID}" \
             --previous-tag "${PREVIOUS_TAG}" \
-            --backend-tag "${BACKEND_TAG}" \
+            --backend-tag "${BACKEND_TAG_PINNED}" \
             --web-tag "${WEB_TAG}" \
             --previous-web-tag "${PREVIOUS_WEB_TAG}" \
             --iac-ref "${IAC_REF}" \
@@ -416,15 +440,19 @@ jobs:
         env:
           RUN_ID: ${{ steps.setup.outputs.run_id }}
           BACKEND_TAG: ${{ inputs.backend_tag }}
+          BACKEND_DIGEST: ${{ inputs.backend_digest }}
           WEB_TAG: ${{ inputs.web_tag }}
         run: |
           chmod +x scripts/create-test-namespace.sh
+          # Compose the digest-pinned image ref. Empty BACKEND_DIGEST =>
+          # plain tag (byte-identical to the pre-digest behaviour).
+          BACKEND_TAG_PINNED="${BACKEND_TAG}${BACKEND_DIGEST:+@${BACKEND_DIGEST}}"
           # --full-stack enables Trivy + scan workspace so the security
           # tests actually exercise the scanner instead of false-passing
           # against a no-scanner stack (#888 silent-success class).
           ./scripts/create-test-namespace.sh \
             --run-id "${RUN_ID}" \
-            --backend-tag "${BACKEND_TAG}" \
+            --backend-tag "${BACKEND_TAG_PINNED}" \
             --web-tag "${WEB_TAG}" \
             --full-stack
 
@@ -453,6 +481,37 @@ jobs:
             deployment/artifact-keeper-trivy --timeout=180s
           kubectl -n "${NAMESPACE}" wait --for=condition=Available \
             deployment/artifact-keeper-trivy --timeout=60s
+
+      - name: Assert deployed pod runs the pinned digest
+        # Only runs when the caller pinned a digest; the empty-default
+        # path (routine dispatches / old callers) skips this entirely.
+        if: inputs.backend_digest != ''
+        env:
+          RUN_ID: ${{ steps.setup.outputs.run_id }}
+          BACKEND_DIGEST: ${{ inputs.backend_digest }}
+        run: |
+          NAMESPACE="test-${RUN_ID}"
+          # app.kubernetes.io/component=backend is a stable selector label
+          # on the backend pod template (iac chart _helpers.tpl
+          # backend.selectorLabels), matching the deployment
+          # artifact-keeper-backend the deploy step waits on.
+          IMGID=$(kubectl -n "${NAMESPACE}" get pods \
+                    -l app.kubernetes.io/component=backend \
+                    -o jsonpath='{.items[0].status.containerStatuses[0].imageID}')
+          echo "backend pod imageID: ${IMGID}"
+          echo "pinned digest:       ${BACKEND_DIGEST}"
+          # Substring match: the runtime may report the per-arch PLATFORM
+          # digest in imageID rather than the manifest-list digest passed
+          # here. If a drill shows that, the caller (resolve-candidate-digest
+          # in artifact-keeper#2696 PR 1) can instead pass the amd64
+          # platform digest; the pull itself is content-addressed either way.
+          case "${IMGID}" in
+            *"${BACKEND_DIGEST}"*)
+              echo "OK: pod imageID contains the pinned digest";;
+            *)
+              echo "::error::pod imageID ${IMGID} does not contain pinned ${BACKEND_DIGEST}"
+              exit 1;;
+          esac
 
   # -------------------------------------------------------------------
   # Real-flow smoke (issue #45)
@@ -1897,17 +1956,24 @@ jobs:
 
       - name: Deploy mesh topology
         id: mesh-deploy
+        env:
+          BACKEND_TAG: ${{ inputs.backend_tag }}
+          BACKEND_DIGEST: ${{ inputs.backend_digest }}
+          WEB_TAG: ${{ inputs.web_tag }}
         run: |
           MESH_RUN_ID="${RUN_ID}"
           chmod +x scripts/create-test-namespace.sh
+          # Compose the digest-pinned image ref. Empty BACKEND_DIGEST =>
+          # plain tag (byte-identical to the pre-digest behaviour).
+          BACKEND_TAG_PINNED="${BACKEND_TAG}${BACKEND_DIGEST:+@${BACKEND_DIGEST}}"
 
           # Deploy 4 mesh instances
           for i in main peer1 peer2 peer3; do
             MESH_NS="test-${MESH_RUN_ID}-mesh-${i}"
             ./scripts/create-test-namespace.sh \
               --run-id "${MESH_RUN_ID}-mesh-${i}" \
-              --backend-tag "${{ inputs.backend_tag }}" \
-              --web-tag "${{ inputs.web_tag }}" \
+              --backend-tag "${BACKEND_TAG_PINNED}" \
+              --web-tag "${WEB_TAG}" \
               --values helm/values-test-mesh.yaml
           done
 


### PR DESCRIPTION
## What / why

Test-repo half of the **candidate-digest release gate** (FixSpec A, PR 2 of 2). Tracks `artifact-keeper/artifact-keeper#2696`.

Today the release job's gate deploys `:dev` (and `web:latest`), so the k8s gate never proves it tested the exact bytes that `docker-publish` published for the tag. This PR gives `release-gate.yml` the ability to pin the backend deploy to a specific manifest-list digest, so the caller (the `artifact-keeper` PR that follows) can point the gate at the published candidate `@sha256:` digest.

## Change

- **New optional input `backend_digest`** (empty-string default) added to **both** `workflow_dispatch.inputs` and `workflow_call.inputs`:
  `description: 'Manifest-list digest (sha256:...) to pin the backend deploy to. Empty = tag only.'`, `required: false`, `type: string`, `default: ''`.
- **At each backend deploy site**, a `BACKEND_DIGEST: ${{ inputs.backend_digest }}` env is added beside the existing `BACKEND_TAG`, and a shell line composes the pinned ref just before the deploy call:
  ```bash
  BACKEND_TAG_PINNED="${BACKEND_TAG}${BACKEND_DIGEST:+@${BACKEND_DIGEST}}"
  ```
  which is then passed to `--backend-tag`. **No deploy shell script or Helm chart change** — the OCI ref grammar accepts `name:tag@sha256:digest`.
- **Pod-digest assertion** in the `deploy` job (guarded `if: inputs.backend_digest != ''`), after the stack-ready wait: reads the backend pod's `containerStatuses[0].imageID` (selector `app.kubernetes.io/component=backend`, a stable selector label on the backend pod template) and fails the job if it does not contain the pinned digest.

### Pinned sites
| job | site |
|---|---|
| `clean-install-smoke` | `--backend-tag` |
| `clean-install-smoke-with-deps` | `--backend-tag` |
| `chart-upgrade-smoke` | `--backend-tag` (**target side only**; `--previous-tag` stays a plain tag) |
| `deploy` | `--backend-tag` + new pod-digest assertion |
| `mesh-tests` deploy loop | switched inline `${{ inputs.backend_tag }}` to the env + pinned form |

### Deliberately NOT pinned (kept on the plain tag, per FixSpec A3.2b)
- `version-set-integrity` — `verify-image-set.sh` probes `/v2/<name>/manifests/<tag>`; it must receive the bare tag.
- compatibility-branch inference (`AK_BACKEND_BRANCH`) — prefix-matches the version (`1.1.`/`1.2.`); a digest would break the match.

## Empty-default path is byte-identical

With `backend_digest=''` (every existing dispatch / old caller), `${BACKEND_DIGEST:+@${BACKEND_DIGEST}}` expands to nothing, so `${BACKEND_TAG}${BACKEND_DIGEST:+@...}` == `${BACKEND_TAG}` exactly. The pod-digest assertion is skipped by its `if:` guard. Routine runs behave exactly as they do today.

## Verification done here
- `actionlint` on the changed workflow: **no new findings** vs. the `main` baseline (the pre-existing `ak-e2e-runners` custom-runner-label notes and shellcheck style notes are unchanged in type and count).
- Shell-expansion proof of the empty-default equivalence (above).

The positive/negative digest drills (FixSpec A6.1/A6.2) require dispatching against published images and will be run by the release engineer after this merges. This PR does not attempt to dispatch CI.

## Merge ordering
**PR 2 of 2 — the `artifact-keeper` caller PR (the `resolve-candidate-digest` job + gate rewire) follows and must merge AFTER this.** The new input is optional, so old-caller/new-gate is safe; new-caller/old-gate would fail on an unknown input.

## Checklist
- [x] No deploy-script or Helm-chart changes (workflow-only)
- [x] Empty-default path byte-identical to current behaviour
- [x] `actionlint` introduces no new findings
- [x] DO-NOT-PIN sites (`version-set-integrity`, compat inference) left on the plain tag
- [x] Pod-digest assertion guarded on non-empty `backend_digest`