### PR TITLE
fix(lifecycle): skip same-session OCI blob reclaim (24h age shield)

### DIFF
--- a/tests/lifecycle/test-oci-gc-mark-sweep.sh
+++ b/tests/lifecycle/test-oci-gc-mark-sweep.sh
@@ -14,9 +14,13 @@
 # This gate:
 #   1. Pushes image A (layer blob B1) and image B (layer blob B2), each tagged.
 #   2. Deletes image A's manifest so B1 is genuinely unreferenced.
-#   3. Triggers GC (POST /api/v1/admin/storage-gc {"dry_run":false}), polling a
-#      few times to absorb a short grace window.
-#   4. Asserts RECLAIM: B1 GET -> 404 (swept).
+#   3. Triggers GC (POST /api/v1/admin/storage-gc {"dry_run":false}) a few times
+#      to run the sweep.
+#   4. RECLAIM (B1 GET -> 404) is NOT assertable at the gate and is SKIPPED: the
+#      backend enforces a compile-time MIN_BLOB_AGE_SECS = 24h shield on blob
+#      deletion (storage_gc_service.rs:123), so a blob pushed this session can
+#      never be swept during the run. Tracked for an env-configurable age shield
+#      in artifact-keeper#2906 (see artifact-keeper-test#292).
 #   5. Asserts NO DANGLING: image B's manifest still resolves (200) and its
 #      referenced blob B2 still resolves (200) -- GC did not sweep a live blob.
 #
@@ -198,25 +202,22 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Trigger GC (poll to absorb a short grace window)
+# Trigger GC. We still RUN the sweep so the no-dangling-ref checks below prove
+# it does not touch a live blob, but the B1 reclaim itself is NOT assertable at
+# the gate: the backend enforces a compile-time MIN_BLOB_AGE_SECS = 24h shield
+# on blob deletion (storage_gc_service.rs:123) that protects in-flight pushes,
+# so a blob pushed this session can never be swept during the run no matter how
+# short BLOB_GC_SWEEP_GRACE_SECS is. This is the same "not drivable at the gate
+# layer" situation as the resurrection sub-test below; it is skipped pending an
+# env-configurable age shield (backend artifact-keeper#2906).
 # ---------------------------------------------------------------------------
 
 begin_test "GC reclaims unreferenced blob B1 (GET -> 404)"
-reclaimed=false
-for _attempt in $(seq 1 6); do
+for _attempt in $(seq 1 3); do
   api_post "/api/v1/admin/storage-gc" '{"dry_run":false}' >/dev/null 2>&1 || true
-  st=$(blob_status "$IMG_A" "$B1_DIGEST")
-  if [ "$st" = "404" ]; then
-    reclaimed=true
-    break
-  fi
-  sleep 5
+  sleep 2
 done
-if $reclaimed; then
-  pass
-else
-  fail "blob B1 still present after GC (last status ${st}); check BLOB_GC_ENABLED=true and a short BLOB_GC_SWEEP_GRACE_SECS in the deploy overlay"
-fi
+skip "same-session blob reclaim is untestable at the gate: backend MIN_BLOB_AGE_SECS is a compile-time 24h shield for in-flight pushes (storage_gc_service.rs:123); tracked for an env-configurable age shield in artifact-keeper#2906 (artifact-keeper-test#292)"
 
 # ---------------------------------------------------------------------------
 # No dangling reference: image B's manifest + referenced blob survive


### PR DESCRIPTION
## Summary

The OCI GC gate asserted that an unreferenced blob B1 is reclaimed (`GET -> 404`) within a short poll window. That reclaim is not observable at the gate: the backend enforces a compile-time `MIN_BLOB_AGE_SECS = 24h` shield on blob deletion (`storage_gc_service.rs:123`) to protect in-flight pushes, so a blob pushed during the same session can never be swept during the run, no matter how short `BLOB_GC_SWEEP_GRACE_SECS` is set.

Change: convert the "B1 reclaimed" assertion to a `skip` (the same "not drivable at the gate layer" pattern already used by the resurrection sub-test), while still triggering the sweep a few times so the no-dangling-ref checks below remain meaningful (they prove GC does not touch a live blob).

Kept unchanged:

- manifest DELETE succeeds (B1 becomes unreferenced)
- image B's manifest still resolves 200 after GC
- referenced blob B2 survives GC (GET -> 200)

Tracked for an env-configurable age shield in backend artifact-keeper#2906.

## Testing

Static validation only (the cluster release-gate suite cannot run locally):

- `bash -n`: pass
- `shellcheck -S warning`: no findings (no orphaned `reclaimed` variable left behind)
- `git diff --check`: clean

## Related

Closes #292
