### PR TITLE
fix(lifecycle): compute OCI GC layer digests in the parent shell

### DIFF
--- a/tests/lifecycle/test-oci-gc-mark-sweep.sh
+++ b/tests/lifecycle/test-oci-gc-mark-sweep.sh
@@ -86,7 +86,9 @@ blob_status() {
 }
 
 # Push a config blob + a layer blob, then a manifest referencing them. Echoes
-# the manifest PUT status. Globals set: LAYER_DIGEST (of the given layer file).
+# the manifest PUT status. Runs in a command-substitution subshell at every
+# call site, so it exports nothing to the parent; callers recompute the layer
+# digest themselves with the same formula used below.
 push_image() {
   local image="$1" layer_file="$2" tag="$3"
   local cfg='{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":[]},"config":{}}'
@@ -97,7 +99,6 @@ push_image() {
   cfg_size=$(wc -c < "$cfg_file" | tr -d ' ')
   layer_digest="sha256:$(shasum -a 256 "$layer_file" | awk '{print $1}')"
   layer_size=$(wc -c < "$layer_file" | tr -d ' ')
-  LAYER_DIGEST="$layer_digest"
 
   push_blob "$image" "$cfg_file" "$cfg_digest" >/dev/null
   push_blob "$image" "$layer_file" "$layer_digest" >/dev/null
@@ -146,7 +147,10 @@ printf 'gc-layer-b2-%s\n' "$RUN_ID" > "${WORK_DIR}/layer-b2.bin"
 
 begin_test "Push image A (layer B1)"
 st=$(push_image "$IMG_A" "${WORK_DIR}/layer-b1.bin" "$TAG")
-B1_DIGEST="$LAYER_DIGEST"
+# push_image runs in a command-substitution subshell, so the LAYER_DIGEST it
+# sets never reaches this parent shell. Recompute B1's digest here in the
+# parent using the same formula push_image uses, so it is defined under set -u.
+B1_DIGEST="sha256:$(shasum -a 256 "${WORK_DIR}/layer-b1.bin" | awk '{print $1}')"
 if [ "$st" = "201" ] || [ "$st" = "200" ]; then
   pass
 else
@@ -158,7 +162,8 @@ fi
 
 begin_test "Push image B (layer B2, stays referenced)"
 st=$(push_image "$IMG_B" "${WORK_DIR}/layer-b2.bin" "$TAG")
-B2_DIGEST="$LAYER_DIGEST"
+# Same subshell caveat as B1: recompute B2's digest in the parent shell.
+B2_DIGEST="sha256:$(shasum -a 256 "${WORK_DIR}/layer-b2.bin" | awk '{print $1}')"
 if [ "$st" = "201" ] || [ "$st" = "200" ]; then
   pass
 else


### PR DESCRIPTION
## Summary

`test-oci-gc-mark-sweep.sh` pushes two images and needs each layer's digest to later probe blob presence. `push_image()` sets a global `LAYER_DIGEST`, but every call site invokes it as `st=$(push_image ...)`, i.e. in a command-substitution subshell. The global set inside the subshell never propagates to the parent, so `B1_DIGEST="$LAYER_DIGEST"` read an unbound variable and, under `set -u`, the script died before reaching any GC assertion.

Fix: recompute `B1_DIGEST` and `B2_DIGEST` in the parent shell immediately after each `push_image` call, using the exact same formula `push_image` uses for the layer digest:

```
sha256:$(shasum -a 256 "$layer_file" | awk '{print $1}')
```

The layer files (`layer-b1.bin`, `layer-b2.bin`) are written in the parent shell before the pushes, so the parent recomputation is byte-for-byte identical to what the manifest referenced. The now-dead `LAYER_DIGEST` global and its stale "Globals set" contract note in `push_image` are removed.

## Testing

Static validation only (the cluster release-gate suite cannot run locally):

- `bash -n` on the changed script: pass
- `shellcheck -S warning`: no findings (the change also clears the SC2034 that removing the dead global would otherwise leave)
- Verified the `shasum -a 256` formula emits a well-formed `sha256:<64-hex>` digest
- `git diff --check`: clean

## Related

Closes #275
