### PR TITLE
fix(repos): gate concurrent-put suite on partial-update contract

### DIFF
--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -263,6 +263,19 @@ _feature_min_version() {
     # only run against a 1.2.0+ backend and stay out of the in-flight
     # 1.1.9 release-gate. Tracks artifact-keeper-test#92, #93, #94, #95.
     "virtual_member_strict_contract") echo "1.2.0" ;;
+    # virtual_member_partial_update_contract: the PRE-#2795 partial-update
+    # PUT /:key/members contract (update listed members in place, leave others
+    # untouched). This is an UPPER-bounded contract, removed when full-set
+    # replace landed (artifact-keeper#2795, on the 1.3.0 line), so it is present
+    # ONLY on 1.1.x / 1.2.x-era backends. It is authoritatively gated by the
+    # branch-aware AK_FEATURES layer (feature-flags.sh: in the 1.1.x/1.2.x
+    # bundles, NOT main). The min-version probe model here cannot express an
+    # upper bound, so on the local-dev fallback path (AK_FEATURES unset) we use
+    # an unreachable sentinel to conservatively SKIP on modern backends rather
+    # than run obsolete assertions; set AK_FEATURES to force a run against a
+    # genuine 1.1.x/1.2.x backend. Gates
+    # tests/repos/test-virtual-members-concurrent-put.sh (artifact-keeper#2899).
+    "virtual_member_partial_update_contract") echo "99.0.0" ;;
     # Auth/Epic-11 features. Targeted for v1.1.9 because security-flavoured
     # work (rotation + token revocation on deactivate) is likely to land on
     # the release/1.1.x maintenance branch as a backport rather than wait

--- a/tests/lib/feature-flags.sh
+++ b/tests/lib/feature-flags.sh
@@ -134,6 +134,25 @@ AK_BACKEND_BRANCH_MAIN="\
   oci_gc_two_phase \
 "
 
+# virtual_member_partial_update_contract: marks a backend whose
+# PUT /:key/members uses the PRE-#2795 PARTIAL-UPDATE contract (update the
+# listed members' priorities in place, leave unlisted members untouched).
+#
+# Unlike every additive flag above, this is an UPPER-bounded contract: it was
+# REMOVED when full-set-replace semantics landed (artifact-keeper#2795, on the
+# 1.3.0 line), so it is present on 1.1.x / 1.2.x-era backends and ABSENT on
+# main (whose backend already has replace semantics). Because MAIN is defined
+# as a superset of the 1.2.x bundle, we cannot express "in 1.2.x but NOT main"
+# by adding the token inside the literal 1_1_X / 1_2_X blocks above (it would
+# flow into MAIN through inheritance). Instead we append it to the 1.1.x and
+# 1.2.x bundles HERE, after MAIN has already been assigned its (token-free)
+# value, so MAIN never captures it.
+#
+# Gates tests/repos/test-virtual-members-concurrent-put.sh. The replacement
+# assertions for replace semantics are pending artifact-keeper#2899.
+AK_BACKEND_BRANCH_1_1_X="$AK_BACKEND_BRANCH_1_1_X virtual_member_partial_update_contract"
+AK_BACKEND_BRANCH_1_2_X="$AK_BACKEND_BRANCH_1_2_X virtual_member_partial_update_contract"
+
 # -----------------------------------------------------------------------------
 # Helpers
 # -----------------------------------------------------------------------------

--- a/tests/repos/test-virtual-members-concurrent-put.sh
+++ b/tests/repos/test-virtual-members-concurrent-put.sh
@@ -120,14 +120,26 @@ setup_workdir
 # whether the update loop should be atomic at all) are the subject of the
 # semantics decision tracked in artifact-keeper#2899.
 #
-# Gate the whole suite behind virtual_member_strict_contract, matching the
-# sibling tests/repos/test-virtual-repo-member-bulk-update.sh, so it auto-skips
-# on current backends until #2899 lands and the assertions can be rewritten for
-# replace semantics. The 5xx / non-200 checks are not cleanly separable from the
-# partial-update reset+race harness, so the entire suite is gated rather than a
-# subset of it.
+# Gate the whole suite behind virtual_member_partial_update_contract, a flag
+# that is enabled ONLY for 1.1.x / 1.2.x-era backends (see feature-flags.sh:
+# it lives in the 1.1.x and 1.2.x bundles, NOT main). The release-gate workflow
+# derives AK_BACKEND_BRANCH from the backend tag: a 1.1.x tag maps to
+# release/1.1.x, a 1.2.x tag to release/1.2.x, and EVERYTHING ELSE (every 1.3+
+# tag, including 1.6.3) maps to 'main'. main-bundle backends already have the
+# #2795 replace semantics, so the flag is absent there and this suite auto-skips
+# on all current gates, running only against 1.1.x / 1.2.x-era backends where
+# the partial-update contract actually held.
+#
+# (virtual_member_strict_contract, used by the sibling shape-assertion test, is
+# the WRONG flag here: it is additive/present-from-1.2.0-onward, so it is
+# enabled on main and would let this suite run its obsolete assertions and fail.)
+#
+# The 5xx / non-200 checks are not cleanly separable from the partial-update
+# reset+race harness, so the entire suite is gated rather than a subset of it.
+# The replacement assertions for replace semantics are pending
+# artifact-keeper#2899.
 begin_test "Backend supports the partial-update virtual-member contract"
