### PR TITLE
fix(ci): drop deploy-time Trivy DB token injection (expires before gate)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -442,15 +442,14 @@ jobs:
           BACKEND_TAG: ${{ inputs.backend_tag }}
           BACKEND_DIGEST: ${{ inputs.backend_digest }}
           WEB_TAG: ${{ inputs.web_tag }}
-          # Authenticated Trivy DB pull for the scanner-adapter (#293). ghcr
-          # denies the adapter's anonymous registry token for the trivy-db pull
-          # once the Trivy server has already pulled anonymously from the same
-          # ghcr endpoint, so give the adapter's in-process Trivy its own
-          # credentials. The workflow's automatic GITHUB_TOKEN authenticates the
-          # (public) ghcr pull; create-test-namespace.sh injects it as
-          # scannerAdapter.env.TRIVY_USERNAME/TRIVY_PASSWORD via helm
-          # --set-string (never a values file). GitHub masks the token in logs.
-          SCANNER_TRIVY_PULL_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No Trivy DB pull token is injected here. #298 passed the deploy job's
+          # automatic GITHUB_TOKEN as SCANNER_TRIVY_PULL_TOKEN, but that token
+          # has a ~1h TTL and expires before late gate jobs (pinned-cve-image-gate
+          # runs ~90min after deploy); ghcr then rejects the expired credential
+          # outright ("DENIED: invalid token") with no anonymous fallback. The
+          # scanner-adapter now pulls the public org mirror
+          # ghcr.io/artifact-keeper/trivy-db (#300/#301) anonymously, which needs
+          # no auth. See artifact-keeper-test#304.
         run: |
           chmod +x scripts/create-test-namespace.sh
           # Compose the digest-pinned image ref. Empty BACKEND_DIGEST =>

--- a/scripts/create-test-namespace.sh
+++ b/scripts/create-test-namespace.sh
@@ -8,12 +8,7 @@
 # and waits for the backend to become healthy.
 #
 # Environment variables:
-#   GHCR_DOCKER_CONFIG       - Base64-encoded Docker config for ghcr.io pull secret
-#   SCANNER_TRIVY_PULL_TOKEN - Optional. When set (and --full-stack), injected as
-#                              scannerAdapter.env.TRIVY_USERNAME/TRIVY_PASSWORD via
-#                              helm --set-string so the scanner-adapter's in-process
-#                              Trivy authenticates its ghcr vuln-DB pull (#293).
-#                              Never written to a values file.
+#   GHCR_DOCKER_CONFIG     - Base64-encoded Docker config for ghcr.io pull secret
 
 set -euo pipefail
 
@@ -143,24 +138,14 @@ if [ -n "$EXTRA_VALUES" ]; then
   HELM_CMD+=(--values "${REPO_ROOT}/${EXTRA_VALUES}")
 fi
 
-# Authenticated Trivy DB pull for the scanner-adapter (artifact-keeper-test#293).
-# The scanner-adapter's in-process Trivy pulls its vuln DB from ghcr; when the
-# Trivy SERVER has already pulled anonymously from the same ghcr endpoint, ghcr
-# denies the adapter's anonymous token, so the adapter needs its own
-# credentials. The token is injected here from the environment (SCANNER_TRIVY_-
-# PULL_TOKEN, set by the workflow) and NEVER stored in a values file. helm
-# --set deep-merges per key with the -f values file, and the chart's
-# scanner-adapter-deployment.yaml ranges over the whole scannerAdapter.env map,
-# so the TRIVY_DB_REPOSITORY / SCANNER_TRIVY_INSECURE keys already in
-# values-test-full.yaml survive. --set-string forces the token to a string and
-# is appended last so it wins over any values-file key. Other callers that do
-# not set the token env simply get no injection (no-op).
-if [ -n "${SCANNER_TRIVY_PULL_TOKEN:-}" ]; then
-  HELM_CMD+=(
-    --set-string scannerAdapter.env.TRIVY_USERNAME=x-access-token
-    --set-string "scannerAdapter.env.TRIVY_PASSWORD=${SCANNER_TRIVY_PULL_TOKEN}"
-  )
-fi
+# No Trivy DB pull credentials are injected. #298 appended a deploy-time
+# GITHUB_TOKEN as scannerAdapter.env.TRIVY_USERNAME/TRIVY_PASSWORD, but a
+# deploy-time-injected GITHUB_TOKEN outlives its ~1h TTL before late gate jobs
+# run (pinned-cve-image-gate runs ~90min after deploy), and ghcr then rejects
+# the expired credential outright ("DENIED: invalid token") with no anonymous
+# fallback. The scanner-adapter pulls the public org mirror
+# ghcr.io/artifact-keeper/trivy-db (values-test-full.yaml, #300/#301)
+# anonymously, which needs no auth. See artifact-keeper-test#304.
 
 "${HELM_CMD[@]}"
 


### PR DESCRIPTION
## Summary

Revert the Trivy DB pull-token injection added in #298. That change passed the deploy job's automatic `GITHUB_TOKEN` as `SCANNER_TRIVY_PULL_TOKEN`, which `create-test-namespace.sh` injected as `scannerAdapter.env.TRIVY_USERNAME` / `TRIVY_PASSWORD` via `helm --set-string`. The token has a ~1h TTL and expires before the late gate jobs run (pinned-cve-image-gate runs ~90min after deploy). ghcr then rejects the expired credential outright (`DENIED: invalid token`) with no anonymous fallback, which is the root cause of the attempt-6/7 pinned-cve failures.

Changes:

- `.github/workflows/release-gate.yml`: remove the `SCANNER_TRIVY_PULL_TOKEN` env (and its comment block) from the deploy step.
- `scripts/create-test-namespace.sh`: remove the `SCANNER_TRIVY_PULL_TOKEN` conditional injection block (the `TRIVY_USERNAME` / `TRIVY_PASSWORD` `--set-string`s) and its header env-var doc.
- A short comment is left at both former call sites recording the expiry lesson (deploy-time-injected GITHUB_TOKEN outlives its TTL before late gate jobs; the public mirror needs no auth).

Left untouched: the org-mirror repositories from #300/#301 and the adapter `TRIVY_DB_REPOSITORY` from #288. The scanner-adapter now pulls the public `ghcr.io/artifact-keeper/trivy-db` anonymously, which is verified working.

## Testing

Static validation (this PR touches the workflow, so the fixture-gate CI runs on the PR):

- `bash -n scripts/create-test-namespace.sh`: pass
- `shellcheck -S warning`: no new findings (the pre-existing SC2064 at the `trap` line is unrelated and untouched)
- `python3 yaml.safe_load` on `release-gate.yml`: parses
- Confirmed no `SCANNER_TRIVY_PULL_TOKEN` / `TRIVY_USERNAME` / `TRIVY_PASSWORD` injection remains (only the new explanatory comments mention them), and the `ghcr.io/artifact-keeper/trivy-db` keys in `values-test-full.yaml` are unchanged
- `git diff --check`: clean

## Related

Closes #304
