### PR TITLE
fix(helm): preseed trivy DB from ghcr in full test values

### DIFF
--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -219,6 +219,17 @@ trivy:
   image:
     repository: aquasec/trivy
     tag: "0.62.1"
+  # Vulnerability DB: pull from ghcr.io/aquasecurity/trivy-db (anonymous) and
+  # pre-seed it with an init container so the DB is present before the server
+  # accepts scans. The gate cluster's anonymous mirror.gcr.io pulls returned
+  # UNAUTHORIZED; ghcr anonymous is the reliably-reachable source per the chart
+  # values comments. repository + preseed together is the chart's documented
+  # "make the fetch reliable" combination. The Java DB (javaRepository) is left
+  # empty so Trivy uses its built-in ghcr default. skipUpdate stays false.
+  db:
+    repository: ghcr.io/aquasecurity/trivy-db
+    preseed:
+      enabled: true
   persistence:
     size: 2Gi
   resources:


### PR DESCRIPTION
## Summary

In the full test overlay (`helm/values-test-full.yaml`), Trivy pulled its vulnerability DB anonymously from `mirror.gcr.io`, which returned UNAUTHORIZED on the gate cluster. With no DB, the scanner could not complete scans and the pinned-cve pre-flight failed.

Change: add a `trivy.db` block that points the DB repository at `ghcr.io/aquasecurity/trivy-db` (anonymous, reliably reachable) and enables `trivy.db.preseed`, so an init container pulls the DB before the server accepts scans. Per the chart's own `values.yaml` comments, `repository` + `preseed` together is the documented "make the fetch reliable" combination, and pointing at ghcr rather than mirror.gcr.io is what makes preseed safe to enable (the mirror.gcr.io preseed was the source of the earlier install-timeout hangs).

Deliberately minimal:

- No pull-secret is added. The chart's `trivy.db` schema exposes no pull-secret key, and ghcr anonymous is already more reliable than mirror.gcr.io for this DB.
- `trivy.db.javaRepository` is left empty so Trivy uses its built-in ghcr default for the Java DB.
- `trivy.db.skipUpdate` stays false (default).
- No test files are touched; the pinned-cve gate's fail-closed assertions are untouched.

## Testing

Static validation only (the cluster release-gate suite cannot run locally):

- `python3` `yaml.safe_load` on the values file: parses cleanly; `trivy.db.repository == ghcr.io/aquasecurity/trivy-db` and `trivy.db.preseed.enabled == true` confirmed
- Confirmed the `trivy.db` keys used (`repository`, `preseed.enabled`) exist in the `artifact-keeper-iac` chart `values.yaml` schema
- `git diff --check`: clean

## Related

Closes #276
