### PR TITLE
fix(helm): set AK_GRYPE_REGISTRY_HOST for scan-target refs

### DIFF
--- a/helm/values-test-full.yaml
+++ b/helm/values-test-full.yaml
@@ -118,6 +118,15 @@ backend:
     # every few seconds for the grace=5 reclaim to be observable. 6-field cron
     # (sec min hour dom mon dow) = every 10 seconds. See artifact-keeper-test#284.
     GC_SCHEDULE: "*/10 * * * * *"
+    # Registry host the backend embeds in grype scan-target refs. The backend
+    # composes the ref via resolve_registry_host, which prefers
+    # AK_GRYPE_REGISTRY_HOST, then PEER_PUBLIC_ENDPOINT, then the dev fallback
+    # http://localhost:8080 (backend grype_scanner.rs:334). Unset, the
+    # scanner-adapter is handed localhost refs it can never resolve (its own
+    # loopback), so image scans fail. fullnameOverride=artifact-keeper makes the
+    # backend Service "artifact-keeper-backend"; SCANNER_TRIVY_INSECURE=true
+    # already covers the plain-http pull. See artifact-keeper-test#308.
+    AK_GRYPE_REGISTRY_HOST: "http://artifact-keeper-backend:8080"
     # NOTE: TRIVY_URL and SCAN_WORKSPACE_PATH were previously set here, but
     # the chart's backend-deployment.yaml auto-injects them when
     # trivy.enabled=true. Setting them here too produces duplicate env keys


### PR DESCRIPTION
## Summary

The backend composes grype scan-target image refs via `resolve_registry_host`, whose precedence is `AK_GRYPE_REGISTRY_HOST`, then `PEER_PUBLIC_ENDPOINT`, then the dev fallback `http://localhost:8080` (`grype_scanner.rs:334`). In the test deploy none of the first two is set, so the backend falls back to `localhost:8080` and hands the scanner-adapter refs pointing at the adapter's own loopback, which it can never resolve. Image scans fail as a result.

Change: set `backend.env.AK_GRYPE_REGISTRY_HOST` to the in-cluster backend Service `http://artifact-keeper-backend:8080`. `fullnameOverride=artifact-keeper` makes the backend Service `artifact-keeper-backend`, and `SCANNER_TRIVY_INSECURE=true` (already set) covers the plain-http pull.

## Testing

Static validation only (the cluster release-gate suite cannot run locally):

- `python3` `yaml.safe_load`: parses; `backend.env.AK_GRYPE_REGISTRY_HOST == http://artifact-keeper-backend:8080`
- `git diff --check`: clean

## Related

Closes #308
