### PR TITLE
test(dtf): oidc-env-config + gcs-custom-endpoint tiers (1.7.0 backfill)

### DIFF
--- a/deploy-test/harness/run.sh
+++ b/deploy-test/harness/run.sh
@@ -265,7 +265,8 @@ case "$CMD" in
              ci-token-basic virtual-usage maven-files-casing backup-reclaim nexus-go-apt nexus-group-virtual pypi-contenttype ldaps \
              vvc3-scoped-admin qcmj-webhook-authz f7qf-peer-authz 5f2q-upload-scope qxxr-refresh-race \
              virtual-no-transfer proxy-upstream-url oidc-group-sync \
-             openapi-signing-tags maven-grouped-name debian-encoded-separator cran-rubygems-download-url backup-custom-name; do
+             openapi-signing-tags maven-grouped-name debian-encoded-separator cran-rubygems-download-url backup-custom-name \
+             oidc-env-config gcs-custom-endpoint; do
       run_tier "$t" || overall=1
     done
     exit "$overall" ;;

--- a/deploy-test/harness/tiers/gcs-custom-endpoint/manifest
+++ b/deploy-test/harness/tiers/gcs-custom-endpoint/manifest
@@ -1,0 +1,23 @@
+# DTF tier manifest: gcs-custom-endpoint
+# Profile-set: gcs-emulator / single. A fake-gcs-server emulator (the GCS analog
+# of the isolation tier's MinIO), on which the custom-endpoint support added by
+# #2646 / PR #2842 is exercised end to end.
+#
+# Guards #2646 / PR #2842: the GCS storage backend can now target a custom
+# endpoint (GCS_ENDPOINT) so it runs against a local emulator instead of real
+# Google storage. The storage.gcs-emulator profile boots fake-gcs-server, pre-
+# creates the bucket, and sets STORAGE_BACKEND=gcs + GCS_ENDPOINT + the SSRF
+# allowlist. The oracle creates a maven repo (inherits the stack's gcs backend),
+# uploads an artifact, and downloads it back, asserting the round-trip against
+# the emulator.
+#
+# RED on a pre-#2646 image: GCS_ENDPOINT is ignored -> the backend targets
+# https://storage.googleapis.com with ADC/metadata auth -> upload/download
+# cannot reach the emulator and fails. GREEN: emulator round-trip succeeds.
+#
+# RATE_LIMIT_ENABLED=false: matches the isolation tier (a few admin PUT/GET back
+# to back through one admin); a tier that disables a shipped control does so
+# explicitly, per design 2.2.
+PROFILES="storage.gcs-emulator"
+ORACLE="oracle.sh"
+RATE_LIMIT_ENABLED="false"

