### PR TITLE
Make release-gate security suite blocking + fix fake-green SAML oracle

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1129,17 +1129,18 @@ jobs:
   # -------------------------------------------------------------------
   security-tests:
     needs: deploy
-    # continue-on-error: test-scan-completes.sh asserts on Grype scanner
-    # finishing with findings. Grype on the v1.1.x backend image fails
-    # deterministically because the vulnerability DB is not pre-seeded
-    # in the Dockerfile and our network-restricted ARC runner pods can't
-    # fetch grype.anchore.io at scan time. The quality gate is
-    # LAST-scanner-wins (policy_service reads LIMIT 1 ORDER BY created_at
-    # DESC), so Trivy success satisfies block_unscanned and the practical
-    # security posture is unaffected. Tracked for fix in v1.1.10:
-    # artifact-keeper#1001 (pre-seed Grype DB in Dockerfile). The other
-    # 44 security tests in the suite still run and gate the release.
-    continue-on-error: true
+    # BLOCKING (#2700). This suite is a hard release gate: it runs every
+    # security/*.sh test EXCEPT the single waivered Grype scan below, and any
+    # failure fails the release (wired into collect-results with the stricter
+    # `!= 'success'` predicate). continue-on-error was removed here: it used to
+    # mask the ENTIRE 45-test suite so a real security regression could ride
+    # through green (unfreeze-bar audit 2026-07-18, "the security suite cannot
+    # fail a release").
+    #
+    # The one genuinely-flaky test — test-scan-completes.sh — is carved out via
+    # `--exclude` and re-run soft in the `security-grype-scan-completes` job,
+    # which carries a NAMED WAIVER (owner + expiry). See that job for the
+    # rationale and the expiry. Nothing else in the suite is waivered.
     if: inputs.test_suite == 'all' || inputs.test_suite == 'security'
     runs-on: ak-e2e-runners
     timeout-minutes: 20
@@ -1207,11 +1208,16 @@ jobs:
           echo "Runner pod IP: ${POD_IP}"
           echo "MOCK_UPSTREAM_HOSTNAME=${POD_IP}" >> "$GITHUB_ENV"
 
-      - name: Run security tests
+      - name: Run security tests (blocking; waivered Grype scan excluded)
         run: |
           mkdir -p "$JUNIT_OUTPUT_DIR"
           chmod +x scripts/run-suite.sh
-          ./scripts/run-suite.sh --suite security --run-id "${RUN_ID}"
+          # test-scan-completes.sh is the single waivered Grype-flake; it runs
+          # soft in the security-grype-scan-completes job. Everything else here
+          # hard-gates the release.
+          ./scripts/run-suite.sh --suite security \
+            --exclude test-scan-completes.sh \
+            --run-id "${RUN_ID}"
 
       - name: Upload test results
         if: always()
@@ -1222,6 +1228,68 @@ jobs:
           # JSON breadcrumbs (e.g. scan-completes-final-resp.json) reach
           # the operator. With *.xml glob the dump dies silently and the
           # gate's failure rendering is a one-line message attribute.
+          path: /tmp/test-results/
+          if-no-files-found: ignore
+
+  # -------------------------------------------------------------------
+  # WAIVERED soft job: the one known-flaky Grype scan (#2700).
+  #
+  # test-scan-completes.sh asserts a scan reaches `completed` cleanly. Grype on
+  # some backend image lines fails deterministically because the vulnerability
+  # DB is not pre-seeded in the Dockerfile and the network-restricted ARC runner
+  # pods cannot fetch grype.anchore.io at scan time. The quality gate is
+  # LAST-scanner-wins (policy_service reads LIMIT 1 ORDER BY created_at DESC), so
+  # Trivy success satisfies block_unscanned; the practical security posture is
+  # unaffected. Grype image-scan EFFICACY is still hard-gated elsewhere by the
+  # blocking `pinned-cve-image-gate` (alpine:3.4 canary, per-scanner floor), so
+  # this waiver does NOT create a Grype blind spot.
+  #
+  # NAMED WAIVER
+  #   owner:   release-engineering (@brandon.geraci)
+  #   reason:  Grype vuln-DB not pre-seeded in backend image; ARC runners are
+  #            network-restricted and cannot fetch grype.anchore.io at scan time.
+  #   tracked: artifact-keeper#1001 (pre-seed Grype DB in Dockerfile)
+  #   expires: 2026-10-01  --  on/after this date, either land #1001 and delete
+  #            this job (folding test-scan-completes.sh back into the blocking
+  #            security-tests suite by dropping the --exclude), or re-justify and
+  #            extend the expiry in a PR. Do NOT let it drift silently.
+  # -------------------------------------------------------------------
+  security-grype-scan-completes:
+    needs: deploy
+    # WAIVER (expires 2026-10-01, artifact-keeper#1001): soft by design so the
+    # documented Grype-DB flake cannot block a release. Excluded from the
+    # collect-results blocking predicate; its outcome is shown in the summary.
+    continue-on-error: true
+    if: inputs.test_suite == 'all' || inputs.test_suite == 'security'
+    runs-on: ak-e2e-runners
+    timeout-minutes: 20
+    env:
+      BASE_URL: ${{ needs.deploy.outputs.backend_url }}
+      RUN_ID: ${{ needs.deploy.outputs.run_id }}
+      ADMIN_PASS: TestRunner!2026secure
+      JUNIT_OUTPUT_DIR: /tmp/test-results
+      RELEASE_GATE: '1'
+      # 300s: test-scan-completes.sh polls to SCAN_TIMEOUT=180; the default 120s
+      # wrapper would SIGKILL it before it writes JUnit XML. See security-tests.
+      TEST_TIMEOUT: '300'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: artifact-keeper/artifact-keeper-test
+
+      - name: Run waivered Grype scan-completion test (soft)
+        run: |
+          mkdir -p "$JUNIT_OUTPUT_DIR"
+          chmod +x scripts/run-suite.sh
+          ./scripts/run-suite.sh --suite security \
+            --filter test-scan-completes.sh \
+            --run-id "${RUN_ID}"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: junit-security-grype-scan-completes
           path: /tmp/test-results/
           if-no-files-found: ignore
 
