### PR TITLE
fix(ci): authenticate scanner-adapter Trivy DB pull from ghcr

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -442,6 +442,15 @@ jobs:
           BACKEND_TAG: ${{ inputs.backend_tag }}
           BACKEND_DIGEST: ${{ inputs.backend_digest }}
           WEB_TAG: ${{ inputs.web_tag }}
+          # Authenticated Trivy DB pull for the scanner-adapter (#293). ghcr
+          # denies the adapter's anonymous registry token for the trivy-db pull
+          # once the Trivy server has already pulled anonymously from the same
+          # ghcr endpoint, so give the adapter's in-process Trivy its own
+          # credentials. The workflow's automatic GITHUB_TOKEN authenticates the
+          # (public) ghcr pull; create-test-namespace.sh injects it as
+          # scannerAdapter.env.TRIVY_USERNAME/TRIVY_PASSWORD via helm
+          # --set-string (never a values file). GitHub masks the token in logs.
+          SCANNER_TRIVY_PULL_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           chmod +x scripts/create-test-namespace.sh
           # Compose the digest-pinned image ref. Empty BACKEND_DIGEST =>

--- a/scripts/create-test-namespace.sh
+++ b/scripts/create-test-namespace.sh
@@ -8,7 +8,12 @@
 # and waits for the backend to become healthy.
 #
 # Environment variables:
-#   GHCR_DOCKER_CONFIG     - Base64-encoded Docker config for ghcr.io pull secret
+#   GHCR_DOCKER_CONFIG       - Base64-encoded Docker config for ghcr.io pull secret
+#   SCANNER_TRIVY_PULL_TOKEN - Optional. When set (and --full-stack), injected as
+#                              scannerAdapter.env.TRIVY_USERNAME/TRIVY_PASSWORD via
+#                              helm --set-string so the scanner-adapter's in-process
+#                              Trivy authenticates its ghcr vuln-DB pull (#293).
+#                              Never written to a values file.
 
 set -euo pipefail
 
@@ -136,6 +141,25 @@ HELM_CMD=(helm upgrade --install "$RELEASE_NAME" "$CHART_DIR"
 
 if [ -n "$EXTRA_VALUES" ]; then
   HELM_CMD+=(--values "${REPO_ROOT}/${EXTRA_VALUES}")
+fi
+
+# Authenticated Trivy DB pull for the scanner-adapter (artifact-keeper-test#293).
+# The scanner-adapter's in-process Trivy pulls its vuln DB from ghcr; when the
+# Trivy SERVER has already pulled anonymously from the same ghcr endpoint, ghcr
+# denies the adapter's anonymous token, so the adapter needs its own
+# credentials. The token is injected here from the environment (SCANNER_TRIVY_-
+# PULL_TOKEN, set by the workflow) and NEVER stored in a values file. helm
+# --set deep-merges per key with the -f values file, and the chart's
+# scanner-adapter-deployment.yaml ranges over the whole scannerAdapter.env map,
+# so the TRIVY_DB_REPOSITORY / SCANNER_TRIVY_INSECURE keys already in
+# values-test-full.yaml survive. --set-string forces the token to a string and
+# is appended last so it wins over any values-file key. Other callers that do
+# not set the token env simply get no injection (no-op).
+if [ -n "${SCANNER_TRIVY_PULL_TOKEN:-}" ]; then
+  HELM_CMD+=(
+    --set-string scannerAdapter.env.TRIVY_USERNAME=x-access-token
+    --set-string "scannerAdapter.env.TRIVY_PASSWORD=${SCANNER_TRIVY_PULL_TOKEN}"
+  )
 fi
 
 "${HELM_CMD[@]}"


### PR DESCRIPTION
## Summary

Container-image scans run in the scanner-adapter's in-process Trivy, which pulls its vulnerability DB from ghcr. When the Trivy server has already pulled anonymously from the same ghcr endpoint, ghcr denies the adapter's anonymous registry token, so the adapter's DB pull fails. The adapter needs its own credentials.

Change: the release-gate `deploy` step passes the workflow's automatic `GITHUB_TOKEN` as `SCANNER_TRIVY_PULL_TOKEN`, and `create-test-namespace.sh` injects it into the helm install as `scannerAdapter.env.TRIVY_USERNAME=x-access-token` / `TRIVY_PASSWORD=<token>` via `helm --set-string`.

## How the deploy invokes helm (verified)

The deploy step does not call helm directly; it runs `scripts/create-test-namespace.sh --full-stack`, which builds the `helm upgrade --install` command (`--values helm/values-test-full.yaml --set backend.image.tag=... --set web.image.tag=...`). `${{ secrets.GITHUB_TOKEN }}` can only be interpolated in the workflow, so the token flows workflow env -> script -> `helm --set-string`. This is why the change spans both files.

## Safety / no-clobber (verified)

- Token is passed via env and `--set-string`, never written to a values file.
- The two `--set-string` flags are appended last (after any `--values`), so they win.
- helm `--set` deep-merges per key with the `-f` values file, and the chart's `scanner-adapter-deployment.yaml` renders env via `range $key, $value := .Values.scannerAdapter.env` (iterates the whole map). So `TRIVY_DB_REPOSITORY` and `SCANNER_TRIVY_INSECURE` added to `values-test-full.yaml` in #288 survive the merge; only `TRIVY_USERNAME` / `TRIVY_PASSWORD` are added.
- The injection is gated on `SCANNER_TRIVY_PULL_TOKEN` being non-empty, so other callers of the script (clean-install-smoke, upgrade jobs) that do not set it get no change.
- The script uses `set -euo pipefail` (no `set -x`) and does not echo `HELM_CMD`, so the token is not printed; GitHub also masks `secrets.GITHUB_TOKEN` in logs.

## Testing

Static validation only (the cluster release-gate suite cannot run locally; this PR touches the workflow, so the fixture-gate CI runs on the PR):

- `bash -n scripts/create-test-namespace.sh`: pass
- `shellcheck -S warning`: no new findings in the changed regions (one pre-existing SC2064 at line 90, an unrelated `trap`, is untouched)
- `python3 yaml.safe_load` on `release-gate.yml`: parses; the deploy step's env carries `SCANNER_TRIVY_PULL_TOKEN`
- `git diff --check`: clean

## Related

Closes #293