--- a/deploy-test/harness/tiers/gcs-custom-endpoint/oracle.sh
+++ b/deploy-test/harness/tiers/gcs-custom-endpoint/oracle.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tiers/gcs-custom-endpoint/oracle.sh -- GCS emulator round-trip oracle (#2646)
+# =============================================================================
+# run.sh has stood up the gcs-emulator profile: postgres + backend
+# (STORAGE_BACKEND=gcs, GCS_ENDPOINT=http://fake-gcs:4443, bucket pre-created)
+# + the fake-gcs-server emulator (published on the slot's S3_PORT). It exported
+# BASE_URL, DB_CONTAINER, ADMIN_USER/ADMIN_PASS, S3_PORT, RELEASE_GATE=1,
+# COMMON_SH, JUNIT_OUTPUT_DIR.
+#
+# WHAT IT TESTS: the custom-GCS-endpoint support added by #2646 / PR #2842
+# (backend/src/storage/gcs.rs). With GCS_ENDPOINT set, the backend routes all
+# JSON/XML API calls at the emulator and uses a static bearer token (no real
+# Google token/metadata endpoint). The oracle creates a maven repo (which
+# inherits the stack's STORAGE_BACKEND=gcs), uploads an artifact, downloads it
+# back, and asserts the bytes round-trip -- AND that the object physically
+# landed in the emulator bucket (queried directly on S3_PORT).
+#
+# DISCRIMINATION: pre-#2646 GCS_ENDPOINT is ignored, so the backend targets
+# https://storage.googleapis.com with ADC/metadata auth. The upload cannot
+# reach the emulator (real Google endpoint + no creds / blocked metadata token),
+# so the PUT fails (non-201) and the emulator bucket stays empty -> RED. On the
+# fix the round-trip succeeds and the bucket holds the object -> GREEN.
+# =============================================================================
+set -uo pipefail
+: "${BASE_URL:?}"; : "${DB_CONTAINER:?}"; : "${COMMON_SH:?}"; : "${S3_PORT:?}"
+# shellcheck source=/dev/null
+source "$COMMON_SH"
+
+ADMPASS="${ADMIN_PASS:-TestRunner!2026secure}"
+SUF="$(date +%s)-${DTF_SLOT:-x}"
+REPO="gcs-emu-${SUF}"
+COORD="com/dtf/gcsapp/1.0.0/gcsapp-1.0.0.jar"
+PAYLOAD="GCS-EMULATOR-ROUNDTRIP-${SUF}"
+EMU="http://127.0.0.1:${S3_PORT}"   # fake-gcs-server host publish
+
+login() {
+  curl -s -X POST "${BASE_URL}/api/v1/auth/login" -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$1\",\"password\":\"$2\"}" | jq -r '.access_token // empty'
+}
+# code <method> <path> <token> [body] [content-type] -> HTTP status
+code() {
+  local m="$1" p="$2" t="$3" b="${4:-}" ct="${5:-application/octet-stream}"
+  if [ -n "$b" ]; then
+    curl -s -o /dev/null -w '%{http_code}' -X "$m" "${BASE_URL}${p}" \
+      -H "Authorization: Bearer $t" -H "Content-Type: $ct" --data-binary "$b"
+  else
+    curl -s -o /dev/null -w '%{http_code}' -X "$m" "${BASE_URL}${p}" -H "Authorization: Bearer $t"
+  fi
+}
+# body <method> <path> <token> -> response body
+body() { curl -s -X "$1" "${BASE_URL}${2}" -H "Authorization: Bearer $3"; }
+# docker exec psql helper (single scalar).
+db() {
+  docker exec "$DB_CONTAINER" psql -U registry -d artifact_registry -tAc "$1" 2>/dev/null \
+    | tr -d '[:space:]'
+}
+# storage_backend of the repo under test -> 'gcs' | 'filesystem' | ''
+db_storage_backend() {
+  db "SELECT storage_backend FROM repositories WHERE key='${REPO}' LIMIT 1"
+}
+# emulator object count for the bucket -> integer string
+emu_object_count() {
+  curl -s "${EMU}/storage/v1/b/ak-artifacts/o" | jq -r '(.items // []) | length' 2>/dev/null
+}
+
+begin_suite "gcs-custom-endpoint"
+
+# ---- bootstrap -------------------------------------------------------------
+TOK="$(login "${ADMIN_USER:-admin}" "$ADMPASS")"
+if [ -z "$TOK" ]; then
+  begin_test "admin login"
+  fail "admin login to ${BASE_URL} failed (no access_token)"
+  end_suite
+fi
+
+# ---------------------------------------------------------------------------
+# CASE 0 -- PREMISE: the emulator is reachable and the bucket exists (so the
+# tier is testing the AK<->emulator path, not a missing-bucket artifact).
+# ---------------------------------------------------------------------------
+begin_test "CASE 0 premise: fake-gcs emulator serves the ak-artifacts bucket on :${S3_PORT}"
+BKT="$(curl -s "${EMU}/storage/v1/b/ak-artifacts" | jq -r '.name // empty' 2>/dev/null)"
+if [ "$BKT" = "ak-artifacts" ]; then
+  pass
+else
+  fail "emulator bucket ak-artifacts not found on ${EMU} (got '${BKT}')" \
+       "storage.gcs-emulator's create-bucket sidecar must provision ak-artifacts in fake-gcs-server before the backend starts."
+  end_suite
+fi
+
+# ---------------------------------------------------------------------------
+# CASE 1 -- STORAGE BACKEND PREMISE: the repo we create is gcs-backed (so the
+# round-trip actually flows through the GCS backend at GCS_ENDPOINT).
+# ---------------------------------------------------------------------------
+begin_test "CASE 1 premise: maven repo '${REPO}' created and stored on the gcs backend"
+RC_CREATE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "${BASE_URL}/api/v1/repositories" \
+  -H "Authorization: Bearer ${TOK}" -H 'Content-Type: application/json' \
+  -d "{\"key\":\"${REPO}\",\"name\":\"${REPO}\",\"format\":\"maven\",\"repo_type\":\"local\"}")
+REPO_BACKEND="$(db_storage_backend)"
+if { [ "$RC_CREATE" = "201" ] || [ "$RC_CREATE" = "200" ]; } && [ "$REPO_BACKEND" = "gcs" ]; then
+  pass
+else
+  fail "repo create / backend premise failed (create_status=$RC_CREATE storage_backend='$REPO_BACKEND')" \
+       "The repo must be created and inherit STORAGE_BACKEND=gcs so the upload flows through the GCS backend."
+fi
+
+# ---------------------------------------------------------------------------
+# CASE 2 -- HEADLINE (#2646): upload an artifact -> the GCS backend PUTs it to
+# the emulator (201).
+# ---------------------------------------------------------------------------
+begin_test "CASE 2 (#2646 HEADLINE): upload artifact to gcs-backed repo -> emulator PUT succeeds (201)"
+PRE_CNT="$(emu_object_count)"; PRE_CNT="${PRE_CNT:-0}"
+UP=$(code PUT "/maven/${REPO}/${COORD}" "$TOK" "$PAYLOAD")
+if [ "$UP" = "201" ] || [ "$UP" = "200" ]; then
+  pass
+else
+  fail "artifact upload to the gcs emulator failed (PUT status=$UP, expected 201)" \
+       "With GCS_ENDPOINT set (#2646) the PUT must reach fake-gcs-server. On a pre-#2646 image GCS_ENDPOINT is ignored, so the backend targets real Google storage (no creds / blocked metadata token) and the PUT fails -- the RED this tier catches."
+fi
+
+# ---------------------------------------------------------------------------
+# CASE 3 (#2646): download the artifact back -> bytes match (round-trip).
+# ---------------------------------------------------------------------------
+begin_test "CASE 3 (#2646): download the artifact back from the emulator -> bytes match"
+DL=$(body GET "/maven/${REPO}/${COORD}" "$TOK")
+if [ "$DL" = "$PAYLOAD" ]; then
+  pass
+else
+  fail "gcs emulator round-trip byte mismatch (got '$DL', expected '$PAYLOAD')" \
+       "The download must return the exact uploaded bytes from fake-gcs-server. RED on a pre-#2646 image (upload never reached the emulator)."
+fi
+
+# ---------------------------------------------------------------------------
+# CASE 4 (#2646): the object physically landed in the emulator bucket (queried
+# directly on the emulator, independent of AK's DB) -- proves the bytes went to
+# GCS_ENDPOINT, not just AK's metadata layer.
+# ---------------------------------------------------------------------------
+begin_test "CASE 4 (#2646): the uploaded object is present in the emulator bucket (direct emulator query)"
+POST_CNT="$(emu_object_count)"; POST_CNT="${POST_CNT:-0}"
+if [ "$POST_CNT" -gt "$PRE_CNT" ] 2>/dev/null; then
+  pass
+else
+  fail "no new object in the emulator bucket (pre=$PRE_CNT post=$POST_CNT)" \
+       "A successful gcs-backed upload must create an object in fake-gcs-server. RED on a pre-#2646 image (nothing ever reached the emulator, so the bucket stays empty)."
+fi
+
+# ---- discrimination summary (printed, not a gate) --------------------------
+echo ""
+echo "=== DISCRIMINATION SUMMARY (why this tier guards #2646 / PR #2842) ==="
+echo "  Backend booted STORAGE_BACKEND=gcs GCS_ENDPOINT=http://fake-gcs:4443:"
+echo "    upload PUT status         = ${UP}          (fix: 201; pre-fix: fails, endpoint ignored)"
+echo "    download bytes match      = $([ "$DL" = "$PAYLOAD" ] && echo yes || echo no)"
+echo "    emulator objects pre/post = ${PRE_CNT}/${POST_CNT}   (fix: post>pre; pre-fix: stays 0)"
+echo "  Pre-#2646 GCS_ENDPOINT is ignored -> backend targets real Google GCS ->"
+echo "  the round-trip cannot reach the emulator and CASE 2/3/4 flip RED."
+
+end_suite

