### PR TITLE
fix(helm): point scanner-adapter Trivy at ghcr DB in full test values

### DIFF
--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -240,6 +240,24 @@ trivy:
       cpu: "1"
       memory: 2Gi
 
+# Container-image scans run in the scanner-adapter's in-process Trivy, which
+# does NOT read the trivy.db.* server settings above (#281 fixed only the Trivy
+# server, used for filesystem/SBOM scans). Point the adapter's own Trivy at the
+# anonymous ghcr DB so image scans do not hit the rate-limited mirror.gcr.io.
+#
+# The chart's scanner-adapter-deployment.yaml renders these with
+# `range $key, $value := .Values.scannerAdapter.env`, i.e. it iterates the
+# whole map, and Helm deep-merges this override into the chart's default
+# scannerAdapter.env per key. The chart default sets SCANNER_TRIVY_INSECURE:
+# "true" (the adapter reaches the AK registry over the plain-HTTP in-cluster
+# Service); it would survive the merge on its own, but we replicate it here so
+# the override is self-describing. TRIVY_DB_REPOSITORY is the additive key.
+# See artifact-keeper-test#285.
+scannerAdapter:
+  env:
+    TRIVY_DB_REPOSITORY: "ghcr.io/aquasecurity/trivy-db"
+    SCANNER_TRIVY_INSECURE: "true"
+
 secrets:
   jwtSecret: "ak-ci-nonprod-q7z6wharZXoYYW3BI1ZPSdbMDyXrXS6DiCajP8IPCHg4Bjgb"
 


### PR DESCRIPTION
## Summary

Container-image scans run in the scanner-adapter's in-process Trivy, which does NOT read the `trivy.db.*` server settings. #281 fixed only the Trivy server (used for filesystem/SBOM scans). Without its own DB repository the adapter's Trivy pulls the vuln DB from the rate-limited `mirror.gcr.io` and image scans fail.

Change: add a top-level `scannerAdapter.env` override:

```yaml
scannerAdapter:
  env:
    TRIVY_DB_REPOSITORY: "ghcr.io/aquasecurity/trivy-db"
    SCANNER_TRIVY_INSECURE: "true"
```

## Chart-defaults finding (as requested)

I read `artifact-keeper/artifact-keeper-iac` `charts/artifact-keeper` on main:

- `values.yaml` sets exactly one default under `scannerAdapter.env`: `SCANNER_TRIVY_INSECURE: "true"` (the adapter reaches the AK registry over the plain-HTTP in-cluster Service). No other default env keys.
- `templates/scanner-adapter-deployment.yaml` renders env with `{{- range $key, $value := .Values.scannerAdapter.env }}`, i.e. it iterates the whole map rather than referencing individual keys.

Because a single `-f` override is deep-merged into the chart defaults by Helm per key, `SCANNER_TRIVY_INSECURE: "true"` would survive on its own even if I only added `TRIVY_DB_REPOSITORY`. Per instruction I replicated it anyway so the override is self-describing and robust to any future merge-order change. `TRIVY_DB_REPOSITORY` is the only strictly additive key.

## Testing

Static validation only (the cluster release-gate suite cannot run locally):

- `python3` `yaml.safe_load`: parses cleanly; `scannerAdapter.env` has both keys with the expected values
- Confirmed no bleed from the sibling GC-schedule change (`backend.env.GC_SCHEDULE` absent on this branch)
- `git diff --check`: clean

## Related

Closes #285