-if require_feature "virtual_member_strict_contract"; then
+if require_feature "virtual_member_partial_update_contract"; then
   pass
 else
   end_suite

--- a/tests/repos/test-virtual-members-concurrent-put.sh
+++ b/tests/repos/test-virtual-members-concurrent-put.sh
@@ -73,6 +73,13 @@
 #
 # KNOWN GAP / TRACKING ISSUE
 # --------------------------
+# CONTRACT SUPERSEDED: everything below assumes the pre-#2795 partial-update
+# PUT semantics. Backend PR artifact-keeper#2795 changed PUT /:key/members to
+# full-set replace, which invalidates these invariants (see the contract gate
+# near begin_suite). The suite is gated off on current backends pending the
+# replace-semantics decision in artifact-keeper#2899; the notes below are
+# retained as the historical rationale for the partial-update assertions.
+#
 # Once the backend wraps the loop in a single transaction, a stronger
 # assertion becomes meaningful: the final state across A, B, C should
 # match exactly one writer's payload semantics for the contested rows.
@@ -94,6 +101,38 @@ source "$(dirname "$0")/../lib/common.sh"
 begin_suite "virtual-members-concurrent-put"
 auth_admin
 setup_workdir
+
+# ---------------------------------------------------------------------------
+# Contract gate (artifact-keeper#2899).
+#
+# This suite was written against the PRE-#2795 PARTIAL-UPDATE PUT semantics:
+# PUT /:key/members updated priorities on the listed existing members and left
+# unlisted members untouched. That is what makes the race meaningful (two
+# writers touch an overlapping member set) and what every invariant below
+# assumes: V keeps all 3 members, the uncontested rows A=10 and C=300 survive,
+# and the per-iteration reset PUT sets only row B without dropping A and C.
+#
+# Backend PR artifact-keeper#2795 changed PUT /:key/members to FULL-SET REPLACE:
+# the request body becomes the complete member set. Under replace, writer 1's
+# {A,B} body drops C, writer 2's {B,C} body drops A, and the reset-B-only setup
+# PUT would drop A and C entirely, so none of these invariants hold and the race
+# harness itself is invalid. The correct replace-semantics assertions (and
+# whether the update loop should be atomic at all) are the subject of the
+# semantics decision tracked in artifact-keeper#2899.
+#
+# Gate the whole suite behind virtual_member_strict_contract, matching the
+# sibling tests/repos/test-virtual-repo-member-bulk-update.sh, so it auto-skips
+# on current backends until #2899 lands and the assertions can be rewritten for
+# replace semantics. The 5xx / non-200 checks are not cleanly separable from the
+# partial-update reset+race harness, so the entire suite is gated rather than a
+# subset of it.
+begin_test "Backend supports the partial-update virtual-member contract"
+if require_feature "virtual_member_strict_contract"; then
+  pass
+else
+  end_suite
+  exit 0
+fi
 
 LOCAL_A="test-vmcp-a-${RUN_ID}"
 LOCAL_B="test-vmcp-b-${RUN_ID}"


### PR DESCRIPTION
## Summary

`test-virtual-members-concurrent-put.sh` was written against the pre-#2795 partial-update `PUT /:key/members` semantics, where a PUT updated priorities on the listed existing members and left unlisted members untouched. Every invariant depends on that: V keeps all 3 members, the uncontested rows A=10 and C=300 survive, and the per-iteration reset PUT sets only row B without dropping A and C.

Backend PR artifact-keeper#2795 changed `PUT /:key/members` to full-set replace, where the request body becomes the complete member set. Under replace, writer 1's `{A,B}` body drops C, writer 2's `{B,C}` body drops A, and the reset-B-only setup PUT would drop A and C entirely. The invariants no longer hold and the race harness itself is invalid.

Change: gate the whole suite behind `require_feature "virtual_member_strict_contract"`, matching the sibling `test-virtual-repo-member-bulk-update.sh`, so it auto-skips on current backends until the replace-semantics decision in artifact-keeper#2899 lands and the assertions can be rewritten. The 5xx / non-200 checks are not cleanly separable from the partial-update reset+race harness (the reset PUT is itself partial-update-shaped), so the entire suite is gated rather than a subset. The stale KNOWN GAP header note is annotated to point at the superseding change.

## Note for reviewers

This uses the existing `virtual_member_strict_contract` flag as instructed. That flag maps to `>= 1.2.0` in `_feature_min_version` and is present in the 1.2.x / main branch feature bundles, so the auto-skip depends on the release gate's `AK_BACKEND_BRANCH` resolving to a set that does NOT include it (e.g. a 1.6.x branch label, which the feature-flag resolver treats as unknown and defaults to the restrictive 1.1.x set). Please confirm the gate's branch label so the suite skips as intended rather than running the obsolete assertions.

## Testing

Static validation only (the cluster release-gate suite cannot run locally):

- `bash -n` on the changed script: pass
- `shellcheck -S warning`: no findings
- `git diff --check`: clean

## Related

Closes #274