@@ -2035,7 +2103,7 @@ jobs:
   # Collect results and publish summary
   # -------------------------------------------------------------------
   collect-results:
-    needs: [version-set-integrity, clean-install-smoke, clean-install-smoke-with-deps, chart-upgrade-smoke, deploy, real-flow-smoke, scan-completion-gate, sbom-correctness-gate, pinned-cve-gate, pinned-cve-image-gate, format-tests, security-tests, compatibility-tests, repo-tests, promotion-tests, rbac-tests, lifecycle-tests, webhook-tests, search-tests, platform-tests, auth-tests, admin-tests, stress-tests, resilience-tests, mesh-tests]
+    needs: [version-set-integrity, clean-install-smoke, clean-install-smoke-with-deps, chart-upgrade-smoke, deploy, real-flow-smoke, scan-completion-gate, sbom-correctness-gate, pinned-cve-gate, pinned-cve-image-gate, format-tests, security-tests, security-grype-scan-completes, compatibility-tests, repo-tests, promotion-tests, rbac-tests, lifecycle-tests, webhook-tests, search-tests, platform-tests, auth-tests, admin-tests, stress-tests, resilience-tests, mesh-tests]
     if: always()
     runs-on: ak-e2e-runners
     steps:
@@ -2054,7 +2122,7 @@ jobs:
           echo "| Suite | Status |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-------|--------|" >> "$GITHUB_STEP_SUMMARY"
 
-          for job in version-set-integrity clean-install-smoke clean-install-smoke-with-deps chart-upgrade-smoke real-flow-smoke scan-completion-gate sbom-correctness-gate pinned-cve-gate pinned-cve-image-gate format-tests repo-tests promotion-tests rbac-tests lifecycle-tests webhook-tests search-tests platform-tests auth-tests admin-tests security-tests compatibility-tests stress-tests resilience-tests mesh-tests; do
+          for job in version-set-integrity clean-install-smoke clean-install-smoke-with-deps chart-upgrade-smoke real-flow-smoke scan-completion-gate sbom-correctness-gate pinned-cve-gate pinned-cve-image-gate format-tests repo-tests promotion-tests rbac-tests lifecycle-tests webhook-tests search-tests platform-tests auth-tests admin-tests security-tests security-grype-scan-completes compatibility-tests stress-tests resilience-tests mesh-tests; do
             status="skipped"
             case "$job" in
               version-set-integrity) status="${{ needs.version-set-integrity.result }}" ;;
@@ -2077,6 +2145,7 @@ jobs:
               auth-tests) status="${{ needs.auth-tests.result }}" ;;
               admin-tests) status="${{ needs.admin-tests.result }}" ;;
               security-tests) status="${{ needs.security-tests.result }}" ;;
+              security-grype-scan-completes) status="${{ needs.security-grype-scan-completes.result }}" ;;
               compatibility-tests) status="${{ needs.compatibility-tests.result }}" ;;
               stress-tests) status="${{ needs.stress-tests.result }}" ;;
               resilience-tests) status="${{ needs.resilience-tests.result }}" ;;
@@ -2099,16 +2168,20 @@ jobs:
           if-no-files-found: ignore
 
       - name: Gate check - fail if any required suite did not succeed
-        # stress-tests and security-tests are intentionally excluded from
-        # this rollup. Both have continue-on-error: true (see the comments
-        # above each job) so their outcome can be 'failure' on
-        # known-flaky / known-infra-debt scenarios without blocking the
-        # release gate:
+        # security-tests is now BLOCKING (#2700). It is enforced with the
+        # stricter `!= 'success'` predicate (like the silent-success gates) so a
+        # 'skipped' outcome cannot mask a security regression -- guarded by the
+        # suite-selection condition so a partial non-security invocation
+        # (inputs.test_suite != 'all'/'security'), where the job legitimately
+        # skips, still passes. The single known-flaky Grype scan was carved out
+        # into the soft, WAIVERED security-grype-scan-completes job (owner +
+        # expiry 2026-10-01, artifact-keeper#1001), which stays OFF this
+        # predicate. Grype image-scan efficacy remains hard-gated by
+        # pinned-cve-image-gate.
+        #
+        # stress-tests remains intentionally excluded (continue-on-error: true):
         #   - stress-tests: bcrypt-bound auth saturation under sustained
         #     load on shared ARC runners (artifact-keeper#991).
