### PR TITLE
fix(platform): scrape metrics from admin endpoint in cardinality gate

### DIFF
--- a/tests/platform/test-metrics-unmatched-cardinality.sh
+++ b/tests/platform/test-metrics-unmatched-cardinality.sh
@@ -56,9 +56,13 @@ JUNK_PATHS=(
 )
 NUM_PROBES=${#JUNK_PATHS[@]}
 
-# Fetch /metrics text (public endpoint; no auth needed).
+# Fetch the Prometheus metrics text. The backend serves metrics only at
+# /api/v1/admin/metrics behind admin auth; the old unauthenticated /metrics
+# path was removed (see tests/security/redteam/test-15-metrics-auth.sh). We
+# reuse the suite's admin token via auth_header() (auth_admin ran above).
 fetch_metrics() {
-  curl -sf --max-time 15 "${BASE_URL}/metrics" 2>/dev/null
+  curl -sf --max-time 15 -H "$(auth_header)" \
+    "${BASE_URL}/api/v1/admin/metrics" 2>/dev/null
 }
 
 # Sum ak_http_requests_total across every series whose label set contains
@@ -80,7 +84,7 @@ begin_test "Metrics endpoint is available"
 if fetch_metrics > /dev/null 2>&1; then
   pass
 else
-  fail "GET /metrics returned error"
+  fail "GET /api/v1/admin/metrics returned error"
 fi
 
 # =========================================================================
@@ -101,7 +105,7 @@ METRICS="$(fetch_metrics || true)"
 if [ -n "$METRICS" ]; then
   pass
 else
-  fail "GET /metrics returned an empty body after probing"
+  fail "GET /api/v1/admin/metrics returned an empty body after probing"
 fi
 
 # =========================================================================


### PR DESCRIPTION
## Summary

The `metrics-unmatched-cardinality` release gate scraped `GET /metrics` unauthenticated. The backend no longer serves metrics there: the Prometheus endpoint moved to `GET /api/v1/admin/metrics` behind admin auth, and the old public path was removed (this is exactly what `tests/security/redteam/test-15-metrics-auth.sh` regression-guards). With the old path gone, every fetch in this gate returned an error and the suite failed.

`fetch_metrics()` now hits `/api/v1/admin/metrics` with the suite's admin token via `auth_header()`. `auth_admin` already runs at the top of the suite, so the token is populated. The two failure messages that named `/metrics` were updated to the new path.

The series assertions are unchanged and still valid: they read from the same metrics registry, so `ak_http_requests_total{path="unmatched"}` and `path="/health"` appear identically whether the text is served at the old or new endpoint. The junk-path probes still hit `${BASE_URL}${p}` unauthenticated on purpose, which is what mints the `path="unmatched"` series.

## Testing

Static validation only (the cluster release-gate suite cannot run locally):

- `bash -n` on the changed script: pass
- `shellcheck -S warning`: no findings
- `git diff --check`: clean

## Related

Closes #272
