### PR TITLE
fix(formats): verify conda download with bzip2 -t not file

### DIFF
--- a/tests/formats/test-conda.sh
+++ b/tests/formats/test-conda.sh
@@ -125,8 +125,12 @@ begin_test "Download conda package"
 DL_URL="${CONDA_URL}/${SUBDIR}/${CONDA_FILENAME}"
 DL_FILE="${WORK_DIR}/downloaded.tar.bz2"
 if curl -sf -H "$(format_auth_header)" -o "$DL_FILE" "$DL_URL"; then
-  # Verify it is a valid bzip2 file
-  if file "$DL_FILE" | grep -qi "bzip2\|bz2"; then
+  # Verify it is a valid bzip2 file. Use `bzip2 -t` (integrity test) rather than
+  # `file`: the gate runner image does not ship the `file` utility, so the old
+  # `file ... | grep bzip2` check errored out and mis-reported a valid download.
+  # bzip2 is provably present (the fixture is built with `tar cjf`). See
+  # artifact-keeper-test#294.
+  if bzip2 -t "$DL_FILE"; then
     pass
   else
     fail "downloaded file is not a valid bzip2 archive"


### PR DESCRIPTION
## Summary

The "Download conda package" step verified the download with `file "$DL_FILE" | grep -qi bzip2`. The gate runner image does not ship the `file` utility, so that pipeline errored and the check mis-reported a perfectly valid `.tar.bz2` download as "not a valid bzip2 archive".

Change: verify with `bzip2 -t` (bzip2's built-in integrity test) instead. `bzip2` is provably present on the runner because the test builds its own fixture with `tar cjf` earlier in the same script. The failure message is unchanged and still accurate.

## Testing

Static validation only (the cluster release-gate suite cannot run locally):

- `bash -n`: pass
- `shellcheck -S warning`: no new findings in the changed region (two pre-existing SC2164 warnings at lines 42 and 66 are unrelated and untouched)
- `git diff --check`: clean
- Local smoke: `bzip2 -t` validates an archive produced by `tar cjf` (the same builder the fixture uses)

## Related

Closes #294