-        #   - security-tests: Grype DB not pre-seeded in v1.1.x backend
-        #     image; quality gate is last-scanner-wins so Trivy covers
-        #     the policy gate (artifact-keeper#1001).
         #
         # The three new silent-success gates (scan-completion-gate,
         # sbom-correctness-gate, pinned-cve-gate) use the STRICTER
@@ -2144,6 +2217,7 @@ jobs:
           needs.sbom-correctness-gate.result != 'success' ||
           needs.pinned-cve-gate.result != 'success' ||
           needs.pinned-cve-image-gate.result != 'success' ||
+          ((needs.security-tests.result != 'success') && (inputs.test_suite == 'all' || inputs.test_suite == 'security')) ||
           needs.deploy.result == 'failure' || needs.deploy.result == 'cancelled' ||
           needs.format-tests.result == 'failure' || needs.format-tests.result == 'cancelled' ||
           needs.compatibility-tests.result == 'failure' || needs.compatibility-tests.result == 'cancelled' ||

--- a/scripts/run-suite.sh
+++ b/scripts/run-suite.sh
@@ -2,11 +2,17 @@
 # run-suite.sh - Discover and run test scripts for a given suite
 #
 # Usage:
-#   ./run-suite.sh --suite <name> [--filter <pattern>] [--run-id <id>]
+#   ./run-suite.sh --suite <name> [--filter <pattern>] [--exclude <pat[,pat]>] [--run-id <id>]
 #
 # Discovers test scripts by globbing tests/<suite>/**/test-*.sh, applies an
-# optional filter pattern, then runs each script with a timeout. Prints a
-# summary and exits non-zero if any test failed.
+# optional include filter and/or an exclude list, then runs each script with a
+# timeout. Prints a summary and exits non-zero if any test failed.
+#
+# --filter  <pattern>      keep only scripts whose path contains <pattern>.
+# --exclude <pat[,pat...]> drop scripts whose path contains ANY comma-separated
+#                          substring. Used by the release gate to carve a single
+#                          known-flaky script (e.g. a waivered Grype scan) out of
+#                          an otherwise-blocking suite so the rest can hard-gate.
 #
 # Environment variables:
 #   TEST_TIMEOUT  - Per-test timeout in seconds (default: 120)
@@ -24,15 +30,17 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 SUITE=""
 FILTER=""
+EXCLUDE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --suite)  SUITE="$2"; shift 2 ;;
-    --filter) FILTER="$2"; shift 2 ;;
-    --run-id) export RUN_ID="$2"; shift 2 ;;
+    --suite)   SUITE="$2"; shift 2 ;;
+    --filter)  FILTER="$2"; shift 2 ;;
+    --exclude) EXCLUDE="$2"; shift 2 ;;
+    --run-id)  export RUN_ID="$2"; shift 2 ;;
     *)
       echo "Unknown argument: $1"
-      echo "Usage: run-suite.sh --suite <name> [--filter <pattern>] [--run-id <id>]"
+      echo "Usage: run-suite.sh --suite <name> [--filter <pattern>] [--exclude <pat[,pat]>] [--run-id <id>]"
       exit 1
       ;;
   esac