--- a/deploy-test/harness/tiers/oidc-env-config/manifest
+++ b/deploy-test/harness/tiers/oidc-env-config/manifest
@@ -1,0 +1,23 @@
+# DTF tier manifest: oidc-env-config
+# Profile-set: filesystem / single + sso.oidc-bootstrap (env-var OIDC bootstrap,
+# no mock IdP -- create_oidc only SSRF-validates the issuer + inserts the row).
+#
+# Guards #2792 / PR #2841: OIDC provider toggles are now configurable via env at
+# bootstrap (main.rs bootstrap_oidc_from_env -> build_oidc_request_from_values).
+# The sso.oidc-bootstrap profile sets OIDC_ISSUER/CLIENT_ID/SECRET (the required
+# trio that triggers creation) plus the three toggles under test with values
+# chosen to flip against the pre-fix hardcoded defaults:
+#   * OIDC_MAP_GROUPS_TO_GROUPS=true  (headline; pre-fix None -> stored false)
+#   * OIDC_AUTO_CREATE_USERS=false    (pre-fix Some(true) -> stored true)
+#   * OIDC_PKCE_ENABLED=false         (pre-fix None -> service default true)
+# The oracle logs in as admin, reads the bootstrapped provider back through
+# GET /api/v1/admin/sso/oidc, and asserts the stored config reflects the env.
+# RED on a pre-#2792 image (env ignored -> map_groups_to_groups=false); GREEN on
+# the fixed image (true).
+#
+# RATE_LIMIT_ENABLED=false: matches the oidc-group-sync tier's discipline (a few
+# admin logins back to back); a tier that disables a shipped control does so
+# explicitly, per design 2.2.
+PROFILES="storage.filesystem sso.oidc-bootstrap"
+ORACLE="oracle.sh"
+RATE_LIMIT_ENABLED="false"

