### PR TITLE
fix(ci): preseed scanner-adapter Trivy DB with retries at deploy

### DIFF
--- a/scripts/create-test-namespace.sh
+++ b/scripts/create-test-namespace.sh
@@ -158,6 +158,54 @@ BACKEND_SVC="http://artifact-keeper-backend.${NAMESPACE}.svc.cluster.local:8080"
 echo "Waiting for backend to become healthy..."
 "${REPO_ROOT}/tests/lib/wait-for-ready.sh" "$BACKEND_SVC" 120
 
+# ---------------------------------------------------------------------------
+# Pre-seed the scanner-adapter's Trivy vulnerability DB (artifact-keeper-test#306)
+#
+# ghcr throttles the cluster's ANONYMOUS token allowance during the deploy
+# image-pull burst, so the scanner-adapter's first DB pull can fail with
+# "DENIED: invalid token" even though the identical anonymous pull from the
+# public org mirror ghcr.io/artifact-keeper/trivy-db succeeds once the burst
+# subsides (verified inside the adapter image on the cluster: ~102MB in ~6s,
+# anonymous, from the mirror). Rather than let a scan fail later, pull the DB
+# now with retries into the pod's emptyDir cache, so scan-time trivy never
+# touches the network.
+#
+# This lands where scans look: the adapter reads its cache dir from
+# SCANNER_TRIVY_CACHE_DIR (default /home/scanner/.cache/trivy) and runs every
+# scan with `--cache-dir <that dir>` (backend docker/scanner-adapter/config.go:69
+# + scan.go:67/328); the download below uses the same env/default and the same
+# `image --download-db-only` form as the adapter's own DownloadDB (scan.go:206).
+# TRIVY_DB_REPOSITORY is read from the pod env (set from values-test-full.yaml)
+# with the mirror as a hardcoded fallback; trivy honours that env natively. No
+# credentials are involved: the mirror is public and pulled anonymously.
+# ---------------------------------------------------------------------------
+if [ "$FULL_STACK" = true ]; then
+  echo "Pre-seeding scanner-adapter Trivy vulnerability DB..."
+  ADAPTER_POD=$(kubectl -n "$NAMESPACE" get pods \
+    -l app.kubernetes.io/component=scanner-adapter \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+  if [ -z "$ADAPTER_POD" ]; then
+    echo "ERROR: no scanner-adapter pod found (label app.kubernetes.io/component=scanner-adapter) in namespace ${NAMESPACE}" >&2
+    exit 1
+  fi
+  db_seeded=false
+  for attempt in $(seq 1 10); do
+    echo "  Trivy DB preseed attempt ${attempt}/10 (pod ${ADAPTER_POD})..."
+    if kubectl -n "$NAMESPACE" exec "$ADAPTER_POD" -- sh -c \
+        'TRIVY_DB_REPOSITORY="${TRIVY_DB_REPOSITORY:-ghcr.io/artifact-keeper/trivy-db}" trivy image --download-db-only --cache-dir "${SCANNER_TRIVY_CACHE_DIR:-/home/scanner/.cache/trivy}"'; then
+      db_seeded=true
+      echo "  Trivy DB preseed succeeded on attempt ${attempt}/10"
+      break
+    fi
+    echo "  attempt ${attempt}/10 failed (likely ghcr anonymous-token throttling during the deploy pull burst); retrying in 30s"
+    sleep 30
+  done
+  if [ "$db_seeded" != true ]; then
+    echo "ERROR: scanner-adapter Trivy DB preseed failed after 10 attempts; ghcr anonymous-token throttling did not clear within ~5m. Image scans will fail without a cached DB. See artifact-keeper-test#306." >&2
+    exit 1
+  fi
+fi
+
 echo ""
 echo "Test environment ready."
 echo "BACKEND_URL=${BACKEND_SVC}"


### PR DESCRIPTION
## Summary

Root cause of the recurring pinned-cve failures: ghcr throttles the cluster's anonymous token allowance during the deploy image-pull burst, so the scanner-adapter's first Trivy DB pull can fail with `DENIED: invalid token`, even though the identical anonymous pull from the public org mirror `ghcr.io/artifact-keeper/trivy-db` succeeds once the burst subsides.

Change: in `create-test-namespace.sh`, in the `--full-stack` path after the backend readiness wait, find the scanner-adapter pod and `kubectl exec` a `trivy image --download-db-only` into its cache, with up to 10 retries 30s apart. The script fails (exit non-zero) with a clear error naming the throttle issue if all attempts fail. Progress lines (`attempt N/10`) are echoed; no tokens are involved (public mirror, anonymous pull). The DB lands in the pod's emptyDir cache, so scan-time trivy never hits the network.

## Verification (as requested)

Confirmed against the chart and the backend's scanner-adapter source so the preseed lands exactly where scans read:

- Pod label: the chart's `scannerAdapter.selectorLabels` include `app.kubernetes.io/component: scanner-adapter` (`_helpers.tpl`), so `-l app.kubernetes.io/component=scanner-adapter` selects the pod.
- Cache dir: `docker/scanner-adapter/config.go:69` -> `CacheDir: getenv("SCANNER_TRIVY_CACHE_DIR", "/home/scanner/.cache/trivy")`. The chart does not set `SCANNER_TRIVY_CACHE_DIR`, so the adapter uses the `/home/scanner/.cache/trivy` default, and my exec uses the same `${SCANNER_TRIVY_CACHE_DIR:-/home/scanner/.cache/trivy}`.
- Scans use it: `scan.go:67` and `scan.go:328` run trivy with `--cache-dir s.cfg.CacheDir`; `dbPresent` (`scan.go:192`) checks `<cacheDir>/db/metadata.json`.
- Same download form: the adapter's own `DownloadDB` (`scan.go:206`) runs `trivy image --download-db-only --cache-dir <cacheDir>`, which is what the preseed runs.
- Cache is an emptyDir mounted at `/home/scanner/.cache` (chart `scanner-adapter-deployment.yaml`), so the preseeded DB persists in the pod for scan time; `readOnlyRootFilesystem: true` is fine because the cache and `/tmp` are writable emptyDirs.
- `TRIVY_DB_REPOSITORY`: read from the pod env (set from `values-test-full.yaml`, #288/#301) with `ghcr.io/artifact-keeper/trivy-db` as a hardcoded fallback; trivy honours the env natively. The trivy binary is on PATH (`config.go:68` `SCANNER_TRIVY_PATH` default `"trivy"`), consistent with the successful cluster probe.

Left untouched: the mirror repositories (#301) and the #304 token-injection removal.

## Testing

Static validation only (the cluster run happens in CI):

- `bash -n`: pass
- `shellcheck -S warning`: no new findings in the added block (the two pre-existing SC2064 warnings are the `trap` at line 85, unrelated and untouched)
- `git diff --check`: clean
- Only `scripts/create-test-namespace.sh` changed (no workflow change)

## Related

Closes #306