@@ -64,20 +72,46 @@ if [ ${#ALL_SCRIPTS[@]} -eq 0 ]; then
   exit 1
 fi
 
-# Apply filter if provided
+# Parse the exclude list (comma-separated substrings) once.
+EXCLUDE_PATS=()
+if [ -n "$EXCLUDE" ]; then
+  IFS=',' read -r -a EXCLUDE_PATS <<< "$EXCLUDE"
+fi
+
+# Apply include filter, then exclude list.
 SCRIPTS=()
+EXCLUDED=()
 for script in "${ALL_SCRIPTS[@]}"; do
-  if [ -n "$FILTER" ]; then
-    if [[ "$script" == *"$FILTER"* ]]; then
-      SCRIPTS+=("$script")
-    fi
-  else
-    SCRIPTS+=("$script")
+  # Include filter (substring): if set, script path must contain it.
+  if [ -n "$FILTER" ] && [[ "$script" != *"$FILTER"* ]]; then
+    continue
   fi
+  # Exclude list (substring): drop if it matches ANY exclude pattern.
+  skip_this=false
+  for pat in "${EXCLUDE_PATS[@]}"; do
+    [ -z "$pat" ] && continue
+    if [[ "$script" == *"$pat"* ]]; then
+      skip_this=true
+      break
+    fi
+  done
+  if [ "$skip_this" = true ]; then
+    EXCLUDED+=("$script")
+    continue
+  fi
+  SCRIPTS+=("$script")
 done
 
+if [ ${#EXCLUDED[@]} -gt 0 ]; then
+  echo "Excluded ${#EXCLUDED[@]} script(s) via --exclude '${EXCLUDE}':"
+  for script in "${EXCLUDED[@]}"; do
+    echo "  - $(basename "$script")"
+  done
+  echo ""
+fi
+
 if [ ${#SCRIPTS[@]} -eq 0 ]; then
-  echo "ERROR: no test scripts matched filter '${FILTER}'"
+  echo "ERROR: no test scripts matched filter '${FILTER}' after exclude '${EXCLUDE}'"
   exit 1
 fi
 

--- a/tests/security/test-saml-signature.sh
+++ b/tests/security/test-saml-signature.sh
@@ -1,10 +1,40 @@
 #!/usr/bin/env bash
-# test-saml-signature.sh - #548: SAML signature verification
+# test-saml-signature.sh - #548 / #2700: SAML signature verification (real oracle)
 #
-# Verifies that the SSO subsystem is functional and that forged SAML
-# assertions are rejected. Because a full SAML IdP is unlikely to be
-# available in the test environment, tests skip gracefully when SAML
-# is not configured.
+# Verifies that the SAML SSO subsystem cryptographically verifies assertions:
+# a validly-signed assertion authenticates, and a FORGED assertion is EXPLICITLY
+# rejected. This is a regression guard for the #2449 SAML XML-Signature-Wrapping
+# (XSW) CRITICAL auth-bypass class.
+#
+# #2700 hardening (why this file was rewritten):
+#   1. The old forged-assertion oracle counted a 500 crash (and any non-200) as
+#      PASS -- only a 200-with-token was a failure. A server that CRASHES on a
+#      forged assertion is itself a defect (robustness + a fake-green that hides
+#      a broken verifier). This version HARD-FAILS unless the server returns an
+#      EXPLICIT rejection (a controlled 4xx / deny). 5xx = FAIL. A 200 or a
+#      session-establishing 3xx = FAIL. Only an explicit 4xx rejection passes.
+#   2. The old test degraded to "the endpoint exists" (a smoke check) whenever
+#      SAML was not pre-configured. This version brings its OWN IdP fixture: it
+#      provisions a real SAML provider through the admin API and drives a real
+#      signed-vs-forged flow -- the same pattern the DTF `sso` tier uses
+#      (deploy-test/harness/tiers/sso/: Keycloak IdP + a bergshamra-backed
+#      signer probe). The signed positive control reuses that tier's probe when
+#      a Rust toolchain is available on the runner.
+#
+# Relationship to the DTF sso tier:
+#   deploy-test/harness/tiers/sso/oracle.sh is the FULL discriminating oracle
+#   (Keycloak in-compose + every XSW variant, DB-asserted). It runs in the DTF
+#   harness against a candidate image. THIS script is the release-gate
+#   (k8s-deployed backend) counterpart: no compose/Keycloak available here, so
+#   it self-provisions a provider via the admin API and exercises the accept
+#   (signed) / explicit-reject (forged) contract directly over HTTP.
+#
+# Skip semantics (load-bearing):
+#   The forged-rejection assertion only skips when the backend genuinely does
+#   not expose a SAML ACS endpoint at all (SAML not compiled/mounted in this
+#   deploy). It NEVER skips-to-green on a crash, and it NEVER treats a 500 as a
+#   pass. The signed positive control skips only when the DTF signer probe
+#   cannot be built (no Rust toolchain) -- a genuine tooling limit, not a bug.
 
 source "$(dirname "$0")/../lib/common.sh"
 
@@ -12,141 +42,269 @@ begin_suite "saml-signature"
 auth_admin
 setup_workdir
 
-# ---------------------------------------------------------------------------
-# SSO providers endpoint
-# ---------------------------------------------------------------------------
-
-begin_test "SSO providers endpoint responds"
-status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
-  -H "$(auth_header)" \
-  "${BASE_URL}/api/v1/auth/sso/providers" 2>/dev/null) || true
-
-if [ "$status" -ge 200 ] 2>/dev/null && [ "$status" -lt 300 ] 2>/dev/null; then
-  pass
-elif [ "$status" = "404" ]; then
-  skip "SSO providers endpoint does not exist on this deployment"
-else
-  # 401/403/500 still means the endpoint exists and responded
-  pass
-fi
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SP_ENTITY_ID="artifact-keeper"
+ADMIN_GROUP="ak-admins"
+SUF="${RUN_ID:-local}-$(date +%s)"
+IDP_ENTITY="https://idp.saml-sig-test.local/${SUF}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK" 2>/dev/null || true' EXIT
 
 # ---------------------------------------------------------------------------
-# Check if SAML is configured
+# Helpers (mirror deploy-test/harness/tiers/sso/oracle.sh, provider-scoped API)
 # ---------------------------------------------------------------------------
 
-begin_test "Check SAML provider availability"
-SAML_CONFIGURED=false
-sso_response=$(curl -s $CURL_TIMEOUT \
-  -H "$(auth_header)" \
-  "${BASE_URL}/api/v1/auth/sso/providers" 2>/dev/null) || true
+# create_saml_provider <cert_pem_file> -> prints provider UUID (empty on failure)
+create_saml_provider() {
+  local cert_file="$1" body resp
+  body=$(jq -n \
+    --arg name "saml-sig-${SUF}" \
+    --arg eid  "$IDP_ENTITY" \
+    --arg sso  "https://idp.saml-sig-test.local/sso" \
+    --arg cert "$(cat "$cert_file")" \
+    --arg spid "$SP_ENTITY_ID" \
+    --arg admg "$ADMIN_GROUP" \
+    '{name:$name, entity_id:$eid, sso_url:$sso, certificate:$cert,
+      sp_entity_id:$spid, sign_requests:false, require_signed_assertions:true,
+      admin_group:$admg, is_enabled:true}')
+  resp=$(curl -s $CURL_TIMEOUT -X POST "${BASE_URL}/api/v1/admin/sso/saml" \
+    -H "$(auth_header)" -H 'Content-Type: application/json' \
+    -d "$body" 2>/dev/null) || return 0
+  echo "$resp" | jq -r '.id // empty' 2>/dev/null
+}
 
-if echo "$sso_response" | jq -e '.[] | select(.type == "saml" or .protocol == "saml")' >/dev/null 2>&1; then
-  SAML_CONFIGURED=true
-  pass
-elif echo "$sso_response" | jq -e '. | length' >/dev/null 2>&1; then
-  skip "no SAML provider configured in test environment"
-else
-  skip "SSO providers response not parseable or endpoint unavailable"
-fi
+# saml_admin_api_available -> 0 if POST /api/v1/admin/sso/saml is mounted
+saml_admin_api_available() {
+  local code
+  code=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+    -X POST "${BASE_URL}/api/v1/admin/sso/saml" \
+    -H "$(auth_header)" -H 'Content-Type: application/json' \
+    -d '{}' 2>/dev/null) || code="000"
+  # 404/405 => not mounted. Anything else (400 validation, 422, 200, 401)
+  # means the route exists.
+  case "$code" in
+    404|405|000) return 1 ;;
+    *) return 0 ;;
+  esac
+}
 
-# ---------------------------------------------------------------------------
-# SAML login redirect (if configured)
-# ---------------------------------------------------------------------------
+# provider_request_id <pid> -> the AuthnRequest ID to echo as InResponseTo
+provider_request_id() {
+  local pid="$1" loc
+  loc=$(curl -s -o /dev/null -w '%{redirect_url}' $CURL_TIMEOUT \
+    "${BASE_URL}/api/v1/auth/sso/saml/${pid}/login" 2>/dev/null) || true
+  [ -z "$loc" ] && return 0
+  python3 - "$loc" <<'PY' 2>/dev/null || true
+import sys, urllib.parse, base64, re
+u = sys.argv[1]
+try:
+    q = urllib.parse.parse_qs(urllib.parse.urlparse(u).query)
+    xml = base64.b64decode(q['SAMLRequest'][0]).decode('utf-8', 'replace')
+    m = re.search(r'ID="([^"]+)"', xml)
+    print(m.group(1) if m else "")
+except Exception:
+    print("")
+PY
+}
 
-begin_test "SAML login redirect"
-if [ "$SAML_CONFIGURED" = "true" ]; then
-  saml_status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
-    -L --max-redirs 0 \
-    "${BASE_URL}/api/v1/auth/sso/saml/login" 2>/dev/null) || true
+# post_acs_status <acs_url> <b64payload> -> HTTP status
+post_acs_status() {
+  curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT -X POST \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    --data-urlencode "SAMLResponse=$2" --data-urlencode 'RelayState=forged' \
+    "$1" 2>/dev/null || echo "000"
+}
 
-  # Expect a redirect (302/303) or 200 with a form
-  if [ "$saml_status" = "302" ] || [ "$saml_status" = "303" ] || [ "$saml_status" = "200" ]; then
-    pass
-  elif [ "$saml_status" = "404" ]; then
-    skip "SAML login endpoint not found"
-  else
-    # Any non-5xx response is acceptable
-    if [ "$saml_status" -lt 500 ] 2>/dev/null; then
-      pass
-    else
-      fail "SAML login returned ${saml_status}"
-    fi
-  fi
-else
-  skip "SAML not configured"
-fi
+# post_acs_body <acs_url> <b64payload> -> response body
+post_acs_body() {
+  curl -s $CURL_TIMEOUT -X POST \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    --data-urlencode "SAMLResponse=$2" --data-urlencode 'RelayState=forged' \
+    "$1" 2>/dev/null || true
+}
 
-# ---------------------------------------------------------------------------
-# Forged SAML assertion must be rejected
-# ---------------------------------------------------------------------------
-
-begin_test "Forged SAML assertion rejected at ACS endpoint"
-
-# Build a minimal, obviously forged SAML response (base64 encoded)
-FORGED_SAML="$(cat <<'SAML_XML' | base64 | tr -d '\n'
-<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_forged_response" Version="2.0" IssueInstant="2026-01-01T00:00:00Z" Destination="http://localhost:8080/api/v1/auth/sso/saml/acs">
-  <saml:Issuer>http://forged-idp.test</saml:Issuer>
+# forged_unsigned_b64 <name_id> <in_response_to> -> base64 forged SAMLResponse
+# A minimal, obviously-forged (UNSIGNED) admin assertion. No crypto required:
+# a verifier with require_signed_assertions=true MUST reject it.
+forged_unsigned_b64() {
+  local nid="$1" irt="$2" irt_attr=""
+  [ -n "$irt" ] && irt_attr=" InResponseTo=\"${irt}\""
+  cat <<SAML_XML | base64 | tr -d '\n'
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_forged_response_${SUF}"${irt_attr} Version="2.0" IssueInstant="2026-01-01T00:00:00Z" Destination="${BASE_URL}/api/v1/auth/sso/saml/acs">
+  <saml:Issuer>${IDP_ENTITY}</saml:Issuer>
   <samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>
-  <saml:Assertion ID="_forged_assertion" Version="2.0" IssueInstant="2026-01-01T00:00:00Z">
-    <saml:Issuer>http://forged-idp.test</saml:Issuer>
-    <saml:Subject>
-      <saml:NameID>attacker@forged.test</saml:NameID>
-    </saml:Subject>
+  <saml:Assertion ID="_forged_assertion_${SUF}" Version="2.0" IssueInstant="2026-01-01T00:00:00Z">
+    <saml:Issuer>${IDP_ENTITY}</saml:Issuer>
+    <saml:Subject><saml:NameID>${nid}</saml:NameID></saml:Subject>
     <saml:AuthnStatement AuthnInstant="2026-01-01T00:00:00Z">
       <saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef></saml:AuthnContext>
     </saml:AuthnStatement>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="groups"><saml:AttributeValue>${ADMIN_GROUP}</saml:AttributeValue></saml:Attribute>
+    </saml:AttributeStatement>
   </saml:Assertion>
 </samlp:Response>
 SAML_XML
-)"
+}
 
