### PR TITLE
test(dtf): 1.7.0 backfill batch-1 tiers (5 merged fixes: #2721/#2723/#2562/#2754/#2790)

### DIFF
--- a/deploy-test/harness/run.sh
+++ b/deploy-test/harness/run.sh
@@ -257,11 +257,15 @@ case "$CMD" in
     # Base tiers, then the 1.6.1 feature/fix coverage tiers (ci-token-basic
     # #2786, virtual-usage #2785, maven-files-casing #2706/#2707, backup-reclaim
     # #2787, nexus-go-apt #2784, nexus-group-virtual #2783, pypi-contenttype
-    # #2801, ldaps #2782).
+    # #2801, ldaps #2782), then the 1.7.0 backfill batch-1 tiers
+    # (openapi-signing-tags #2721, maven-grouped-name #2723,
+    # debian-encoded-separator #2562, cran-rubygems-download-url #2754,
+    # backup-custom-name #2790).
     for t in smoke isolation migration proxy-egress sso native-client upgrade supply-chain dos format-conformance \
              ci-token-basic virtual-usage maven-files-casing backup-reclaim nexus-go-apt nexus-group-virtual pypi-contenttype ldaps \
              vvc3-scoped-admin qcmj-webhook-authz f7qf-peer-authz 5f2q-upload-scope qxxr-refresh-race \
-             virtual-no-transfer proxy-upstream-url oidc-group-sync; do
+             virtual-no-transfer proxy-upstream-url oidc-group-sync \
+             openapi-signing-tags maven-grouped-name debian-encoded-separator cran-rubygems-download-url backup-custom-name; do
       run_tier "$t" || overall=1
     done
     exit "$overall" ;;

--- a/deploy-test/harness/tiers/backup-custom-name/manifest
+++ b/deploy-test/harness/tiers/backup-custom-name/manifest
@@ -1,0 +1,28 @@
+# DTF tier manifest: backup-custom-name  (#2790 / PR #2840)
+# Profile-set: filesystem / single. The backup archive's storage key is chosen
+# by BackupService before any bytes are written and is recorded in the `backups`
+# row's `storage_path`; the naming behaviour is backend-agnostic, so this runs
+# on the default filesystem overlay and is asserted directly from the DB row.
+#
+# The feature/bug (#2790): CreateBackupRequest gained an optional `name` field
+# so operators can label an archive instead of the fixed `{uuid}.tar.gz`. The
+# name is sanitized ([A-Za-z0-9._-]; path separators, '..', whitespace, control
+# chars rejected) and a short unique suffix appended so distinct backups sharing
+# a label never collide. When no name is given the historical `{uuid}` name is
+# preserved. Pre-#2790 the `name` field does not exist, so it is ignored: a
+# custom name never reaches the filename and an unsafe name is silently accepted
+# (the archive still lands under the default uuid name).
+#
+# Oracle (oracle.sh) is the discriminating gate:
+#   * POST /api/v1/admin/backups {"name":"<label>"} -> the created `backups`
+#     row's storage_path filename must contain "<label>".
+#     Pre-#2790: storage_path is `.../{uuid}.tar.gz` (no label) -> FAIL.
+#   * POST /api/v1/admin/backups {"name":"<unsafe>"} (path separator / '..')
+#     must be rejected 400.
+#     Pre-#2790: the unknown field is ignored and the request is accepted -> FAIL.
+#
+# RATE_LIMIT_ENABLED=false: the oracle drives admin login + several admin
+# create-backup calls back-to-back; the base default (ON) could throttle them.
+PROFILES="storage.filesystem"
+ORACLE="oracle.sh"
+RATE_LIMIT_ENABLED="false"

--- a/deploy-test/harness/tiers/backup-custom-name/oracle.sh
+++ b/deploy-test/harness/tiers/backup-custom-name/oracle.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tiers/backup-custom-name/oracle.sh — custom backup archive name gate
+# (#2790 / PR #2840), filesystem storage.
+# =============================================================================
+# Discriminating oracle for the operator-supplied backup archive name.
+#
+# Background (backup_service.rs::create + resolve_backup_filename): the archive
+# storage key is chosen at create time and stored on the `backups` row as
+# `storage_path`. #2790 adds an optional `name` to CreateBackupRequest: when set
+# it becomes the identifying part of the filename (`{name}-{suffix}.tar.gz`);
+# when omitted the historical `{uuid}.tar.gz` name is kept. The name is
+# sanitized to `[A-Za-z0-9._-]` — path separators, `..`, whitespace and control
+# characters are rejected with 400.
+#
+# Asserts (DB + HTTP):
+#   POSITIVE   — POST create-backup with a custom label -> the row's
+#                storage_path filename CONTAINS the label.
+#                Pre-#2790: the `name` field is ignored -> storage_path is
+#                `.../{uuid}.tar.gz` (no label) -> FAIL.
+#   REJECTION  — POST create-backup with an unsafe label (path separator) -> 400.
+#                Pre-#2790: the unknown field is ignored -> the request is
+#                accepted (2xx) -> FAIL.
+#   CONTROL    — POST create-backup with NO name -> still succeeds and the
+#                default `{uuid}.tar.gz` name is used (feature is additive).
+#
+# run.sh exported BASE_URL, DB_CONTAINER, ADMIN_PASS, RELEASE_GATE=1,
+# JUNIT_OUTPUT_DIR, COMMON_SH.
+# =============================================================================
+set -uo pipefail
+: "${BASE_URL:?}"; : "${DB_CONTAINER:?}"; : "${COMMON_SH:?}"; : "${ADMIN_PASS:?}"
+
+# shellcheck source=/dev/null
+source "$COMMON_SH"
+
+BASE="$BASE_URL"
+DBC="$DB_CONTAINER"
+SUF="$RANDOM$RANDOM"
+LABEL="dtflabel$SUF"          # sanitizer-safe custom name
+UNSAFE="../evil$SUF"          # path-traversal name; must be rejected
+
+jqr(){ jq -r "$1" 2>/dev/null; }
+login(){ curl -s -X POST "$BASE/api/v1/auth/login" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$1\",\"password\":\"$2\"}" | jqr '.access_token // .token // empty'; }
+psql_q(){ docker exec "$DBC" psql -U registry -d artifact_registry -tAc "$1" 2>/dev/null; }
+
+begin_suite "backup-custom-name-filesystem"
+
+TOK=$(login admin "$ADMIN_PASS")
+if [ -z "$TOK" ]; then
+  begin_test "admin login"; fail "admin login failed at $BASE"; end_suite; exit 1
+fi
+
+# ---------------------------------------------------------------------------
+begin_test "POST create-backup with a custom name yields an archive filename containing that name (#2790)"
+CREATE=$(curl -s -X POST "$BASE/api/v1/admin/backups" -H "Authorization: Bearer $TOK" \
+  -H 'Content-Type: application/json' -d "{\"backup_type\":\"full\",\"name\":\"$LABEL\"}")
+BID=$(echo "$CREATE" | jqr '.id // empty')
+echo "-- create resp id: '${BID:-<none>}'"
+if [ -z "$BID" ]; then
+  fail "create backup (custom name) failed: $CREATE"
+else
+  SP=$(psql_q "SELECT storage_path FROM backups WHERE id='$BID';" | tr -d '[:space:]')
+  echo "-- storage_path: '$SP'"
+  if echo "$SP" | grep -q "$LABEL"; then
+    pass
+  else
+    fail "storage_path '$SP' does not contain the custom label '$LABEL' (pre-#2790 the name field is ignored and the key is the default {uuid}.tar.gz)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+begin_test "POST create-backup with an unsafe name (path separator) is rejected 400 (#2790)"
+UHTTP=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/api/v1/admin/backups" \
+  -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' \
+  -d "{\"backup_type\":\"full\",\"name\":\"$UNSAFE\"}")
+echo "-- unsafe-name create -> HTTP $UHTTP"
+if [ "$UHTTP" = "400" ]; then
+  pass
+else
+  fail "unsafe backup name expected HTTP 400, got $UHTTP (pre-#2790 the unknown 'name' field is ignored and the request is accepted)"
+fi
+
+# ---------------------------------------------------------------------------
+begin_test "CONTROL: create-backup with NO name still succeeds with the default {uuid}.tar.gz key (additive feature)"
+DEF=$(curl -s -X POST "$BASE/api/v1/admin/backups" -H "Authorization: Bearer $TOK" \
+  -H 'Content-Type: application/json' -d '{"backup_type":"full"}')
+DBID=$(echo "$DEF" | jqr '.id // empty')
+DSP=$(psql_q "SELECT storage_path FROM backups WHERE id='$DBID';" | tr -d '[:space:]')
+echo "-- default create id='${DBID:-<none>}' storage_path='$DSP'"
+if [ -n "$DBID" ] && echo "$DSP" | grep -qE 'backups/.*\.tar\.gz$' && ! echo "$DSP" | grep -q "$LABEL"; then
+  pass
+else
+  fail "default (no-name) backup did not produce a default .tar.gz key (id='$DBID', storage_path='$DSP')"
+fi
+
+end_suite

--- a/deploy-test/harness/tiers/cran-rubygems-download-url/manifest
+++ b/deploy-test/harness/tiers/cran-rubygems-download-url/manifest
@@ -1,0 +1,31 @@
+# DTF tier manifest: cran-rubygems-download-url  (#2754 / PR #2839)
+# Profile-set: filesystem / single. The advertised coordinates are computed at
+# index-serve time from the artifact's stored filename; this is storage-agnostic
+# and the download route resolves by filename suffix, so this runs on the
+# default filesystem overlay.
+#
+# The bug (#2754): CRAN PACKAGES and RubyGems specs.4.8.gz indices carry only
+# name/version, and the client reconstructs the download filename
+# ({name}_{version}.tar.gz / {name}-{version}.gem). A package pushed through the
+# generic chunked-upload flow is stored at its bare filename with the WHOLE
+# basename as `name` and a `sha256-<prefix>` fallback `version`, so the emitted
+# coordinates made the client reconstruct an unresolvable path -> 404 even
+# though the artifact was present. The fix derives the advertised coordinates
+# from the actual stored filename.
+#
+# Oracle (oracle.sh) is the discriminating gate. For BOTH formats it does a
+# real generic (bare-path) chunked upload, reads the SERVED index, reconstructs
+# the client download path from the index coordinates, and GETs it:
+#   CRAN     — read src/contrib/PACKAGES (DCF text), rebuild
+#              {Package}_{Version}.tar.gz, GET it.
+#   RubyGems — read specs.4.8.gz (Marshal 4.8, gzip), rebuild
+#              {name}-{version}.gem from the advertised coordinates, GET it.
+#   Fixed:     the reconstructed path resolves 200.
+#   Pre-#2754: the index advertises the bare basename + sha256 fallback, so the
+#              reconstructed path 404s -> FAIL.
+#
+# RATE_LIMIT_ENABLED=false: the oracle drives admin login + two generic chunked
+# uploads (session + chunk + complete) + index/download GETs back-to-back.
+PROFILES="storage.filesystem"
+ORACLE="oracle.sh"
+RATE_LIMIT_ENABLED="false"

--- a/deploy-test/harness/tiers/cran-rubygems-download-url/oracle.sh
+++ b/deploy-test/harness/tiers/cran-rubygems-download-url/oracle.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tiers/cran-rubygems-download-url/oracle.sh — bare-path index download-URL
+# coherence gate (#2754 / PR #2839), filesystem storage.
+# =============================================================================
+# Discriminating oracle: a CRAN tarball and a RubyGems gem pushed through the
+# generic (bare-path) chunked-upload flow must advertise a RESOLVABLE download
+# path in their respective indices.
+#
+# Background (cran.rs::source_index_coordinates, rubygems.rs::spec_index_
+# coordinates): a bare-path generic upload is stored with the whole basename as
+# `name` and a `sha256-<prefix>` fallback `version`. Emitting those raw columns
+# in the index makes the client reconstruct `{basename}_{sha256-…}.tar.gz` /
+# `{basename}-{sha256-…}.gem`, which the suffix-resolving download route can
+# never serve. #2754 re-derives the advertised coordinates from the stored
+# filename so the reconstructed path matches the served route.
+#
+# Method (per format): generic chunked upload at a BARE filename path, read the
+# served index, reconstruct the client download path FROM THE INDEX, GET it.
+#   Fixed:     reconstructed path -> 200.
+#   Pre-#2754: index advertises basename + sha256 -> reconstructed path -> 404.
+#
+# run.sh exported BASE_URL, DB_CONTAINER, ADMIN_PASS, RELEASE_GATE=1,
+# JUNIT_OUTPUT_DIR, COMMON_SH.
+# =============================================================================
+set -uo pipefail
+: "${BASE_URL:?}"; : "${DB_CONTAINER:?}"; : "${COMMON_SH:?}"; : "${ADMIN_PASS:?}"
+
+# shellcheck source=/dev/null
+source "$COMMON_SH"
+
+BASE="$BASE_URL"
+SUF="$RANDOM$RANDOM"
+
+jqr(){ jq -r "$1" 2>/dev/null; }
+login(){ curl -s -X POST "$BASE/api/v1/auth/login" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$1\",\"password\":\"$2\"}" | jqr '.access_token // .token // empty'; }
+code(){ curl -s -o /dev/null -w '%{http_code}' "$@"; }
+
+if command -v sha256sum >/dev/null 2>&1; then sha(){ sha256sum "$1" | awk '{print $1}'; }
+else sha(){ shasum -a 256 "$1" | awk '{print $1}'; }; fi
+
+# generic_chunked_upload <token> <repo_key> <artifact_path> <file>
+# Bare-path generic upload (NO artifact_version -> the server derives the
+# sha256-<prefix> fallback that is the #2754 bug condition). Echoes finalize
+# HTTP code on the last line.
+generic_chunked_upload(){
+  local tok="$1" repo="$2" path="$3" src="$4"
+  local size csum sess body last
+  size=$(wc -c <"$src"); csum=$(sha "$src")
+  body=$(curl -s -X POST "$BASE/api/v1/uploads" -H "Authorization: Bearer $tok" \
+    -H 'Content-Type: application/json' -d "{
+      \"repository_key\":\"$repo\",
+      \"artifact_path\":\"$path\",
+      \"total_size\":$size,
+      \"checksum_sha256\":\"$csum\",
+      \"chunk_size\":1048576
+    }")
+  sess=$(echo "$body" | jqr '.session_id // .id // empty')
+  if [ -z "$sess" ]; then echo "SESSION-FAIL: $body" >&2; echo "000"; return; fi
+  last=$((size-1))
+  curl -s -o /dev/null -X PATCH "$BASE/api/v1/uploads/$sess" \
+    -H "Authorization: Bearer $tok" -H 'Content-Type: application/octet-stream' \
+    -H "Content-Range: bytes 0-$last/$size" --data-binary "@$src" >/dev/null
+  curl -s -o /dev/null -w '%{http_code}' -X PUT "$BASE/api/v1/uploads/$sess/complete" \
+    -H "Authorization: Bearer $tok" -H 'Content-Type: application/json'
+}
+
+begin_suite "cran-rubygems-download-url-filesystem"
+
+TOK=$(login admin "$ADMIN_PASS")
+if [ -z "$TOK" ]; then
+  begin_test "admin login"; fail "admin login failed at $BASE"; end_suite; exit 1
+fi
+AUTH=(-H "Authorization: Bearer $TOK")
+
+# ===========================================================================
+# CRAN
+# ===========================================================================
+begin_test "CRAN: bare-path generic upload advertises a resolvable PACKAGES download path (#2754)"
+
+CRAN_REPO="cranbf$SUF"
+CRAN_PKG="cranpkg$SUF"
+CRAN_FILE="${CRAN_PKG}_1.0.0.tar.gz"     # {name}_{version}.tar.gz convention
+curl -s -X POST "$BASE/api/v1/repositories" "${AUTH[@]}" -H 'Content-Type: application/json' \
+  -d "{\"key\":\"$CRAN_REPO\",\"name\":\"$CRAN_REPO\",\"format\":\"cran\",\"repo_type\":\"local\"}" >/dev/null
+
+TGZ="$(mktemp --suffix=.tar.gz)"
+TMPD="$(mktemp -d)"; echo "cran payload $SUF" >"$TMPD/DESCRIPTION"
+tar -czf "$TGZ" -C "$TMPD" DESCRIPTION 2>/dev/null
+
+# BARE path (just the filename) -> stored name = basename, version = sha256 fallback.
+CFIN=$(generic_chunked_upload "$TOK" "$CRAN_REPO" "$CRAN_FILE" "$TGZ")
+echo "-- CRAN bare-path upload finalize -> HTTP $CFIN"
+
+CRAN_OK=1
+if [ "$CFIN" != "200" ] && [ "$CFIN" != "201" ]; then
+  CRAN_OK=0
+  fail "CRAN generic upload did not finalize (HTTP $CFIN); cannot evaluate the gate"
+else
+  PKGS=$(curl -s "${AUTH[@]}" "$BASE/cran/$CRAN_REPO/src/contrib/PACKAGES")
+  echo "-- served PACKAGES index:"; echo "$PKGS" | sed 's/^/     /'
+  ADV_PKG=$(echo "$PKGS" | awk -F': *' '/^Package:/{print $2; exit}' | tr -d '\r')
+  ADV_VER=$(echo "$PKGS" | awk -F': *' '/^Version:/{print $2; exit}' | tr -d '\r')
+  echo "-- advertised coordinates: Package='$ADV_PKG' Version='$ADV_VER'"
+  # Client reconstructs {Package}_{Version}.tar.gz from the index.
+  RECON="${ADV_PKG}_${ADV_VER}.tar.gz"
+  DL=$(code "${AUTH[@]}" "$BASE/cran/$CRAN_REPO/src/contrib/$RECON")
+  echo "-- reconstructed download '$RECON' -> HTTP $DL"
+  if [ "$DL" = "200" ]; then
+    pass
+  else
+    CRAN_OK=0
+    fail "CRAN index-reconstructed download '$RECON' -> HTTP $DL (expected 200). Pre-#2754 the index advertises the bare basename + sha256 fallback -> 404"
+  fi
+fi
+rm -rf "$TGZ" "$TMPD"
+
+# ===========================================================================
+# RubyGems
+# ===========================================================================
+begin_test "RubyGems: bare-path generic upload advertises a resolvable specs.4.8.gz download path (#2754)"
+
+GEM_REPO="gembf$SUF"
+GEM_NAME="rubypkg$SUF"
+GEM_FILE="${GEM_NAME}-1.0.0.gem"          # {name}-{version}.gem convention
+curl -s -X POST "$BASE/api/v1/repositories" "${AUTH[@]}" -H 'Content-Type: application/json' \
+  -d "{\"key\":\"$GEM_REPO\",\"name\":\"$GEM_REPO\",\"format\":\"rubygems\",\"repo_type\":\"local\"}" >/dev/null
+
+# A .gem is a tar; content is irrelevant to suffix-resolved download. Build a
+# small tar so the bytes are a plausible gem envelope.
+GEM="$(mktemp --suffix=.gem)"
+GTMP="$(mktemp -d)"; echo "gem payload $SUF" >"$GTMP/metadata.gz"
+tar -cf "$GEM" -C "$GTMP" metadata.gz 2>/dev/null
+
+GFIN=$(generic_chunked_upload "$TOK" "$GEM_REPO" "$GEM_FILE" "$GEM")
+echo "-- RubyGems bare-path upload finalize -> HTTP $GFIN"
+
+if [ "$GFIN" != "200" ] && [ "$GFIN" != "201" ]; then
+  fail "RubyGems generic upload did not finalize (HTTP $GFIN); cannot evaluate the gate"
+else
+  SPECS="$(mktemp)"
+  curl -s "${AUTH[@]}" "$BASE/gems/$GEM_REPO/specs.4.8.gz" -o "$SPECS"
+  # Marshal 4.8 embeds the name/version strings as literal bytes; decompress and
+  # read them. Order per triple is: <name> "Gem::Version" <version> "ruby".
+  DEC=$(gunzip -c "$SPECS" 2>/dev/null | strings -n 3)
+  echo "-- decompressed specs tokens:"; echo "$DEC" | sed 's/^/     /'
+  # Advertised name: the token beginning with our unique gem-name prefix.
+  # `strings` may merge the Marshal length byte onto the name line when that
+  # byte is printable (longer names), so extract the token rather than the line.
+  ADV_NAME=$(echo "$DEC" | grep -oE "${GEM_NAME}[A-Za-z0-9._-]*" | head -1)
+  # Advertised version: the token on the line AFTER the "Gem::Version" marker.
+  ADV_GVER=$(echo "$DEC" | awk '/Gem::Version/{getline; print; exit}')
+  echo "-- advertised coordinates: name='$ADV_NAME' version='$ADV_GVER'"
+  RECON="${ADV_NAME}-${ADV_GVER}.gem"
+  DL=$(code "${AUTH[@]}" "$BASE/gems/$GEM_REPO/gems/$RECON")
+  echo "-- reconstructed download '$RECON' -> HTTP $DL"
+  if [ "$DL" = "200" ] && ! echo "$ADV_GVER" | grep -q 'sha256-'; then
+    pass
+  else
+    fail "RubyGems index-reconstructed download '$RECON' -> HTTP $DL (expected 200, version must not be a sha256 fallback). Pre-#2754 the index advertises the bare basename + sha256 -> 404"
+  fi
+  rm -f "$SPECS"
+fi
+rm -rf "$GEM" "$GTMP"
+
+end_suite

--- a/deploy-test/harness/tiers/debian-encoded-separator/manifest
+++ b/deploy-test/harness/tiers/debian-encoded-separator/manifest
@@ -1,0 +1,33 @@
+# DTF tier manifest: debian-encoded-separator  (#2562 / PR #2838)
+# Profile-set: filesystem / single. The proxy path-normalization belt runs in
+# the Debian remote-proxy handler before any upstream fetch; it is storage- and
+# upstream-agnostic. The tier creates a Debian REMOTE repo pointing at a
+# deliberately unreachable (non-resolving `.invalid`) upstream, so a request the
+# belt lets through fails fast at the fetch with 502 Bad Gateway, while a request
+# the belt rejects returns 404 — the observable that discriminates the fix.
+#
+# The bug (#2562): the Debian remote-proxy gate (normalized_debian_relpath) did
+# not reject percent-encoded path separators (%2f/%2F for '/', %5c/%5C for '\').
+# A nonstandard upstream that decodes them could split the P2 gate from the
+# fetch. The fix adds a default-on belt that refuses any request whose
+# (once-decoded) proxy path carries an encoded separator, mirroring the existing
+# control-byte belt.
+#
+# Because axum percent-decodes the catch-all path segment once, a client must
+# DOUBLE-encode (%252f / %255c) for the handler to see a literal %2f / %5c; that
+# is exactly the normalization/traversal probe the belt targets.
+#
+# Oracle (oracle.sh) is the discriminating gate (empty P2 filter, so the only
+# thing that can reject the encoded probe is the #2562 belt):
+#   ENCODED  — GET a dists path containing %252f (and %255c) -> 404 (belt deny).
+#              Pre-#2562: the belt is absent, the request passes the (empty)
+#              filter and reaches the unreachable upstream -> 502 -> FAIL.
+#   LEGIT    — GET a normal dists/binary-<arch> path -> NOT 404 (it reaches the
+#              fetch and 502s on the unreachable upstream), proving the belt does
+#              not blanket-reject and the 404 above is specifically the belt.
+#
+# RATE_LIMIT_ENABLED=false: admin login + repo create + a handful of proxy GETs
+# back-to-back.
+PROFILES="storage.filesystem"
+ORACLE="oracle.sh"
+RATE_LIMIT_ENABLED="false"

--- a/deploy-test/harness/tiers/debian-encoded-separator/oracle.sh
+++ b/deploy-test/harness/tiers/debian-encoded-separator/oracle.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tiers/debian-encoded-separator/oracle.sh — Debian proxy encoded-separator
+# rejection gate (#2562 / PR #2838), filesystem storage.
+# =============================================================================
+# Discriminating oracle for the Debian remote-proxy encoded-separator belt.
+#
+# Background (debian.rs::normalized_debian_relpath): the proxy normalizes each
+# request before deciding what to fetch upstream. #2562 adds a default-on belt
+# that refuses any request whose (once-decoded) path carries a percent-encoded
+# path separator — %2f/%2F ('/') or %5c/%5C ('\') — mirroring the existing
+# control-byte belt, so gate/fetch parity never depends on how a nonstandard
+# upstream decodes the sequence.
+#
+# Topology: a Debian REMOTE repo with NO P2 filter (empty allowlist permits
+# everything) pointing at a non-resolving `.invalid` upstream. With an empty
+# filter the ONLY thing that can reject the encoded probe is the #2562 belt, so:
+#   * a request the belt REJECTS returns 404 (debian_filter_denied);
+#   * a request the belt LETS THROUGH reaches the fetch and fails fast with
+#     502 Bad Gateway on the unreachable upstream.
+#
+# axum percent-decodes the catch-all segment once, so the client DOUBLE-encodes
+# (%252f/%255c) to land a literal %2f/%5c at the belt.
+#
+# Asserts:
+#   ENCODED %2f — GET .../binary-amd64/probe%252fx.gz -> 404 (belt deny).
+#                 Pre-#2562: 502 (no belt; fetch attempted) -> FAIL.
+#   ENCODED %5c — GET .../binary-amd64/probe%255cx.gz -> 404 (belt deny).
+#                 Pre-#2562: 502 -> FAIL.
+#   LEGIT       — GET .../binary-amd64/Packages.gz -> NOT 404 (reaches fetch;
+#                 502 on the dead upstream). Positive control: the belt does not
+#                 blanket-reject, so the encoded 404s above are the belt.
+#
+# run.sh exported BASE_URL, DB_CONTAINER, ADMIN_PASS, RELEASE_GATE=1,
+# JUNIT_OUTPUT_DIR, COMMON_SH.
+# =============================================================================
+set -uo pipefail
+: "${BASE_URL:?}"; : "${COMMON_SH:?}"; : "${ADMIN_PASS:?}"
+
+# shellcheck source=/dev/null
+source "$COMMON_SH"
+
+BASE="$BASE_URL"
+SUF="$RANDOM$RANDOM"
+REPO="debenc$SUF"
+UPSTREAM="http://debian-upstream-dtf-$SUF.invalid/"   # never resolves -> fast 502
+
+jqr(){ jq -r "$1" 2>/dev/null; }
+login(){ curl -s -X POST "$BASE/api/v1/auth/login" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$1\",\"password\":\"$2\"}" | jqr '.access_token // .token // empty'; }
+
+begin_suite "debian-encoded-separator-filesystem"
+
+TOK=$(login admin "$ADMIN_PASS")
+if [ -z "$TOK" ]; then
+  begin_test "admin login"; fail "admin login failed at $BASE"; end_suite; exit 1
+fi
+AUTH=(-H "Authorization: Bearer $TOK")
+
+# Remote debian repo with an unreachable upstream and no P2 filter.
+CR=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/api/v1/repositories" "${AUTH[@]}" \
+  -H 'Content-Type: application/json' \
+  -d "{\"key\":\"$REPO\",\"name\":\"$REPO\",\"format\":\"debian\",\"repo_type\":\"remote\",\"upstream_url\":\"$UPSTREAM\"}")
+echo "-- create remote debian repo '$REPO' (upstream $UPSTREAM) -> HTTP $CR"
+
+DPATH="dists/bookworm/main/binary-amd64"
+probe(){ curl -s --max-time 25 -o /dev/null -w '%{http_code}' "${AUTH[@]}" "$BASE/debian/$REPO/$1"; }
+
+SETUP_OK=1
+if [ "$CR" != "200" ] && [ "$CR" != "201" ]; then
+  SETUP_OK=0
+fi
+
+# ---------------------------------------------------------------------------
+begin_test "LEGIT dists path is NOT rejected by the belt (reaches the fetch; 502 on the dead upstream) — control"
+if [ "$SETUP_OK" != "1" ]; then
+  fail "skipped: remote debian repo create failed (HTTP $CR)"
+else
+  LEGIT=$(probe "$DPATH/Packages.gz")
+  echo "-- legit  $DPATH/Packages.gz -> HTTP $LEGIT (expect NOT 404; typically 502)"
+  if [ "$LEGIT" != "404" ] && [ "$LEGIT" != "000" ]; then
+    pass
+  else
+    fail "legit dists path returned HTTP $LEGIT; the belt must not blanket-reject (and the upstream must be reachable enough to 502, not hang)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+begin_test "ENCODED %2f (double-encoded %252f) dists path is REJECTED by the belt -> 404 (#2562)"
+if [ "$SETUP_OK" != "1" ]; then
+  fail "skipped: remote debian repo create failed (HTTP $CR)"
+else
+  ENC2F=$(probe "$DPATH/probe%252fx.gz")
+  echo "-- %2f    $DPATH/probe%252fx.gz -> HTTP $ENC2F (fixed=404 belt; pre-#2562=502 fetch)"
+  if [ "$ENC2F" = "404" ]; then
+    pass
+  else
+    fail "encoded-separator (%2f) path returned HTTP $ENC2F, expected 404 (belt deny). Pre-#2562 the belt is absent and the request reaches the upstream fetch -> 502"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+begin_test "ENCODED %5c (double-encoded %255c) dists path is REJECTED by the belt -> 404 (#2562)"
+if [ "$SETUP_OK" != "1" ]; then
+  fail "skipped: remote debian repo create failed (HTTP $CR)"
+else
+  ENC5C=$(probe "$DPATH/probe%255cx.gz")
+  echo "-- %5c    $DPATH/probe%255cx.gz -> HTTP $ENC5C (fixed=404 belt; pre-#2562=502 fetch)"
+  if [ "$ENC5C" = "404" ]; then
+    pass
+  else
+    fail "encoded-separator (%5c) path returned HTTP $ENC5C, expected 404 (belt deny). Pre-#2562 the belt is absent and the request reaches the upstream fetch -> 502"
+  fi
+fi
+
+end_suite

--- a/deploy-test/harness/tiers/maven-grouped-name/manifest
+++ b/deploy-test/harness/tiers/maven-grouped-name/manifest
@@ -1,0 +1,26 @@
+# DTF tier manifest: maven-grouped-name  (#2723 / PR #2837)
+# Profile-set: filesystem / single. The catalog `packages.name` is written by
+# the upload finalizer from the completed session's coordinates; it is
+# storage-agnostic, so this runs on the default filesystem overlay and is
+# asserted directly from the DB row.
+#
+# The bug (#2723): a Maven/Gradle artifact pushed through the GENERIC chunked
+# upload flow (POST /api/v1/uploads -> PATCH chunk -> PUT .../complete), rather
+# than the dedicated Maven PUT handler, has no replicated POM metadata, so the
+# catalog `packages` row was keyed on the bare artifact name (the filename),
+# splitting a single component across grouped listings. The fix derives the
+# grouped `groupId:artifactId` name from the artifact's GAV path for
+# Maven/Gradle repos.
+#
+# Oracle (oracle.sh) is the discriminating gate:
+#   * generic chunked-upload a .jar to a maven/local repo at a GAV path, then
+#     read the `packages` row's `name`.
+#     Fixed:     name == "groupId:artifactId".
+#     Pre-#2723: name == the bare filename ("<artifactId>-<version>.jar") -> FAIL.
+#
+# RATE_LIMIT_ENABLED=false: the oracle drives admin login + a chunked upload
+# (session create + chunk PATCH + complete) back-to-back; the base default (ON)
+# could throttle them.
+PROFILES="storage.filesystem"
+ORACLE="oracle.sh"
+RATE_LIMIT_ENABLED="false"

--- a/deploy-test/harness/tiers/maven-grouped-name/oracle.sh
+++ b/deploy-test/harness/tiers/maven-grouped-name/oracle.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tiers/maven-grouped-name/oracle.sh — Maven grouped catalog name gate
+# (#2723 / PR #2837), filesystem storage.
+# =============================================================================
+# Discriminating oracle for the Maven/Gradle grouped `packages.name`.
+#
+# Background (upload.rs::completed_package_catalog_entry): a Maven artifact
+# pushed through the generic chunked-upload flow carries no replicated POM
+# metadata, so the catalog `packages` row was keyed on the bare artifact
+# name/filename. Grouped hosted/virtual listings key on `groupId:artifactId`, so
+# the bare-named row split the component. #2723 derives the grouped name from
+# the GAV path for Maven/Gradle repos.
+#
+# Fixture: create a maven/local repo and drive a real generic chunked upload of
+# a small .jar at a GAV path `com/example/<artifactId>/<version>/<file>.jar`,
+# then read the created `packages` row's `name`.
+#
+# Asserts:
+#   * packages.name == "com.example:<artifactId>"   (fixed, #2723)
+#     Pre-#2723: name == "<artifactId>-<version>.jar" (bare filename) -> FAIL.
+#
+# run.sh exported BASE_URL, DB_CONTAINER, ADMIN_PASS, RELEASE_GATE=1,
+# JUNIT_OUTPUT_DIR, COMMON_SH.
+# =============================================================================
+set -uo pipefail
+: "${BASE_URL:?}"; : "${DB_CONTAINER:?}"; : "${COMMON_SH:?}"; : "${ADMIN_PASS:?}"
+
+# shellcheck source=/dev/null
+source "$COMMON_SH"
+
+BASE="$BASE_URL"
+DBC="$DB_CONTAINER"
+SUF="$RANDOM$RANDOM"
+REPO="mgn$SUF"
+AID="mylib$SUF"                                  # artifactId (no separators)
+VER="1.0.0"
+FILE="$AID-$VER.jar"
+APATH="com/example/$AID/$VER/$FILE"              # GAV layout
+GROUPED="com.example:$AID"                       # expected grouped name
+BARE="$FILE"                                     # pre-fix bare name
+
+jqr(){ jq -r "$1" 2>/dev/null; }
+login(){ curl -s -X POST "$BASE/api/v1/auth/login" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$1\",\"password\":\"$2\"}" | jqr '.access_token // .token // empty'; }
+psql_q(){ docker exec "$DBC" psql -U registry -d artifact_registry -tAc "$1" 2>/dev/null; }
+
+# sha256 helper
+if command -v sha256sum >/dev/null 2>&1; then sha(){ sha256sum "$1" | awk '{print $1}'; }
+else sha(){ shasum -a 256 "$1" | awk '{print $1}'; }; fi
+
+# generic_chunked_upload <token> <repo_key> <artifact_path> <version> <file>
+# Drives POST /uploads -> PATCH chunk -> PUT complete. Echoes the finalize HTTP
+# code on the last line. Single-chunk (payload is tiny).
+generic_chunked_upload(){
+  local tok="$1" repo="$2" path="$3" ver="$4" src="$5"
+  local size csum sess
+  size=$(wc -c <"$src"); csum=$(sha "$src")
+  local body
+  body=$(curl -s -X POST "$BASE/api/v1/uploads" -H "Authorization: Bearer $tok" \
+    -H 'Content-Type: application/json' -d "{
+      \"repository_key\":\"$repo\",
+      \"artifact_path\":\"$path\",
+      \"artifact_version\":\"$ver\",
+      \"total_size\":$size,
+      \"checksum_sha256\":\"$csum\",
+      \"chunk_size\":1048576
+    }")
+  sess=$(echo "$body" | jqr '.session_id // .id // empty')
+  if [ -z "$sess" ]; then echo "SESSION-FAIL: $body" >&2; echo "000"; return; fi
+  local last=$((size-1))
+  curl -s -o /dev/null -X PATCH "$BASE/api/v1/uploads/$sess" \
+    -H "Authorization: Bearer $tok" -H 'Content-Type: application/octet-stream' \
+    -H "Content-Range: bytes 0-$last/$size" --data-binary "@$src" >/dev/null
+  curl -s -o /dev/null -w '%{http_code}' -X PUT "$BASE/api/v1/uploads/$sess/complete" \
+    -H "Authorization: Bearer $tok" -H 'Content-Type: application/json'
+}
+
+begin_suite "maven-grouped-name-filesystem"
+
+begin_test "Generic chunked upload of a Maven jar lists under the grouped groupId:artifactId catalog name (#2723)"
+
+TOK=$(login admin "$ADMIN_PASS")
+if [ -z "$TOK" ]; then fail "admin login failed at $BASE"; end_suite; exit 1; fi
+
+# maven/local repo
+curl -s -X POST "$BASE/api/v1/repositories" -H "Authorization: Bearer $TOK" \
+  -H 'Content-Type: application/json' \
+  -d "{\"key\":\"$REPO\",\"name\":\"$REPO\",\"format\":\"maven\",\"repo_type\":\"local\"}" >/dev/null
+
+# minimal but structurally-valid jar (an empty ZIP: PK end-of-central-directory)
+JAR="$(mktemp)"
+printf 'PK\005\006\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000' >"$JAR"
+
+FIN=$(generic_chunked_upload "$TOK" "$REPO" "$APATH" "$VER" "$JAR")
+echo "-- generic chunked upload finalize -> HTTP $FIN"
+if [ "$FIN" != "200" ] && [ "$FIN" != "201" ]; then
+  fail "generic chunked upload did not finalize (HTTP $FIN); cannot evaluate the grouped-name gate"
+  rm -f "$JAR"; end_suite; exit 1
+fi
+rm -f "$JAR"
+
+# Read the catalog row name for this repo.
+NAME=$(psql_q "SELECT p.name FROM packages p JOIN repositories r ON r.id=p.repository_id WHERE r.key='$REPO' ORDER BY p.created_at DESC LIMIT 1;" | tr -d '[:space:]')
+echo "-- packages.name for $REPO: '${NAME:-<none>}'  (expect grouped '$GROUPED', pre-fix bare '$BARE')"
+
+if [ "$NAME" = "$GROUPED" ]; then
+  pass
+elif [ "$NAME" = "$BARE" ]; then
+  fail "catalog name is the bare filename '$NAME' (pre-#2723); expected grouped '$GROUPED'"
+elif [ -z "$NAME" ]; then
+  fail "no packages row was created for repo '$REPO' after the generic upload"
+else
+  fail "catalog name '$NAME' is neither the grouped '$GROUPED' nor the bare '$BARE'"
+fi
+
+end_suite

--- a/deploy-test/harness/tiers/openapi-signing-tags/manifest
+++ b/deploy-test/harness/tiers/openapi-signing-tags/manifest
@@ -1,0 +1,28 @@
+# DTF tier manifest: openapi-signing-tags  (#2721 / PR #2836)
+# Profile-set: filesystem / single. The served OpenAPI document is generated in
+# the backend process from the utoipa path macros; it is storage-agnostic, so
+# this runs on the default filesystem overlay. No seed data is needed — the
+# oracle only fetches the running instance's OpenAPI JSON.
+#
+# The bug (#2721): the utoipa `#[utoipa::path]` macro for `sign_artifact`
+# (POST /api/v1/signing/artifacts/{artifact_id}/sign) omitted `tag = "signing"`,
+# so the exported operation carried `tags: []`. Spectral's error-severity
+# `operation-tags` rule fails the artifact-keeper-api SDK generation pipeline on
+# any untagged operation, so the SDKs were skipped and the exported spec had to
+# be hand-patched. The fix adds `tag = "signing"`.
+#
+# Oracle (oracle.sh) is the discriminating gate: fetch the served
+# /api/v1/openapi.json and assert the sign operation's `tags` array is
+# non-empty. Pre-#2721 the array is empty -> the oracle fails; on the fixed
+# image it carries "signing" -> the oracle passes.
+#
+# The OpenAPI JSON is served at /api/v1/openapi.json whenever swagger is
+# enabled; the base compose leaves ENVIRONMENT unset, which the backend treats
+# as "development", so the spec route is mounted by default.
+#
+# RATE_LIMIT_ENABLED=false: a single admin login + a couple of unauthenticated
+# GETs; the base default (ON) would be fine here, but keep parity with the other
+# backfill tiers so a re-run under load never throttles the probe.
+PROFILES="storage.filesystem"
+ORACLE="oracle.sh"
+RATE_LIMIT_ENABLED="false"

--- a/deploy-test/harness/tiers/openapi-signing-tags/oracle.sh
+++ b/deploy-test/harness/tiers/openapi-signing-tags/oracle.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tiers/openapi-signing-tags/oracle.sh — served OpenAPI operation-tags gate
+# (#2721 / PR #2836), filesystem storage.
+# =============================================================================
+# Discriminating oracle for the untagged signing operation.
+#
+# Background (handlers/signing.rs::sign_artifact): the utoipa path macro for
+# POST /api/v1/signing/artifacts/{artifact_id}/sign omitted `tag = "signing"`,
+# so the merged OpenAPI document served at /api/v1/openapi.json carried an empty
+# `tags` array for that operation. Spectral's error-severity `operation-tags`
+# rule fails the SDK-generation pipeline on any untagged operation.
+#
+# Asserts (against the RUNNING instance's served spec):
+#   * /api/v1/openapi.json is reachable and parses as JSON.
+#   * the operation object at
+#       paths./api/v1/signing/artifacts/{artifact_id}/sign.post
+#     exists AND its `tags` array has length > 0.
+#     Pre-#2721: tags == []  -> length 0 -> FAIL (non-zero exit).
+#     Fixed:     tags == ["signing"] -> length 1 -> PASS.
+#
+# run.sh has stood up the filesystem profile-set and exported BASE_URL,
+# DB_CONTAINER, ADMIN_PASS, RELEASE_GATE=1, JUNIT_OUTPUT_DIR, COMMON_SH.
+# =============================================================================
+set -uo pipefail
+: "${BASE_URL:?}"; : "${COMMON_SH:?}"
+
+# shellcheck source=/dev/null
+source "$COMMON_SH"
+
+BASE="$BASE_URL"
+SIGN_PATH='/api/v1/signing/artifacts/{artifact_id}/sign'
+
+begin_suite "openapi-signing-tags"
+
+# ---------------------------------------------------------------------------
+begin_test "Served OpenAPI /api/v1/openapi.json is reachable and parses as JSON"
+SPEC_FILE="$(mktemp)"
+HTTP=$(curl -s -o "$SPEC_FILE" -w '%{http_code}' "$BASE/api/v1/openapi.json")
+echo "-- GET /api/v1/openapi.json -> HTTP $HTTP ($(wc -c <"$SPEC_FILE") bytes)"
+SPEC_OK=1
+if [ "$HTTP" != "200" ]; then
+  SPEC_OK=0
+  fail "openapi.json not served (HTTP $HTTP); the spec route must be mounted for this gate"
+elif ! jq -e . "$SPEC_FILE" >/dev/null 2>&1; then
+  SPEC_OK=0
+  fail "openapi.json did not parse as JSON"
+else
+  pass
+fi
+
+# ---------------------------------------------------------------------------
+begin_test "POST $SIGN_PATH operation declares a non-empty tags array (#2721)"
+if [ "$SPEC_OK" != "1" ]; then
+  fail "skipped: openapi.json was not retrievable"
+else
+  # Confirm the operation is actually present (guards against a spec that
+  # silently dropped the path, which would make a length check vacuously pass).
+  OP_PRESENT=$(jq -r --arg p "$SIGN_PATH" '.paths[$p].post != null' "$SPEC_FILE" 2>/dev/null)
+  TAGS_LEN=$(jq -r --arg p "$SIGN_PATH" '(.paths[$p].post.tags // []) | length' "$SPEC_FILE" 2>/dev/null)
+  TAGS_VAL=$(jq -c --arg p "$SIGN_PATH" '.paths[$p].post.tags // []' "$SPEC_FILE" 2>/dev/null)
+  echo "-- operation present: $OP_PRESENT   tags: $TAGS_VAL   length: $TAGS_LEN"
+  if [ "$OP_PRESENT" != "true" ]; then
+    fail "sign operation missing from served spec at path '$SIGN_PATH' (cannot evaluate #2721)"
+  elif [ "${TAGS_LEN:-0}" -gt 0 ] 2>/dev/null; then
+    pass
+  else
+    fail "sign operation has an EMPTY tags array (#2721); Spectral operation-tags fails the SDK pipeline on this. Pre-fix tags == []"
+  fi
+fi
+
+rm -f "$SPEC_FILE"
+end_suite


### PR DESCRIPTION
## Summary

Adds five discriminating deploy-test (DTF) tiers that guard the behaviour of five already-merged 1.7.0 backend fixes. Each tier was authored to be **discriminating**: it FAILS on a baseline image without the fix and PASSES on an image with it, so it is a real regression gate rather than an always-green test.

All five were verified by running the same tier against two images on isolated slots:
- **GREEN**: `artifact-keeper-backend:dtf-backfill-green` — a fresh `main` tree with the five fix commits cherry-picked in.
- **RED**: `artifact-keeper-backend:1.6.2-rc` — a baseline image with none of these fixes.

Each tier is also wired into the `all` set in `deploy-test/harness/run.sh`.

## Tiers, guards, and RED→GREEN evidence

### 1. `openapi-signing-tags` — guards #2721 (PR #2836)
Fetches the running instance's `/api/v1/openapi.json` and asserts the operation at `paths./api/v1/signing/artifacts/{artifact_id}/sign.post` declares a non-empty `tags` array.

```
RED  : operation present: true   tags: []            length: 0   -> FAIL (exit 1)
GREEN: operation present: true   tags: ["signing"]   length: 1   -> PASS (exit 0)
```

### 2. `maven-grouped-name` — guards #2723 (PR #2837)
Drives a real generic (chunked-upload) push of a `.jar` to a `maven/local` repo at a GAV path, then reads the created `packages` row's `name`.

```
RED  : packages.name = 'mylib<sfx>-1.0.0.jar' (bare filename)      -> FAIL (exit 1)
GREEN: packages.name = 'com.example:mylib<sfx>' (grouped)          -> PASS (exit 0)
```

### 3. `debian-encoded-separator` — guards #2562 (PR #2838)
Creates a Debian **remote** repo with an empty P2 filter pointing at a non-resolving `.invalid` upstream (so the only thing that can reject the probe is the #2562 belt; a request the belt lets through fails fast at the fetch with 502). Because axum decodes the catch-all segment once, the probe double-encodes (`%252f` / `%255c`) to land a literal `%2f` / `%5c` at the belt.

```
RED  : legit Packages.gz -> 502   probe%252fx.gz -> 502   probe%255cx.gz -> 502   -> FAIL (exit 1)
GREEN: legit Packages.gz -> 502   probe%252fx.gz -> 404   probe%255cx.gz -> 404   -> PASS (exit 0)
```
The legit path returns 502 (reaches the fetch) on both images — the positive control proving the belt does not blanket-reject and the encoded-path 404s are specifically the belt.

### 4. `cran-rubygems-download-url` — guards #2754 (PR #2839)
For both formats: a real generic (bare-path) chunked upload, then reads the SERVED index, reconstructs the client download path from the advertised coordinates, and GETs it.

```
CRAN
RED  : PACKAGES advertises Package='cranpkg<sfx>_1.0.0.tar.gz' Version='sha256-…'
       reconstructed 'cranpkg<sfx>_1.0.0.tar.gz_sha256-….tar.gz' -> 404   -> FAIL
GREEN: PACKAGES advertises Package='cranpkg<sfx>' Version='1.0.0'
       reconstructed 'cranpkg<sfx>_1.0.0.tar.gz' -> 200                    -> PASS

RubyGems (specs.4.8.gz)
RED  : advertises name='rubypkg<sfx>-1.0.0.gem' version='sha256-…'
       reconstructed 'rubypkg<sfx>-1.0.0.gem-sha256-….gem' -> 404          -> FAIL
GREEN: advertises name='rubypkg<sfx>' version='1.0.0'
       reconstructed 'rubypkg<sfx>-1.0.0.gem' -> 200                       -> PASS
```
Overall: RED exit 1 (both sub-checks fail), GREEN exit 0.

### 5. `backup-custom-name` — guards #2790 (PR #2840)
POSTs `/api/v1/admin/backups` with a custom `name`, reads the `backups` row's `storage_path`, and separately POSTs an unsafe name expecting 400. A no-name control confirms the default `{uuid}.tar.gz` key still works.

```
RED  : storage_path 'backups/…/<uuid>.tar.gz' (label absent)  unsafe-name -> HTTP 200   -> FAIL (exit 1)
GREEN: storage_path 'backups/…/dtflabel<sfx>-<8hex>.tar.gz'    unsafe-name -> HTTP 400   -> PASS (exit 0)
       (no-name control passes on both)
```

## How to reproduce

```
cd deploy-test
for t in openapi-signing-tags maven-grouped-name debian-encoded-separator \
         cran-rubygems-download-url backup-custom-name; do
  bash harness/run.sh "$t" --backend-image artifact-keeper-backend:dtf-backfill-green --slot 16   # PASS
  bash harness/run.sh "$t" --backend-image artifact-keeper-backend:1.6.2-rc            --slot 17   # FAIL
done
```

## Notes
- All five flips were observed; none were dropped for non-discrimination.
- The tiers run on the default `storage.filesystem` overlay and drive the real HTTP surface plus DB assertions via `docker exec … psql`, following the existing tier conventions (`begin_suite`/`begin_test`/`pass`/`fail`, run.sh-provided `BASE_URL`/`DB_CONTAINER`/`ADMIN_PASS`).
- `RATE_LIMIT_ENABLED=false` in each manifest so back-to-back admin calls in an oracle are never throttled, matching the other feature/fix tiers.
