### PR TITLE
release-gate: run control jobs on hosted runners

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -89,6 +89,16 @@ on:
         type: boolean
         default: false
 
+# Serialize gate runs that target the same backend image so two runs
+# of one candidate do not interleave across the single shared ARC pool
+# (~29 cluster jobs). The key is the candidate tag, so distinct
+# candidates keep their own group and are unaffected; cancel-in-progress
+# is false so an in-flight gate finishes (including teardown) rather
+# than being cancelled mid-deploy and leaking a namespace.
+concurrency:
+  group: release-gate-${{ inputs.backend_tag }}
+  cancel-in-progress: false
+
 env:
   NAMESPACE_CPU: ${{ vars.TEST_NAMESPACE_CPU || '4000m' }}
   NAMESPACE_MEMORY: ${{ vars.TEST_NAMESPACE_MEMORY || '8Gi' }}
@@ -119,7 +129,11 @@ jobs:
   # routine gate runs against non-release builds are unaffected.
   # -------------------------------------------------------------------
   version-set-integrity:
-    runs-on: ak-e2e-runners
+    # Registry/input validation only: helm template renders the chart
+    # locally and curl checks image tags on public ghcr.io. No kubectl,
+    # no kubeconfig, no cluster mutation, so it runs on a hosted runner
+    # and stays available even when the ARC pool is saturated or down.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -2028,7 +2042,11 @@ jobs:
   collect-results:
     needs: [version-set-integrity, clean-install-smoke, clean-install-smoke-with-deps, chart-upgrade-smoke, deploy, real-flow-smoke, scan-completion-gate, sbom-correctness-gate, pinned-cve-gate, pinned-cve-image-gate, format-tests, security-tests, compatibility-tests, repo-tests, promotion-tests, rbac-tests, lifecycle-tests, webhook-tests, search-tests, platform-tests, auth-tests, admin-tests, stress-tests, resilience-tests, mesh-tests]
     if: always()
-    runs-on: ak-e2e-runners
+    # Result rollup only: aggregates needs[].result and downloads JUnit
+    # artifacts. No cluster access. Runs on a hosted runner so a
+    # cancelled or timed-out run terminates the rollup cleanly instead
+    # of leaving it queued behind a saturated or offline ARC pool.
+    runs-on: ubuntu-latest
     steps:
       - name: Download all test artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## Summary

Make the release-gate's control jobs runner-independent so gate supervision does not depend on the single shared ARC pool that the ~29 cluster jobs contend for.

- **version-set-integrity** moves to `ubuntu-latest`. It is registry/input validation only: it renders the Helm chart locally with `helm template` and checks image tags on public `ghcr.io` with `curl`. It has no `kubectl`, no kubeconfig, and mutates no cluster state, so it does not need a cluster-capable runner and now stays available even when the ARC pool is saturated or down.
- **collect-results** moves to `ubuntu-latest`. It only aggregates `needs.*.result` and downloads JUnit artifacts. On a hosted runner a cancelled or timed-out run terminates the rollup cleanly instead of queuing behind a saturated or offline ARC pool, so result collection cannot sit queued indefinitely after a cancellation.
- **Workflow-level concurrency** added, keyed to the candidate `backend_tag` with `cancel-in-progress: false`. Two runs targeting the same backend image serialize across the single shared pool rather than interleaving; distinct candidates keep their own group and are unaffected. This workflow is triggered only by `workflow_dispatch` and `workflow_call` (no `pull_request` trigger), so no unrelated PR checks are serialized.

### What stayed on the cluster runners (`ak-e2e-runners`)

All namespace-mutating jobs: `deploy`, `clean-install-smoke`, `chart-upgrade-smoke`, the test-suite jobs, and **teardown**. Teardown runs `kubectl`/`helm` and `scripts/teardown-test-namespace.sh` to remove the test namespace, so it must keep cluster access and was not moved.

### Teardown capacity note (not changed here)

Teardown currently shares the same `ak-e2e-runners` label as the ~29 cluster jobs, so under a saturated pool it can queue behind the very jobs it needs to clean up after. If a dedicated priority label for teardown becomes available, giving teardown its own `runs-on` would guarantee it cluster-control capacity. This PR does not invent a new runner pool; it only flags the option.

## Test Checklist

- [x] `git diff --check` clean (no whitespace errors)
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`), 29 jobs, concurrency block present
- [x] Moved jobs verified cluster-free: no `kubectl`, `KUBECONFIG`, `helm install/upgrade`, or private hostnames in their steps
- [x] Job runner counts: 27 on `ak-e2e-runners` + 2 on `ubuntu-latest` = 29
- [x] `teardown` runner unchanged
- [x] `actionlint` run: only pre-existing findings (unknown custom label `ak-e2e-runners` on all self-hosted jobs, and shellcheck style notes in untouched jobs); no new findings from this change

## API Changes

None. CI workflow only; no test suite content, versions, or deploy jobs changed.

Closes #270