-# Try common ACS endpoint paths
-ACS_PATHS=(
-  "/api/v1/auth/sso/saml/acs"
-  "/api/v1/auth/saml/acs"
-  "/auth/saml/acs"
-  "/saml/acs"
-)
+# body_has_session <body> -> 0 if the response looks like a granted session
+body_has_session() {
+  echo "$1" | jq -e '.token // .access_token // .id_token // .session' >/dev/null 2>&1
+}
 
-acs_tested=false
-for acs_path in "${ACS_PATHS[@]}"; do
-  status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
-    -X POST \
-    -H "Content-Type: application/x-www-form-urlencoded" \
-    -d "SAMLResponse=${FORGED_SAML}&RelayState=forged" \
-    "${BASE_URL}${acs_path}" 2>/dev/null) || true
-
-  if [ "$status" = "404" ]; then
-    continue
+# assert_forged_rejected <label> <acs_url> <status> <body>
+# The #2700 oracle: PASS only on an EXPLICIT rejection (controlled 4xx).
+#   - 4xx (400/401/403/422)         -> PASS (explicit rejection)
+#   - 5xx (crash on attacker input) -> FAIL
+#   - 200 / session-bearing 3xx     -> FAIL (forged assertion accepted)
+#   - anything else (bare 200/3xx)  -> FAIL (not an explicit rejection)
+assert_forged_rejected() {
+  local label="$1" acs="$2" st="$3" body="$4"
+  if body_has_session "$body"; then
+    fail "${label}: forged assertion ACCEPTED (session/token issued) at ${acs}" \
+         "status=${st} body-snip=$(echo "$body" | head -c 300)"
+    return
   fi
+  case "$st" in
+    400|401|403|422)
+      pass ;;
+    5??)
+      fail "${label}: forged assertion CRASHED the verifier (HTTP ${st}) at ${acs}" \
+           "A 5xx on attacker input is a defect (robustness + fake-green). The verifier must return a controlled rejection, not crash." ;;
+    2??|3??)
+      fail "${label}: forged assertion was NOT explicitly rejected (HTTP ${st}) at ${acs}" \
+           "Expected a controlled 4xx rejection. A ${st} is not an explicit deny for a forged assertion." ;;
+    *)
+      fail "${label}: forged assertion produced no controlled rejection (HTTP ${st}) at ${acs}" ;;
+  esac
+}
 