--- a/deploy-test/harness/tiers/oidc-env-config/oracle.sh
+++ b/deploy-test/harness/tiers/oidc-env-config/oracle.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tiers/oidc-env-config/oracle.sh -- OIDC env-bootstrap toggle oracle (#2792)
+# =============================================================================
+# run.sh has stood up filesystem/single + sso.oidc-bootstrap (backend booted
+# with OIDC_ISSUER/CLIENT_ID/SECRET + OIDC_NAME + the three toggle env vars) and
+# exported BASE_URL, DB_CONTAINER, ADMIN_USER/ADMIN_PASS, RELEASE_GATE=1,
+# COMMON_SH, JUNIT_OUTPUT_DIR.
+#
+# WHAT IT TESTS: the env-bootstrap provider-toggle wiring added by #2792 /
+# PR #2841 (main.rs build_oidc_request_from_values). At boot, AK reconciles an
+# env-managed OIDC provider named OIDC_NAME from the OIDC_* env. This oracle
+# logs in as admin, reads that provider back through the admin SSO API, and
+# asserts its stored config reflects the env toggles:
+#   * map_groups_to_groups == true   (OIDC_MAP_GROUPS_TO_GROUPS=true)  HEADLINE
+#   * auto_create_users    == false  (OIDC_AUTO_CREATE_USERS=false)
+#   * pkce_enabled         == false  (OIDC_PKCE_ENABLED=false)
+#
+# DISCRIMINATION: pre-#2792 the bootstrap hardcoded
+#   auto_create_users: Some(true), pkce_enabled: None, map_groups_to_groups: None
+# so the stored provider (via the service-layer create defaults) has
+#   map_groups_to_groups=false, auto_create_users=true, pkce_enabled=true
+# -- every one of the three assertions flips RED on a pre-fix image. On the fix
+# each env var is honored -> GREEN. The stored config is read back both through
+# the admin API (primary) AND the oidc_configs DB row (belt-and-suspenders).
+# =============================================================================
+set -uo pipefail
+: "${BASE_URL:?}"; : "${DB_CONTAINER:?}"; : "${COMMON_SH:?}"
+# shellcheck source=/dev/null
+source "$COMMON_SH"
+
+ADMPASS="${ADMIN_PASS:-TestRunner!2026secure}"
+PROVIDER_NAME="dtf-env-bootstrap"   # must match OIDC_NAME in sso.oidc-bootstrap.yml
+
+login() {
+  curl -s -X POST "${BASE_URL}/api/v1/auth/login" -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$1\",\"password\":\"$2\"}" | jq -r '.access_token // empty'
+}
+
+# docker exec psql helper (single scalar).
+db() {
+  docker exec "$DB_CONTAINER" psql -U registry -d artifact_registry -tAc "$1" 2>/dev/null \
+    | tr -d '[:space:]'
+}
+
+begin_suite "oidc-env-config"
+
+# ---- bootstrap -------------------------------------------------------------
+TOK="$(login "${ADMIN_USER:-admin}" "$ADMPASS")"
+if [ -z "$TOK" ]; then
+  begin_test "admin login"
+  fail "admin login to ${BASE_URL} failed (no access_token)"
+  end_suite
+fi
+
+# Read the env-managed provider back through the admin SSO API. list_oidc
+# returns an array of OidcConfigResponse; select the one named OIDC_NAME.
+PROVIDER_JSON="$(curl -s "${BASE_URL}/api/v1/admin/sso/oidc" \
+  -H "Authorization: Bearer ${TOK}" \
+  | jq -c --arg n "$PROVIDER_NAME" '.[] | select(.name==$n)' 2>/dev/null)"
+
+# ---------------------------------------------------------------------------
+# CASE 0 -- PREMISE: the env-var bootstrap actually created the provider.
+# ---------------------------------------------------------------------------
+begin_test "CASE 0 premise: OIDC provider '${PROVIDER_NAME}' bootstrapped from env (OIDC_ISSUER/CLIENT_ID/SECRET)"
+if [ -n "$PROVIDER_JSON" ] && [ "$PROVIDER_JSON" != "null" ]; then
+  pass
+else
+  fail "env-bootstrapped OIDC provider '${PROVIDER_NAME}' not found via GET /api/v1/admin/sso/oidc" \
+       "The required trio (OIDC_ISSUER/CLIENT_ID/SECRET) is set in the profile, so bootstrap_oidc_from_env must create a provider named '${PROVIDER_NAME}'. Absence means bootstrap did not run."
+  end_suite
+fi
+
+MG_API="$(echo "$PROVIDER_JSON" | jq -r '.map_groups_to_groups')"
+AC_API="$(echo "$PROVIDER_JSON" | jq -r '.auto_create_users')"
+PK_API="$(echo "$PROVIDER_JSON" | jq -r '.pkce_enabled')"
+
+# DB read-back (belt-and-suspenders; the admin API is the primary source).
+MG_DB="$(db "SELECT map_groups_to_groups FROM oidc_configs WHERE name='${PROVIDER_NAME}' LIMIT 1")"
+AC_DB="$(db "SELECT auto_create_users FROM oidc_configs WHERE name='${PROVIDER_NAME}' LIMIT 1")"
+PK_DB="$(db "SELECT pkce_enabled FROM oidc_configs WHERE name='${PROVIDER_NAME}' LIMIT 1")"
+
+# ---------------------------------------------------------------------------
+# CASE 1 -- HEADLINE (#2792): OIDC_MAP_GROUPS_TO_GROUPS=true -> stored true.
+# ---------------------------------------------------------------------------
+begin_test "CASE 1 (#2792 HEADLINE): OIDC_MAP_GROUPS_TO_GROUPS=true -> stored map_groups_to_groups=true"
+if [ "$MG_API" = "true" ] && [ "$MG_DB" = "t" ]; then
+  pass
+else
+  fail "map_groups_to_groups not honored from env (api='$MG_API' db='$MG_DB', expected true/t)" \
+       "OIDC_MAP_GROUPS_TO_GROUPS=true must make the bootstrapped provider store map_groups_to_groups=true. On a pre-#2792 image the env is ignored (hardcoded None -> stored false), which is exactly the gap this tier catches (RED api='false')."
+fi
+
+# ---------------------------------------------------------------------------
+# CASE 2 (#2792): OIDC_AUTO_CREATE_USERS=false -> stored false (overrides the
+# prior hardcoded Some(true) bootstrap default).
+# ---------------------------------------------------------------------------
+begin_test "CASE 2 (#2792): OIDC_AUTO_CREATE_USERS=false -> stored auto_create_users=false"
+if [ "$AC_API" = "false" ] && [ "$AC_DB" = "f" ]; then
+  pass
+else
+  fail "auto_create_users not honored from env (api='$AC_API' db='$AC_DB', expected false/f)" \
+       "OIDC_AUTO_CREATE_USERS=false must override the prior hardcoded Some(true). On a pre-#2792 image the value is forced true (RED api='true')."
+fi
+
+# ---------------------------------------------------------------------------
+# CASE 3 (#2792): OIDC_PKCE_ENABLED=false -> stored false (overrides the
+# service-layer create default of true).
+# ---------------------------------------------------------------------------
+begin_test "CASE 3 (#2792): OIDC_PKCE_ENABLED=false -> stored pkce_enabled=false"
+if [ "$PK_API" = "false" ] && [ "$PK_DB" = "f" ]; then
+  pass
+else
+  fail "pkce_enabled not honored from env (api='$PK_API' db='$PK_DB', expected false/f)" \
+       "OIDC_PKCE_ENABLED=false must override the service-layer default (true). On a pre-#2792 image the env is ignored (hardcoded None -> stored true) (RED api='true')."
+fi
+
+# ---- discrimination summary (printed, not a gate) --------------------------
+echo ""
+echo "=== DISCRIMINATION SUMMARY (why this tier guards #2792 / PR #2841) ==="
+echo "  Backend booted with the OIDC_* bootstrap env; stored provider config:"
+echo "    OIDC_MAP_GROUPS_TO_GROUPS=true  -> map_groups_to_groups api='${MG_API}' db='${MG_DB}'  (fix: true/t;  pre-fix: false/f)"
+echo "    OIDC_AUTO_CREATE_USERS=false    -> auto_create_users    api='${AC_API}' db='${AC_DB}'  (fix: false/f; pre-fix: true/t)"
+echo "    OIDC_PKCE_ENABLED=false         -> pkce_enabled         api='${PK_API}' db='${PK_DB}'  (fix: false/f; pre-fix: true/t)"
+echo "  All three flip on a pre-#2792 image (env ignored, hardcoded defaults)."
+
+end_suite

--- a/deploy-test/profiles/sso.oidc-bootstrap.yml
+++ b/deploy-test/profiles/sso.oidc-bootstrap.yml
@@ -1,0 +1,47 @@
+# =============================================================================
+# profiles/sso.oidc-bootstrap.yml -- sso dimension = oidc env bootstrap  [DTF]
+# =============================================================================
+# Drives AK's env-var OIDC bootstrap path (main.rs `bootstrap_oidc_from_env` ->
+# `build_oidc_request_from_values`) so the oidc-env-config tier can assert that
+# the provider toggles are configurable from the environment at boot (#2792 /
+# PR #2841). No mock IdP is needed: `AuthConfigService::create_oidc` only
+# SSRF-validates the issuer URL and inserts the row -- it performs NO live
+# discovery/token fetch at create time. The tier reads the stored config back
+# through the admin SSO API and asserts the toggles reflect the env vars.
+#
+# Why the issuer host is `idp.dtf.invalid`: the create-time SSRF guard
+# (`validate_outbound_sso_url`) resolves DNS names and blocks private/internal
+# addresses, but a host that does NOT resolve (the reserved `.invalid` TLD,
+# RFC 6761 -> guaranteed NXDOMAIN) sails through as "not blocked" without any
+# IdP being reachable. This keeps the tier a pure config-bootstrap probe with
+# zero extra containers.
+#
+# Bootstrap env (read by main.rs at startup):
+#   OIDC_ISSUER / OIDC_CLIENT_ID / OIDC_CLIENT_SECRET  -> required trio; their
+#     presence triggers provider creation on boot.
+#   OIDC_NAME                                          -> reconciled provider
+#     name (the oracle finds the row by this name).
+#   OIDC_MAP_GROUPS_TO_GROUPS=true   -> map_groups_to_groups (headline #2792;
+#     pre-fix hardcoded None -> stored false; fix -> stored true).
+#   OIDC_AUTO_CREATE_USERS=false     -> auto_create_users (pre-fix hardcoded
+#     Some(true) -> stored true; fix -> stored false).
+#   OIDC_PKCE_ENABLED=false          -> pkce_enabled (pre-fix hardcoded None ->
+#     service default true; fix -> stored false).
+# Each of the three toggles is chosen to flip against the pre-fix default, so
+# the tier is discriminating on ALL THREE, with map_groups_to_groups as the
+# primary ask.
+# =============================================================================
+services:
+  backend:
+    environment:
+      # Required trio -- presence triggers env bootstrap on boot.
+      OIDC_ISSUER: "https://idp.dtf.invalid"
+      OIDC_CLIENT_ID: "dtf-oidc-bootstrap-client"
+      OIDC_CLIENT_SECRET: "dtf-oidc-bootstrap-secret"
+      # Env-managed provider name the oracle reconciles against.
+      OIDC_NAME: "dtf-env-bootstrap"
+      # The three toggles under test (#2792). Values chosen to flip against the
+      # pre-fix hardcoded defaults so each is a discriminator.
+      OIDC_MAP_GROUPS_TO_GROUPS: "true"
+      OIDC_AUTO_CREATE_USERS: "false"
+      OIDC_PKCE_ENABLED: "false"

--- a/deploy-test/profiles/storage.gcs-emulator.yml
+++ b/deploy-test/profiles/storage.gcs-emulator.yml
@@ -1,0 +1,91 @@
+# =============================================================================
+# profiles/storage.gcs-emulator.yml -- storage dimension = gcs (fake-gcs-server)
+# =============================================================================
+# The GCS analog of storage.s3.yml (MinIO). Adds a fake-gcs-server emulator +
+# a create-bucket sidecar, and points the backend's GCS storage at the emulator
+# via GCS_ENDPOINT. This exercises the custom-endpoint support added by #2646 /
+# PR #2842 (backend/src/storage/gcs.rs): GCS_ENDPOINT routes all JSON/XML API
+# URLs at the emulator and selects an emulator auth mode (static bearer token,
+# no real Google token/metadata endpoint contacted).
+#
+# The overlay:
+#   * ADDS  `fake-gcs` (fsouza/fake-gcs-server) on a dedicated 172.16/12 subnet
+#     so the backend's SSRF-guarded control/stream clients can reach it once
+#     AK_SSRF_ALLOW_PRIVATE_CIDRS allowlists that CIDR (the GCS clients use the
+#     shared guarded builder, unlike the S3 SDK; same escape-hatch discipline as
+#     sso.oidc.yml / upstreams.mockpypi.yml).
+#   * ADDS  `gcs-createbucket` -- a curl sidecar that POSTs the bucket into the
+#     emulator JSON API (the GCS analog of the isolation tier's `mc mb`).
+#   * PATCHES backend.environment with STORAGE_BACKEND=gcs + GCS_BUCKET +
+#     GCS_ENDPOINT (http://fake-gcs:4443) + the SSRF allowlist, and no
+#     GCS_PRIVATE_KEY so the emulator (static-token) auth mode engages.
+#
+# RED (pre-#2646): GCS_ENDPOINT is ignored -> base_url stays
+# https://storage.googleapis.com and auth mode is ADC (metadata token) -> the
+# upload/download round-trip cannot reach the emulator and fails. GREEN: the
+# round-trip succeeds against fake-gcs.
+#
+# Required vars (exported by run.sh): DTF_SLOT (per-slot subnet + static IP so
+# concurrent slots never collide), S3_PORT (reused as the emulator's spare host
+# publish port -- this tier runs no MinIO).
+# =============================================================================
+services:
+  fake-gcs:
+    image: fsouza/fake-gcs-server:latest
+    container_name: ak-dtf${DTF_SLOT}-fake-gcs
+    command:
+      - "-scheme"
+      - "http"
+      - "-host"
+      - "0.0.0.0"
+      - "-port"
+      - "4443"
+      - "-backend"
+      - "memory"
+    ports:
+      - "127.0.0.1:${S3_PORT:?set S3_PORT}:4443"
+    networks:
+      gcsemu:
+        ipv4_address: 172.29.${DTF_SLOT}.70
+
+  gcs-createbucket:
+    image: curlimages/curl:latest
+    container_name: ak-dtf${DTF_SLOT}-gcs-mkbucket
+    depends_on:
+      - fake-gcs
+    # NOTE: single-line script -- a YAML folded (>) block preserves newlines on
+    # more-indented continuation lines, which would split the curl command.
+    entrypoint:
+      - "/bin/sh"
+      - "-c"
+      - 'for i in $$(seq 1 30); do if curl -sf -X POST "http://fake-gcs:4443/storage/v1/b?project=dtf" -H "Content-Type: application/json" -d "{\"name\":\"ak-artifacts\"}"; then echo bucket-ready; exit 0; fi; echo "waiting for fake-gcs ($$i)"; sleep 1; done; echo gcs-createbucket-FAILED; exit 1'
+    networks:
+      gcsemu: {}
+
+  backend:
+    depends_on:
+      postgres:
+        condition: service_healthy
+      gcs-createbucket:
+        condition: service_completed_successfully
+    environment:
+      STORAGE_BACKEND: gcs
+      GCS_BUCKET: ak-artifacts
+      # Custom endpoint (#2646): routes GCS API URLs at the emulator + selects
+      # the static-token emulator auth mode (no GCS_PRIVATE_KEY set).
+      GCS_ENDPOINT: http://fake-gcs:4443
+      # The GCS control/stream clients are SSRF-guarded; allow the emulator's
+      # private subnet. Metadata/loopback/link-local stay hard-blocked.
+      AK_SSRF_ALLOW_PRIVATE_CIDRS: 172.16.0.0/12
+    networks:
+      dtf: {}
+      gcsemu: {}
+
+networks:
+  # backend <-> fake-gcs. 172.16/12 subnet so the emulator is allowlisted by
+  # AK_SSRF_ALLOW_PRIVATE_CIDRS at fetch time.
+  gcsemu:
+    name: ak-dtf${DTF_SLOT}-gcsemu
+    ipam:
+      config:
+        - subnet: 172.29.${DTF_SLOT}.0/24


### PR DESCRIPTION
## Summary

Backfills two discriminating DTF tiers for banked 1.7.0 fixes. Each was
verified to flip: **RED** on the pre-fix `1.6.2-rc` image, **GREEN** on a
`dtf-batch2-green` image built from `main` with both fix commits cherry-picked.

| Tier | Guards | Profile added | GREEN | RED |
| --- | --- | --- | --- | --- |
| `oidc-env-config` | #2792 / PR #2841 | `sso.oidc-bootstrap.yml` | 4/4 pass | 3/4 fail (premise passes) |
| `gcs-custom-endpoint` | #2646 / PR #2842 | `storage.gcs-emulator.yml` | 5/5 pass | stack unhealthy (exit 7) |

Both tier names are wired into the `all` set in `harness/run.sh`.

---

### Tier 1 — `oidc-env-config` (guards #2792 / PR #2841)

PR #2841 exposes OIDC provider toggles as env vars in the bootstrap path
(`main.rs` `build_oidc_request_from_values`). The tier boots the backend with
the OIDC env bootstrap (`OIDC_ISSUER` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET`
+ `OIDC_NAME`) and the three toggles set to values that flip against the
pre-fix hardcoded defaults, then reads the bootstrapped provider back through
`GET /api/v1/admin/sso/oidc` (and the `oidc_configs` DB row) and asserts:

- `OIDC_MAP_GROUPS_TO_GROUPS=true` → `map_groups_to_groups=true` (headline)
- `OIDC_AUTO_CREATE_USERS=false` → `auto_create_users=false`
- `OIDC_PKCE_ENABLED=false` → `pkce_enabled=false`

No mock IdP is required: `create_oidc` only SSRF-validates the issuer URL and
inserts the row (no live discovery at create time), so the profile uses an
unresolvable `idp.dtf.invalid` issuer host that passes the guard.

**RED → GREEN evidence** (`--slot 20` = `1.6.2-rc`, `--slot 19` = `dtf-batch2-green`):

```
GREEN (dtf-batch2-green):  Results: 4 passed, 0 failed, 0 skipped
  map_groups_to_groups api='true'  db='t'
  auto_create_users    api='false' db='f'
  pkce_enabled         api='false' db='f'

RED (1.6.2-rc):            Results: 1 passed, 3 failed, 0 skipped
  CASE 0 premise (provider bootstrapped) ... PASS
  CASE 1 map_groups_to_groups api='false' db='f'  (expected true)   FAIL
  CASE 2 auto_create_users    api='true'  db='t'  (expected false)  FAIL
  CASE 3 pkce_enabled         api='true'  db='t'  (expected false)  FAIL
```

The premise (provider gets bootstrapped) passes on both images; only the toggle
assertions flip — the env is ignored on the pre-fix image (hardcoded
`map_groups_to_groups: None`, `auto_create_users: Some(true)`, `pkce_enabled:
None`).

---

### Tier 2 — `gcs-custom-endpoint` (guards #2646 / PR #2842)

PR #2842 lets the GCS backend target a custom endpoint (`GCS_ENDPOINT`) so it
can run against a local emulator instead of real Google storage (the GCS analog
of `S3_ENDPOINT`/MinIO). The tier runs an `fsouza/fake-gcs-server` emulator + a
create-bucket sidecar, points the backend at it (`STORAGE_BACKEND=gcs`,
`GCS_ENDPOINT=http://fake-gcs:4443`, `AK_SSRF_ALLOW_PRIVATE_CIDRS` for the
emulator subnet), creates a maven repo (inherits the gcs backend), uploads an
artifact and downloads it back — asserting the round-trip AND that the object
physically landed in the emulator bucket (queried directly on the emulator).

**RED → GREEN evidence** (`--slot 19` = `dtf-batch2-green`, `--slot 20` = `1.6.2-rc`):

```
GREEN (dtf-batch2-green):  Results: 5 passed, 0 failed, 0 skipped
  upload PUT status         = 201
  download bytes match      = yes
  emulator objects pre/post = 0/1

RED (1.6.2-rc):            RUN EXIT: 7
  container ak-dtf20-backend is unhealthy
  !! stack failed to come up healthy for tier 'gcs-custom-endpoint'
  (backend /health = 503: GCS_ENDPOINT ignored -> targets real
   storage.googleapis.com with ADC/metadata auth -> never becomes ready)
```

On the pre-fix image `GCS_ENDPOINT` is ignored, so the backend keeps targeting
real Google GCS and its storage-health probe never passes — the tier fails to
come up (the task's expected "upload/health fails" RED). On the fix the
emulator round-trip succeeds and the tier is healthy and green.

---

## Test Checklist
- [x] Tiers verified discriminating (RED on `1.6.2-rc`, GREEN on `dtf-batch2-green`)
- [x] Both tiers wired into the `all` set in `run.sh`
- [x] No changes to existing tiers/profiles beyond the `all` set line