-  acs_tested=true
+# ---------------------------------------------------------------------------
+# Locate / build the DTF sso signer probe (optional; needed only for the
+# SIGNED positive control). Reused verbatim from the sso tier.
+# ---------------------------------------------------------------------------
+PROBE_DIR="${REPO_ROOT}/deploy-test/harness/tiers/sso/probe"
+PROBE_BIN="${PROBE_DIR}/target/release/dtf-saml-xsw-probe"
+PROBE_READY=false
+ensure_probe() {
+  if [ -x "$PROBE_BIN" ]; then PROBE_READY=true; return 0; fi
+  command -v cargo >/dev/null 2>&1 || return 1
+  [ -d "$PROBE_DIR" ] || return 1
+  ( cd "$PROBE_DIR" && cargo build --release >/dev/null 2>&1 ) || return 1
+  [ -x "$PROBE_BIN" ] && PROBE_READY=true
+}
 
-  # A forged assertion must not result in a successful login (200 with token)
-  if [ "$status" = "200" ]; then
-    # Check if the response contains a token (actual authentication success)
-    body=$(curl -s $CURL_TIMEOUT \
-      -X POST \
-      -H "Content-Type: application/x-www-form-urlencoded" \
-      -d "SAMLResponse=${FORGED_SAML}&RelayState=forged" \
-      "${BASE_URL}${acs_path}" 2>/dev/null) || true
-    if echo "$body" | jq -e '.token // .access_token' >/dev/null 2>&1; then
-      fail "forged SAML assertion was accepted and returned a token at ${acs_path}"
-    else
-      # 200 without token (e.g., error page) is acceptable
-      pass
-    fi
-  elif [ "$status" = "400" ] || [ "$status" = "401" ] || [ "$status" = "403" ] || [ "$status" = "422" ]; then
+# ---------------------------------------------------------------------------
+# 1. SSO providers endpoint responds (5xx is now a failure, not a pass)
+# ---------------------------------------------------------------------------
+begin_test "SSO providers endpoint responds"
+status=$(curl -s -o /dev/null -w '%{http_code}' $CURL_TIMEOUT \
+  -H "$(auth_header)" \
+  "${BASE_URL}/api/v1/auth/sso/providers" 2>/dev/null) || status="000"
+if [ "$status" = "404" ]; then
+  skip "SSO providers endpoint does not exist on this deployment"
+elif [ "$status" -ge 200 ] 2>/dev/null && [ "$status" -lt 500 ] 2>/dev/null; then
+  # 2xx/3xx/4xx: the endpoint exists and responded in a controlled way.
+  pass
+else
+  fail "SSO providers endpoint returned ${status} (a 5xx is a server error, not a healthy response)"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Real SAML provider fixture + signed-vs-forged flow
+# ---------------------------------------------------------------------------
+PROVIDER=""
+PROVIDER_CERT="${WORK}/idp_cert.pem"
+PROVIDER_KEY="${WORK}/idp_key.pem"
+
+begin_test "Provision an ephemeral SAML provider (real IdP fixture) via admin API"
+if ! saml_admin_api_available; then
+  skip "admin SAML provider API (/api/v1/admin/sso/saml) not mounted on this backend line; falling back to generic-ACS forged-rejection check"
+else
+  # Prefer the DTF signer probe's keypair (lets us also mint a SIGNED positive).
+  if ensure_probe; then
+    "$PROBE_BIN" keygen "$WORK" >/dev/null 2>&1 || true
+  fi
+  # Fall back to an openssl self-signed cert for the provider registration.
+  # (For the forged-UNSIGNED negative the cert need not match any real key.)
+  if [ ! -s "$PROVIDER_CERT" ] && command -v openssl >/dev/null 2>&1; then
+    openssl req -x509 -newkey rsa:2048 -nodes -keyout "$PROVIDER_KEY" \
+      -out "$PROVIDER_CERT" -days 2 -subj "/CN=saml-sig-test-${SUF}" >/dev/null 2>&1 || true
+  fi
+  if [ -s "$PROVIDER_CERT" ]; then
+    PROVIDER="$(create_saml_provider "$PROVIDER_CERT")"
+  fi
+  if [ -n "$PROVIDER" ] && [ "$PROVIDER" != "null" ]; then
     pass
   else
-    # 500, 302, etc. all indicate the forged assertion was not silently accepted
-    pass
+    fail "could not provision a SAML provider via /api/v1/admin/sso/saml" \
+         "The admin route reported available but provider creation returned no id. A registry that ships SAML must let the release gate register a test IdP."
   fi
-  break
-done
+fi
 
-if [ "$acs_tested" = "false" ]; then
-  skip "no SAML ACS endpoint found at any known path"
+if [ -n "$PROVIDER" ] && [ "$PROVIDER" != "null" ]; then
+  ACS_URL="${BASE_URL}/api/v1/auth/sso/saml/${PROVIDER}/acs"
+
+  # ---- SIGNED POSITIVE CONTROL (proves the verifier is not reject-everything)
+  begin_test "Validly-signed assertion authenticates (positive control)"
+  if [ "$PROBE_READY" = true ] && [ -s "$PROVIDER_KEY" ]; then
+    NID="saml-sig-legit-${SUF}"
+    RID="$(provider_request_id "$PROVIDER")"
+    SIGNED_B64="$("$PROBE_BIN" craft --key "$PROVIDER_KEY" \
+      --issuer "$IDP_ENTITY" --audience "$SP_ENTITY_ID" \
+      --request-id "$RID" --name-id "$NID" --case positive --groups Developers 2>/dev/null)"
+    if [ -z "$SIGNED_B64" ]; then
+      fail "signer probe produced no signed assertion (craft failed)"
+    else
+      st=$(post_acs_status "$ACS_URL" "$SIGNED_B64")
+      body=$(post_acs_body "$ACS_URL" "$SIGNED_B64")
+      # Accept = authenticated: a redirect/2xx that is NOT a rejection.
+      if [ "$st" -ge 200 ] 2>/dev/null && [ "$st" -lt 400 ] 2>/dev/null; then
+        pass
+      else
+        fail "a validly-signed assertion must authenticate (got HTTP ${st})" \
+             "If the signer probe and the backend verifier disagree, the positive control breaks. body-snip=$(echo "$body" | head -c 200)"
+      fi
+    fi
+  else
+    skip "signed positive control needs the DTF SAML signer (deploy-test/harness/tiers/sso/probe); no Rust toolchain on this runner. Negative (forged-rejection) control below still runs hard."
+  fi
+
+  # ---- FORGED NEGATIVE (the #2449 class + the #2700 fake-green fix)
+  begin_test "Forged UNSIGNED assertion is explicitly rejected at provider ACS"
+  NID="saml-sig-forged-${SUF}"
+  RID="$(provider_request_id "$PROVIDER")"
+  FORGED_B64="$(forged_unsigned_b64 "$NID" "$RID")"
+  st=$(post_acs_status "$ACS_URL" "$FORGED_B64")
+  body=$(post_acs_body "$ACS_URL" "$FORGED_B64")
+  assert_forged_rejected "provider ACS" "$ACS_URL" "$st" "$body"
+
+else
+  # ---- FALLBACK: no provider (old backend line). Still a REAL reject check
+  # against the generic ACS, with the corrected hard-fail oracle. Only a
+  # genuinely-absent ACS endpoint (all 404) is a legitimate skip.
+  begin_test "Forged UNSIGNED assertion is explicitly rejected at ACS endpoint"
+  NID="saml-sig-forged-${SUF}"
+  FORGED_B64="$(forged_unsigned_b64 "$NID" "")"
+  ACS_PATHS=(
+    "/api/v1/auth/sso/saml/acs"
+    "/api/v1/auth/saml/acs"
+    "/auth/saml/acs"
+    "/saml/acs"
+  )
+  acs_tested=false
+  for acs_path in "${ACS_PATHS[@]}"; do
+    acs="${BASE_URL}${acs_path}"
+    st=$(post_acs_status "$acs" "$FORGED_B64")
+    [ "$st" = "404" ] && continue
+    acs_tested=true
+    body=$(post_acs_body "$acs" "$FORGED_B64")
+    assert_forged_rejected "generic ACS" "$acs" "$st" "$body"
+    break
+  done
+  if [ "$acs_tested" = false ]; then
+    skip "no SAML ACS endpoint mounted at any known path (SAML not compiled/mounted in this deploy)"
+  fi
 fi
 
 end_suite


### PR DESCRIPTION
Closes #302 (tracks backend artifact-keeper/artifact-keeper#2700).

An un-freeze-bar item. Two release-gate defects: the security suite could not fail a release, and the SAML forged-assertion oracle was fake-green.

## 1. `security-tests` is now blocking
Before: the job was `continue-on-error: true` (which masks the **entire** 45-test suite, not just the flaky bit) **and** it was excluded from the `collect-results` blocking predicate. A security regression was doubly non-blocking.

After:
- `scripts/run-suite.sh` gains a documented `--exclude <pat[,pat]>` option.
- The single genuinely-flaky test, `test-scan-completes.sh` (Grype vuln-DB not pre-seeded in the backend image; network-restricted ARC runners can't reach grype.anchore.io), is carved out with `--exclude` and re-run **soft** in a new dedicated job `security-grype-scan-completes` carrying a **named waiver**:
  - owner: release-engineering (@brandon.geraci)
  - tracked: artifact-keeper#1001 (pre-seed Grype DB in Dockerfile)
  - **expires: 2026-10-01** — on/after which land #1001 and delete the job (fold the test back in by dropping `--exclude`), or re-justify in a PR.
- `continue-on-error` is dropped from the rest of `security-tests`.
- `security-tests` joins the blocking rollup with the stricter `!= 'success'` predicate (suite-guarded so a partial non-security invocation, where the job legitimately skips, still passes).

No new Grype blind spot: image-scan **efficacy** is still hard-gated by the existing blocking `pinned-cve-image-gate` (alpine:3.4 canary, per-scanner floor). The waiver only covers the flaky self-scan completion assertion.

## 2. SAML forged-assertion oracle is no longer fake-green
`tests/security/test-saml-signature.sh` previously treated a **500 crash** on a forged assertion as PASS (only a 200-with-token failed). Rewritten so a forged assertion passes **only** on an explicit controlled rejection (4xx); a **5xx crash hard-FAILs**, and an accepted 200/session hard-FAILs.

It also stops degrading to a smoke check: it brings its **own IdP fixture** by provisioning a real SAML provider via `/api/v1/admin/sso/saml` and driving a real signed-vs-forged flow, reusing the DTF `sso` tier's bergshamra-backed signer probe (`deploy-test/harness/tiers/sso/probe`) for the signed positive control. This is the same fixture/pattern as the full DTF `sso` oracle (which stays the Keycloak-in-compose, DB-asserted home of the #2449 XSW class).

## Validation
- `python3` YAML parse of `release-gate.yml` + structural checks: security-tests no longer `continue-on-error`, new soft job present and in the rollup `needs`/summary, gate `if:` now references `security-tests`.
- `bash -n` + `shellcheck -S warning` clean on both changed scripts.
- `run-suite.sh --exclude` / `--filter` functionally tested (correct carve-out).
- SAML oracle truth-table tested (401/400/403/422 -> PASS; 5xx -> FAIL; 200+token / session-3xx -> FAIL; bare 200/3xx -> FAIL).
- DTF signer probe builds (`cargo build --release`) and its `keygen`/`craft` CLI matches the test's calls (signed payload carries `<Signature>`; `forged_unsigned` carries none).
- **Limit:** a full end-to-end run of the SAML test against a live backend + the sso-tier Keycloak was not executed here (needs a candidate backend image + Keycloak boot). The load-bearing oracle logic, the reused probe, and the workflow wiring are validated as above; first live exercise will be the reviewer's gate run.

All actions remain full-SHA-pinned per CONTRIBUTING. No milestone set (this repo has no 1.7.0 milestone).

DRAFT — release-infra change, for review before merge.